### PR TITLE
Align auth routes and token handling

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -52,4 +52,13 @@ class AuthController extends Controller
             'user' => $user
         ]);
     }
+
+    public function logout(Request $request)
+    {
+        $request->user()->token()->revoke();
+
+        return response()->json([
+            'message' => 'Successfully logged out'
+        ]);
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -40,9 +40,9 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:api');
 
 
-        Route::middleware('auth:api')->get('/token', function (Request $request) {
+        Route::middleware('auth:api')->get('auth/token', function (Request $request) {
             return response()->json([
-                'token' => $request->user()->token()->accessToken,
+                'access_token' => $request->user()->token()->accessToken,
             ]);
         });
 
@@ -60,13 +60,13 @@ Route::get('/user', function (Request $request) {
         Route::get('/user/{user}', [UserController::class, 'getUserDetails'])->name('user.details');
 
             // User Logout
-            Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+            Route::post('auth/logout', [AuthController::class, 'logout'])->name('logout');
 
             // Verify Email (Email Verification)
-            Route::get('/email/verify/{id}/{hash}', [AuthController::class, 'verifyEmail'])->name('verification.verify');
+            Route::get('auth/email/verify/{id}/{hash}', [AuthController::class, 'verifyEmail'])->name('verification.verify');
 
             // Resend Verification Email
-            Route::post('/email/verify/resend', [AuthController::class, 'resendVerificationEmail'])->name('verification.resend');
+            Route::post('auth/email/verify/resend', [AuthController::class, 'resendVerificationEmail'])->name('verification.resend');
         });
         // Document Management
 
@@ -85,10 +85,12 @@ Route::get('/user', function (Request $request) {
 
         Route::post('/legal-doc-upload', [LegalDocArchiveController::class, 'uploadLegalDoc']);
 
-        Route::post('register', [AuthController::class, 'register']);
-        Route::post('login', [AuthController::class, 'login']);
-        Route::post('/forgot-password', [AuthController::class, 'forgotPassword'])->name('forgot-password');
-        Route::post('/reset-password', [AuthController::class, 'resetPassword'])->name('reset-password');
+        Route::prefix('auth')->group(function () {
+            Route::post('register', [AuthController::class, 'register']);
+            Route::post('login', [AuthController::class, 'login']);
+            Route::post('forgot-password', [AuthController::class, 'forgotPassword'])->name('forgot-password');
+            Route::post('reset-password', [AuthController::class, 'resetPassword'])->name('reset-password');
+        });
 
         // Resourcea //
         Route::apiResource('clients', ClientController::class);

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,5 +1,5 @@
 import apiClient from '../../shared/libs/axios';
-import { AuthResponse } from '../../shared/libs/authTokens';
+import { AuthResponse, setAuthToken, clearAuthToken } from '../../shared/libs/authTokens';
 
 export interface LoginRequest {
   email: string;
@@ -34,6 +34,7 @@ export const authApi = {
    */
   async login(credentials: LoginRequest): Promise<AuthResponse> {
     const response = await apiClient.post('/api/auth/login', credentials);
+    setAuthToken(response.data.access_token);
     return response.data;
   },
 
@@ -95,6 +96,7 @@ export const authApi = {
    */
   async logout(): Promise<void> {
     await apiClient.post('/api/auth/logout');
+    clearAuthToken();
   },
 
   /**

--- a/frontend/src/shared/libs/authTokens.ts
+++ b/frontend/src/shared/libs/authTokens.ts
@@ -1,13 +1,8 @@
-// Helper functions for HTTP-only cookie authentication
-// Note: Actual token storage is handled server-side via HTTP-only cookies
-
-export interface AuthTokens {
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number;
-}
+// Utility helpers for managing auth tokens in localStorage
 
 export interface AuthResponse {
+  access_token: string;
+  token_type: string;
   user: {
     id: string;
     email: string;
@@ -15,78 +10,17 @@ export interface AuthResponse {
     lastName: string;
     role: string;
   };
-  tokens: AuthTokens;
 }
 
-/**
- * Get access token from server API (not from client storage)
- * This ensures tokens are handled securely via HTTP-only cookies
- */
-export const getAccessToken = async (): Promise<string | null> => {
-  try {
-    const response = await fetch('/api/auth/token', {
-      credentials: 'include' // Include HTTP-only cookies
-    });
-
-    if (response.ok) {
-      const data = await response.json();
-      return data.access_token || null;
-    }
-    
-    return null;
-  } catch (error) {
-    console.warn('Failed to get access token:', error);
-    return null;
-  }
+export const setAuthToken = (token: string): void => {
+  localStorage.setItem('token', token);
 };
 
-/**
- * Refresh access token using HTTP-only refresh token
- */
-export const refreshAccessToken = async (): Promise<AuthTokens | null> => {
-  try {
-    const response = await fetch('/api/auth/refresh', {
-      method: 'POST',
-      credentials: 'include'
-    });
-
-    if (response.ok) {
-      const data = await response.json();
-      return data.tokens || null;
-    }
-    
-    return null;
-  } catch (error) {
-    console.error('Failed to refresh token:', error);
-    return null;
-  }
+export const getAuthToken = (): string | null => {
+  return localStorage.getItem('token');
 };
 
-/**
- * Check if user is authenticated by verifying token validity
- */
-export const isAuthenticated = async (): Promise<boolean> => {
-  try {
-    const response = await fetch('/api/auth/verify', {
-      credentials: 'include'
-    });
-    
-    return response.ok;
-  } catch (error) {
-    return false;
-  }
+export const clearAuthToken = (): void => {
+  localStorage.removeItem('token');
 };
 
-/**
- * Logout and clear all authentication tokens
- */
-export const logout = async (): Promise<void> => {
-  try {
-    await fetch('/api/auth/logout', {
-      method: 'POST',
-      credentials: 'include'
-    });
-  } catch (error) {
-    console.warn('Logout request failed:', error);
-  }
-};

--- a/frontend/src/shared/libs/axios.ts
+++ b/frontend/src/shared/libs/axios.ts
@@ -1,10 +1,9 @@
-import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosError } from 'axios';
 import { handleApiError } from './errorHandler';
+import { getAuthToken, clearAuthToken } from './authTokens';
 
-// Create axios instance with base configuration
 const apiClient: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000/v1',
-  withCredentials: true, // Enable cookies for HTTP-only auth
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
@@ -12,101 +11,26 @@ const apiClient: AxiosInstance = axios.create({
   }
 });
 
-// Request interceptor - Add auth token if available
-apiClient.interceptors.request.use(
-  async (config: InternalAxiosRequestConfig) => {
-    try {
-      // Get access token from API endpoint (not from storage)
-      const tokenResponse = await fetch('/api/auth/token', {
-        credentials: 'include'
-      });
-      
-      if (tokenResponse.ok) {
-        const { access_token } = await tokenResponse.json();
-        if (access_token) {
-          config.headers.Authorization = `Bearer ${access_token}`;
-        }
-      }
-    } catch (error) {
-      console.warn('Failed to get access token:', error);
-    }
-    
-    return config;
-  },
-  (error: AxiosError) => {
-    return Promise.reject(error);
+apiClient.interceptors.request.use((config) => {
+  const token = getAuthToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
   }
-);
-
-// Response interceptor - Handle token refresh and errors
-let isRefreshing = false;
-let refreshSubscribers: Array<(token: string) => void> = [];
-
-const subscribeTokenRefresh = (cb: (token: string) => void) => {
-  refreshSubscribers.push(cb);
-};
-
-const onRefreshed = (token: string) => {
-  refreshSubscribers.map(cb => cb(token));
-  refreshSubscribers = [];
-};
+  return config;
+});
 
 apiClient.interceptors.response.use(
   (response) => response,
-  async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
-
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      if (isRefreshing) {
-        // Wait for refresh to complete
-        return new Promise((resolve) => {
-          subscribeTokenRefresh((token: string) => {
-            if (originalRequest.headers) {
-              originalRequest.headers.Authorization = `Bearer ${token}`;
-            }
-            resolve(apiClient(originalRequest));
-          });
-        });
-      }
-
-      originalRequest._retry = true;
-      isRefreshing = true;
-
-      try {
-        // Attempt token refresh
-        const refreshResponse = await fetch('/api/auth/refresh', {
-          method: 'POST',
-          credentials: 'include'
-        });
-
-        if (refreshResponse.ok) {
-          const { access_token } = await refreshResponse.json();
-          
-          if (originalRequest.headers) {
-            originalRequest.headers.Authorization = `Bearer ${access_token}`;
-          }
-          
-          onRefreshed(access_token);
-          isRefreshing = false;
-          
-          return apiClient(originalRequest);
-        } else {
-          // Refresh failed - redirect to login
-          window.location.href = '/login';
-        }
-      } catch (refreshError) {
-        // Refresh failed - redirect to login
-        window.location.href = '/login';
-      } finally {
-        isRefreshing = false;
-      }
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      clearAuthToken();
+      window.location.href = '/login';
     }
 
-    // Handle and format error
-    const formattedError = handleApiError(error);
-    return Promise.reject(formattedError);
+    return Promise.reject(handleApiError(error));
   }
 );
 
 export default apiClient;
 export { apiClient };
+


### PR DESCRIPTION
## Summary
- serve auth endpoints under `/api/auth/*` and add token endpoint
- add logout logic in `AuthController`
- manage access tokens via `localStorage` with new axios interceptors

## Testing
- `APP_KEY=base64:n2BwqzO9IFD7cBMI3bQ4QTqmIOb6RpsxYtR9TS7nZ0k= php artisan test` (warning: missing .env)
- `npm test` (fails: React.Children.only expected to receive a single React element child)


------
https://chatgpt.com/codex/tasks/task_e_6899cc1820b48330b7163cfd622ed458