### PR TITLE
feat(frontend): default to Arabic and add translation script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "translate:all": "node scripts/translate.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",

--- a/frontend/scripts/translate.js
+++ b/frontend/scripts/translate.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.error('OPENAI_API_KEY is required');
+  process.exit(1);
+}
+
+async function translate() {
+  const enPath = path.join(process.cwd(), 'src', 'i18n', 'locales', 'en', 'common.json');
+  const arPath = path.join(process.cwd(), 'src', 'i18n', 'locales', 'ar', 'common.json');
+
+  const enContent = fs.readFileSync(enPath, 'utf8');
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content: 'Translate the provided JSON keys to Arabic and return a valid JSON object preserving the keys.'
+        },
+        {
+          role: 'user',
+          content: enContent
+        }
+      ],
+      temperature: 0.3
+    })
+  });
+
+  if (!response.ok) {
+    console.error('OpenAI API error', await response.text());
+    process.exit(1);
+  }
+
+  const data = await response.json();
+  const translation = data.choices[0].message.content;
+
+  fs.writeFileSync(arPath, translation);
+  console.log('Arabic translations updated');
+}
+
+translate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,2 @@
+import i18n from './i18n/i18n';
+export default i18n;

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -16,12 +16,13 @@ i18n
   .init({
     resources,
     fallbackLng: 'ar',
+    lng: 'ar',
     supportedLngs: ['ar', 'en'],
     ns: ['common'],
     defaultNS: 'common',
     interpolation: { escapeValue: false },
     detection: {
-      order: ['localStorage', 'querystring', 'navigator'],
+      order: ['localStorage', 'querystring'],
       lookupLocalStorage: 'lang',
       caches: ['localStorage'],
     },

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -11,6 +11,7 @@
     "settings": "الإعدادات",
     "logout": "تسجيل الخروج",
     "welcome": "مرحباً",
+    "hello_user": "مرحباً {{name}}",
     "loading": "جاري التحميل...",
     "save": "حفظ",
     "cancel": "إلغاء",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -11,6 +11,7 @@
     "settings": "Settings",
     "logout": "Logout",
     "welcome": "Welcome",
+    "hello_user": "Hello {{name}}",
     "loading": "Loading...",
     "save": "Save",
     "cancel": "Cancel",

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -70,11 +70,18 @@ export const Landing = () => {
                 {t('landing.title')}
               </h1>
               <p className={`text-xs transition-colors duration-300 ${
-                specialEdition 
-                  ? 'text-amber-700 dark:text-amber-300' 
+                specialEdition
+                  ? 'text-amber-700 dark:text-amber-300'
                   : 'text-gray-600 dark:text-gray-400'
               }`}>
                 {specialEdition ? 'النسخة الذهبية - طبعة محدودة' : t('landing.subtitle')}
+              </p>
+              <p className={`text-xs transition-colors duration-300 ${
+                specialEdition
+                  ? 'text-amber-700 dark:text-amber-300'
+                  : 'text-gray-600 dark:text-gray-400'
+              }`}>
+                {t('hello_user', { name: 'أحمد' })}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- default UI language to Arabic and adjust language detection
- add OpenAI translation script and package command
- translate landing header with dynamic greeting

## Testing
- `npm test -- --run` (fails: React.Children.only expected to receive a single React element child)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any and no-empty-object-type)


------
https://chatgpt.com/codex/tasks/task_e_689a752dc0408330ae040a3959b0fb4e