### PR TITLE
feat: add schema audit command

### DIFF
--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -2,7 +2,38 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\File;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('schema:audit', function () {
+    $tables = DB::select('SELECT name FROM sqlite_master WHERE type="table" AND name NOT LIKE "sqlite_%"');
+    $report = [];
+
+    foreach ($tables as $table) {
+        $columns = [];
+        foreach (Schema::getColumns($table->name) as $column) {
+            $columns[$column['name']] = [
+                'type' => $column['type_name'],
+                'nullable' => $column['nullable'],
+                'default' => $column['default'],
+            ];
+        }
+
+        $report[$table->name] = [
+            'columns' => $columns,
+            'indexes' => Schema::getIndexes($table->name),
+            'foreign_keys' => Schema::getForeignKeys($table->name),
+            'differences' => [],
+        ];
+    }
+
+    $path = storage_path('app/reports');
+    File::ensureDirectoryExists($path);
+    File::put($path.'/schema_audit.json', json_encode($report, JSON_PRETTY_PRINT));
+    $this->info('Schema audit written to storage/app/reports/schema_audit.json');
+})->purpose('Generate a schema audit report');

--- a/backend/storage/app/.gitignore
+++ b/backend/storage/app/.gitignore
@@ -1,4 +1,6 @@
 *
 !private/
 !public/
