### PR TITLE
fix: improve auth routes and frontend base URL

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -61,4 +61,23 @@ class AuthController extends Controller
             'message' => 'Successfully logged out'
         ]);
     }
+
+    /**
+     * Return the authenticated user's profile
+     */
+    public function profile(Request $request)
+    {
+        return response()->json($request->user());
+    }
+
+    /**
+     * Verify current authentication status
+     */
+    public function verify(Request $request)
+    {
+        return response()->json([
+            'authenticated' => (bool) $request->user(),
+            'user' => $request->user(),
+        ]);
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -59,9 +59,6 @@ Route::get('/user', function (Request $request) {
         // Get user details
         Route::get('/user/{user}', [UserController::class, 'getUserDetails'])->name('user.details');
 
-            // User Logout
-            Route::post('auth/logout', [AuthController::class, 'logout'])->name('logout');
-
             // Verify Email (Email Verification)
             Route::get('auth/email/verify/{id}/{hash}', [AuthController::class, 'verifyEmail'])->name('verification.verify');
 
@@ -90,6 +87,12 @@ Route::get('/user', function (Request $request) {
             Route::post('login', [AuthController::class, 'login']);
             Route::post('forgot-password', [AuthController::class, 'forgotPassword'])->name('forgot-password');
             Route::post('reset-password', [AuthController::class, 'resetPassword'])->name('reset-password');
+
+            Route::middleware('auth:api')->group(function () {
+                Route::get('profile', [AuthController::class, 'profile']);
+                Route::get('verify', [AuthController::class, 'verify']);
+                Route::post('logout', [AuthController::class, 'logout'])->name('logout');
+            });
         });
 
         // Resourcea //

--- a/frontend/src/shared/libs/axios.ts
+++ b/frontend/src/shared/libs/axios.ts
@@ -3,7 +3,8 @@ import { handleApiError } from './errorHandler';
 import { getAuthToken, clearAuthToken } from './authTokens';
 
 const apiClient: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000/v1',
+  // Default to Laravel's local dev server
+  baseURL: import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000',
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- fix frontend Axios base URL for API requests
- add profile and verify endpoints to AuthController
- register protected auth routes for profile, verify, and logout

## Testing
- `npm test` (fails: AddEditClientForm, AddEditProcedureForm, ProtectedRoute)
- `composer test` (fails: vendor autoload missing)


------
https://chatgpt.com/codex/tasks/task_e_689a8720b66883308d4bf12ffcdd6266