+!reports/
+!reports/**
 !.gitignore

--- a/backend/storage/app/reports/schema_audit.json
+++ b/backend/storage/app/reports/schema_audit.json
@@ -1,0 +1,4805 @@
+{
+    "migrations": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "migration": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "batch": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "users": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "email": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "email_verified_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "role": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "password": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "remember_token": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            },
+            {
+                "name": "users_email_unique",
+                "columns": [
+                    "email"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "password_reset_tokens": {
+        "columns": {
+            "email": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "token": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "1": {
+                "name": "sqlite_autoindex_password_reset_tokens_1",
+                "columns": [
+                    "email"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "sessions": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "ip_address": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "user_agent": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "payload": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "last_activity": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": {
+            "1": {
+                "name": "sessions_last_activity_index",
+                "columns": [
+                    "last_activity"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "2": {
+                "name": "sessions_user_id_index",
+                "columns": [
+                    "user_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "3": {
+                "name": "sqlite_autoindex_sessions_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "cache": {
+        "columns": {
+            "key": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "value": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "expiration": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": {
+            "1": {
+                "name": "sqlite_autoindex_cache_1",
+                "columns": [
+                    "key"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "cache_locks": {
+        "columns": {
+            "key": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "owner": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "expiration": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": {
+            "1": {
+                "name": "sqlite_autoindex_cache_locks_1",
+                "columns": [
+                    "key"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "jobs": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "queue": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "payload": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "attempts": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "reserved_at": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "available_at": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "jobs_queue_index",
+                "columns": [
+                    "queue"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "job_batches": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "total_jobs": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "pending_jobs": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "failed_jobs": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "failed_job_ids": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "options": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "cancelled_at": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "finished_at": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "1": {
+                "name": "sqlite_autoindex_job_batches_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "failed_jobs": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "uuid": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "connection": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "queue": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "payload": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "exception": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "failed_at": {
+                "type": "datetime",
+                "nullable": false,
+                "default": "CURRENT_TIMESTAMP"
+            }
+        },
+        "indexes": [
+            {
+                "name": "failed_jobs_uuid_unique",
+                "columns": [
+                    "uuid"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "oauth_auth_codes": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "scopes": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "revoked": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": null
+            },
+            "expires_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "0": {
+                "name": "oauth_auth_codes_user_id_index",
+                "columns": [
+                    "user_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "2": {
+                "name": "sqlite_autoindex_oauth_auth_codes_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "oauth_access_tokens": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "client_id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "scopes": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "revoked": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "expires_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "0": {
+                "name": "oauth_access_tokens_user_id_index",
+                "columns": [
+                    "user_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "2": {
+                "name": "sqlite_autoindex_oauth_access_tokens_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "oauth_refresh_tokens": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "access_token_id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "revoked": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": null
+            },
+            "expires_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "0": {
+                "name": "oauth_refresh_tokens_access_token_id_index",
+                "columns": [
+                    "access_token_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "2": {
+                "name": "sqlite_autoindex_oauth_refresh_tokens_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "oauth_clients": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "owner_type": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "owner_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "secret": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "provider": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "redirect_uris": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "grant_types": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "revoked": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "0": {
+                "name": "oauth_clients_owner_type_owner_id_index",
+                "columns": [
+                    "owner_type",
+                    "owner_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "2": {
+                "name": "sqlite_autoindex_oauth_clients_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "oauth_device_codes": {
+        "columns": {
+            "id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "client_id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "user_code": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "scopes": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "revoked": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": null
+            },
+            "user_approved_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "last_polled_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "expires_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": {
+            "0": {
+                "name": "oauth_device_codes_client_id_index",
+                "columns": [
+                    "client_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "1": {
+                "name": "oauth_device_codes_user_code_unique",
+                "columns": [
+                    "user_code"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            "2": {
+                "name": "oauth_device_codes_user_id_index",
+                "columns": [
+                    "user_id"
+                ],
+                "type": null,
+                "unique": false,
+                "primary": false
+            },
+            "4": {
+                "name": "sqlite_autoindex_oauth_device_codes_1",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        },
+        "foreign_keys": [],
+        "differences": []
+    },
+    "events": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "date": {
+                "type": "datetime",
+                "nullable": false,
+                "default": null
+            },
+            "title": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "description": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "user_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "unclients": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "slug": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "email": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "phone_number": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "address": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "work": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "emergency_number": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "date_of_birth": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "gender": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "religion": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "identity_number": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            },
+            {
+                "name": "unclients_email_unique",
+                "columns": [
+                    "email"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "unclients_identity_number_unique",
+                "columns": [
+                    "identity_number"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "unclients_slug_unique",
+                "columns": [
+                    "slug"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "clients": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "slug": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "email": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "phone_number": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "address": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "nationality": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "work": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "emergency_number": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "date_of_birth": {
+                "type": "date",
+                "nullable": true,
+                "default": null
+            },
+            "gender": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "religion": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u0645\u0633\u0644\u0645'"
+            },
+            "identity_number": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'active'"
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "clients_identity_number_unique",
+                "columns": [
+                    "identity_number"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "clients_slug_unique",
+                "columns": [
+                    "slug"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "lawyers": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "birthdate": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "identity_number": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "law_reg_num": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "lawyer_class": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "email": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "phone_number": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "gender": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "address": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "religion": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "lawyers_email_unique",
+                "columns": [
+                    "email"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "lawyers_identity_number_unique",
+                "columns": [
+                    "identity_number"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "lawyers_law_reg_num_unique",
+                "columns": [
+                    "law_reg_num"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            },
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "user_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "court_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "court_levels": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "courts": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "court_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "court_level_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "court_level_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "court_levels",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "court_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "court_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "divisions": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "court_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "court_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "courts",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "case_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "case_sub_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "case_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "case_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "case_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "leg_cases": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "is_deleted": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": "'0'"
+            },
+            "slug": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "title": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "description": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "fees": {
+                "type": "float",
+                "nullable": true,
+                "default": null
+            },
+            "total_expenses": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "total_payments": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "expenses": {
+                "type": "float",
+                "nullable": true,
+                "default": null
+            },
+            "case_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "case_sub_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "updated_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "litigants_name": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "litigants_address": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "litigants_phone": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "litigants_lawyer_name": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "litigants_lawyer_phone": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "client_capacity": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u0645\u062f\u0639\u0649'"
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u0642\u064a\u062f \u0627\u0644\u062a\u062c\u0647\u064a\u0632'"
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "updated_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "case_sub_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "case_sub_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "case_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "case_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "procedure_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            },
+            {
+                "name": "procedure_types_name_unique",
+                "columns": [
+                    "name"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "procedure_place_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            },
+            {
+                "name": "procedure_place_types_name_unique",
+                "columns": [
+                    "name"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "procedures": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "procedure_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "procedure_place_name": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "procedure_place_type_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "lawyer_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "job": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "result": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "note": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u062c\u0627\u0631\u064a \u0627\u0644\u062a\u0646\u0641\u064a\u0630'"
+            },
+            "event_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "date_start": {
+                "type": "date",
+                "nullable": true,
+                "default": null
+            },
+            "date_end": {
+                "type": "date",
+                "nullable": true,
+                "default": null
+            },
+            "cost1": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost2": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost3": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "updated_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "updated_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "event_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "events",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "lawyer_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "lawyers",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "procedure_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "procedure_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "legal_session_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "legal_sessions": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "court_session": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "legal_session_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "court_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "session_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "cost1": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost2": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost3": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "session_roll": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "Judgment_operative": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u062c\u0627\u0631\u0649 \u0627\u0644\u062a\u0646\u0641\u064a\u0630'"
+            },
+            "lawyer_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "orders": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "result": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "notes": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "lawyer_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "lawyers",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "court_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "courts",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "legal_session_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "legal_session_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "service_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "services": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "slug": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "description": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "service_place_name": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "service_year": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": "'1'"
+            },
+            "updated_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u062c\u0627\u0631\u0649 \u0627\u0644\u062a\u0646\u0641\u064a\u0630'"
+            },
+            "service_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            },
+            {
+                "name": "services_slug_unique",
+                "columns": [
+                    "slug"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": false
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "updated_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "service_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "service_client": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "service_unclient": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "unclient_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "unclient_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "unclients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "attorney_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "power_of_attorneys": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "attorney_num": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "attorney_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "attorney_chart": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "attorney_place": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "title": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "description": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "lawyer_insert": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "image": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "updated_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "attorney_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "attorney_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "attorney_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "updated_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "leg_case_lawyer": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "lawyer_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "lawyer_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "lawyers",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "leg_case_client": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "leg_case_court": {
+        "columns": {
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "court_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "case_number": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "case_year": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "court_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "courts",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "legal_ad_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "legal_ads": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "description": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "results": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "send_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "receive_date": {
+                "type": "date",
+                "nullable": true,
+                "default": null
+            },
+            "lawyer_send_id": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "legal_ad_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "lawyer_receive_id": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u0642\u064a\u062f \u0627\u0644\u062a\u062c\u0647\u064a\u0632'"
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "court_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "cost1": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost2": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost3": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "updated_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "court_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "courts",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "updated_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "legal_ad_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "legal_ad_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "notifications": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "user_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "event_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "type": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "message": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "read": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": "'0'"
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "event_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "events",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "user_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "service_procedures": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "title": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "lawyer_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "job": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "procedure_place_name": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "procedure_place_type_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "result": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "note": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": "'\u062c\u0627\u0631\u0649 \u0627\u0644\u062a\u0646\u0641\u064a\u0630'"
+            },
+            "event_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "date_start": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "date_end": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "cost1": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost2": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "cost3": {
+                "type": "numeric",
+                "nullable": true,
+                "default": "'0'"
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "updated_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "updated_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "lawyer_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "lawyers",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "event_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "events",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            }
+        ],
+        "differences": []
+    },
+    "public_documents": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "title": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "description": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "file_path": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "service_documents": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "file_path": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "case_documents": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "unclient_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "description": {
+                "type": "text",
+                "nullable": false,
+                "default": null
+            },
+            "file_path": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "unclient_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "unclients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "power_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "revenue_categories": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "revenues": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "amount": {
+                "type": "float",
+                "nullable": false,
+                "default": null
+            },
+            "from_client": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": "'1'"
+            },
+            "from_unclients": {
+                "type": "tinyint",
+                "nullable": false,
+                "default": "'0'"
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "expense_categories": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "expenses": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "created_by": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "legal_session_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "expense_category_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "client_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "unclients_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "description": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "note": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "expense_date": {
+                "type": "date",
+                "nullable": true,
+                "default": null
+            },
+            "amount": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "legal_session_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "legal_sessions",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "created_by"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "users",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "unclients_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "unclients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "client_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "clients",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "set null"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "expense_category_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "expense_categories",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "invoices": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "leg_case_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "service_id": {
+                "type": "integer",
+                "nullable": true,
+                "default": null
+            },
+            "invoice_number": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "status": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "issue_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "due_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "total_amount": {
+                "type": "numeric",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "leg_case_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "leg_cases",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "service_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "services",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "payments": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "invoice_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "payment_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "payment_method": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "amount": {
+                "type": "numeric",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "invoice_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "invoices",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "appeal_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_type": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "appeal_sub_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_sub_type": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "appeal_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "appeal_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "cassation_rule_subjects": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "rule_description": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "cassation_rules": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_sub_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_number": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "appeal_year": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "session_date": {
+                "type": "date",
+                "nullable": false,
+                "default": null
+            },
+            "cassation_rule_subjects_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "legal_summary": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "cassation_rule_subjects_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "cassation_rule_subjects",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "appeal_sub_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "appeal_sub_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "appeal_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "appeal_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "cassation_judges": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "cassation_rules_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "judge_name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "cassation_rules_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "cassation_rules",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "appeal_pdfs": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "cassation_rule_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "file_name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "file_path": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "cassation_rule_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "cassation_rules",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "cascade"
+            }
+        ],
+        "differences": []
+    },
+    "search_degrees": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "degree_name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "degree_value": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "search_courts": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "degree_value": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "court_name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "court_value": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "search_case_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "degree_value": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "court_value": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "case_type_name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "case_type_value": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "doc_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [],
+        "differences": []
+    },
+    "doc_sub_types": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "name": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "doc_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "doc_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "doc_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    },
+    "legal_docs": {
+        "columns": {
+            "id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "path": {
+                "type": "varchar",
+                "nullable": false,
+                "default": null
+            },
+            "thumbnail_path": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "word_path": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "pdf_path": {
+                "type": "varchar",
+                "nullable": true,
+                "default": null
+            },
+            "description": {
+                "type": "text",
+                "nullable": true,
+                "default": null
+            },
+            "doc_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "doc_sub_type_id": {
+                "type": "integer",
+                "nullable": false,
+                "default": null
+            },
+            "created_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            },
+            "updated_at": {
+                "type": "datetime",
+                "nullable": true,
+                "default": null
+            }
+        },
+        "indexes": [
+            {
+                "name": "primary",
+                "columns": [
+                    "id"
+                ],
+                "type": null,
+                "unique": true,
+                "primary": true
+            }
+        ],
+        "foreign_keys": [
+            {
+                "name": null,
+                "columns": [
+                    "doc_sub_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "doc_sub_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            },
+            {
+                "name": null,
+                "columns": [
+                    "doc_type_id"
+                ],
+                "foreign_schema": "main",
+                "foreign_table": "doc_types",
+                "foreign_columns": [
+                    "id"
+                ],
+                "on_update": "no action",
+                "on_delete": "no action"
+            }
+        ],
+        "differences": []
+    }
+}


### PR DESCRIPTION
## Summary
- add artisan console command to audit schema and generate JSON report
- allow tracking of reports directory

## Testing
- `php artisan migrate --force`
- `php artisan schema:audit`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6899855ade98833098f9eabc4c880d45