### PR TITLE
fix: robust frontend authentication flow

### DIFF
--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,5 +1,10 @@
 import apiClient from '../../shared/libs/axios';
-import { AuthResponse, setAuthToken, clearAuthToken } from '../../shared/libs/authTokens';
+import {
+  AuthResponse,
+  setAuthToken,
+  clearAuthToken,
+  getAuthToken
+} from '../../shared/libs/authTokens';
 
 export interface LoginRequest {
   email: string;
@@ -102,7 +107,12 @@ export const authApi = {
   /**
    * Verify authentication status
    */
-  async verifyAuth(): Promise<{ user: User; authenticated: boolean }> {
+  async verifyAuth(): Promise<{ user: User | null; authenticated: boolean }> {
+    const token = getAuthToken();
+    if (!token) {
+      return { user: null, authenticated: false };
+    }
+
     const response = await apiClient.get('/api/auth/verify');
     return response.data;
   }

--- a/frontend/src/features/auth/slice.ts
+++ b/frontend/src/features/auth/slice.ts
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { authApi, User, LoginRequest, RegisterRequest } from './api';
 import { AuthResponse } from '../../shared/libs/authTokens';
+import { ApiError } from '../../shared/libs/errorHandler';
 
 export interface AuthState {
   user: User | null;
@@ -26,7 +27,7 @@ export const loginUser = createAsyncThunk(
       const response = await authApi.login(credentials);
       return response;
     } catch (error: any) {
-      return rejectWithValue(error.message || 'Login failed');
+      return rejectWithValue(error as ApiError);
     }
   }
 );
@@ -38,7 +39,7 @@ export const registerUser = createAsyncThunk(
       const response = await authApi.register(userData);
       return response;
     } catch (error: any) {
-      return rejectWithValue(error.message || 'Registration failed');
+      return rejectWithValue(error as ApiError);
     }
   }
 );
@@ -50,7 +51,7 @@ export const verifyAuth = createAsyncThunk(
       const response = await authApi.verifyAuth();
       return response;
     } catch (error: any) {
-      return rejectWithValue(error.message || 'Auth verification failed');
+      return rejectWithValue(error as ApiError);
     }
   }
 );
@@ -62,7 +63,7 @@ export const logoutUser = createAsyncThunk(
       await authApi.logout();
       return;
     } catch (error: any) {
-      return rejectWithValue(error.message || 'Logout failed');
+      return rejectWithValue(error as ApiError);
     }
   }
 );
@@ -74,7 +75,7 @@ export const updateProfile = createAsyncThunk(
       const updatedUser = await authApi.updateProfile(updates);
       return updatedUser;
     } catch (error: any) {
-      return rejectWithValue(error.message || 'Profile update failed');
+      return rejectWithValue(error as ApiError);
     }
   }
 );
@@ -112,7 +113,7 @@ const authSlice = createSlice({
       })
       .addCase(loginUser.rejected, (state, action) => {
         state.isLoading = false;
-        state.error = action.payload as string;
+        state.error = (action.payload as ApiError)?.message || 'Login failed';
         state.isAuthenticated = false;
         state.user = null;
       })
@@ -131,7 +132,7 @@ const authSlice = createSlice({
       })
       .addCase(registerUser.rejected, (state, action) => {
         state.isLoading = false;
-        state.error = action.payload as string;
+        state.error = (action.payload as ApiError)?.message || 'Registration failed';
         state.isAuthenticated = false;
         state.user = null;
       })
@@ -152,11 +153,12 @@ const authSlice = createSlice({
           state.isAuthenticated = false;
         }
       })
-      .addCase(verifyAuth.rejected, (state) => {
+      .addCase(verifyAuth.rejected, (state, action) => {
         state.isLoading = false;
         state.isInitialized = true;
         state.user = null;
         state.isAuthenticated = false;
+        state.error = (action.payload as ApiError)?.message || null;
       })
 
     // Logout
@@ -165,6 +167,9 @@ const authSlice = createSlice({
         state.user = null;
         state.isAuthenticated = false;
         state.error = null;
+      })
+      .addCase(logoutUser.rejected, (state, action) => {
+        state.error = (action.payload as ApiError)?.message || 'Logout failed';
       })
 
     // Update Profile
@@ -179,8 +184,18 @@ const authSlice = createSlice({
       })
       .addCase(updateProfile.rejected, (state, action) => {
         state.isLoading = false;
-        state.error = action.payload as string;
+        state.error = (action.payload as ApiError)?.message || 'Profile update failed';
       });
+
+    // Global 401 handler
+    builder.addMatcher(
+      (action): action is any =>
+        action.type.endsWith('/rejected') && (action.payload as ApiError)?.status === 401,
+      (state) => {
+        state.user = null;
+        state.isAuthenticated = false;
+      }
+    );
   }
 });
 

--- a/frontend/src/shared/libs/authTokens.ts
+++ b/frontend/src/shared/libs/authTokens.ts
@@ -1,4 +1,6 @@
-// Utility helpers for managing auth tokens in localStorage
+// Utility helpers for managing auth tokens in localStorage and axios
+
+import apiClient from './axios';
 
 export interface AuthResponse {
   access_token: string;
@@ -12,15 +14,19 @@ export interface AuthResponse {
   };
 }
 
+// Persist token and attach to axios default headers
 export const setAuthToken = (token: string): void => {
   localStorage.setItem('token', token);
+  apiClient.defaults.headers.common.Authorization = `Bearer ${token}`;
 };
 
 export const getAuthToken = (): string | null => {
   return localStorage.getItem('token');
 };
 
+// Remove token from storage and axios defaults
 export const clearAuthToken = (): void => {
   localStorage.removeItem('token');
+  delete apiClient.defaults.headers.common.Authorization;
 };
 

--- a/frontend/src/shared/libs/axios.ts
+++ b/frontend/src/shared/libs/axios.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
 import { handleApiError } from './errorHandler';
-import { getAuthToken, clearAuthToken } from './authTokens';
 
 const apiClient: AxiosInstance = axios.create({
   // Default to Laravel's local dev server
@@ -12,8 +11,14 @@ const apiClient: AxiosInstance = axios.create({
   }
 });
 
+const getToken = () => localStorage.getItem('token');
+const clearToken = () => {
+  localStorage.removeItem('token');
+  delete apiClient.defaults.headers.common.Authorization;
+};
+
 apiClient.interceptors.request.use((config) => {
-  const token = getAuthToken();
+  const token = getToken();
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
@@ -24,8 +29,7 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
     if (error.response?.status === 401) {
-      clearAuthToken();
-      window.location.href = '/login';
+      clearToken();
     }
 
     return Promise.reject(handleApiError(error));


### PR DESCRIPTION
## Summary
- attach tokens to axios and keep defaults in sync
- add token-aware auth verification
- handle 401s cleanly in auth slice

## Testing
- `bun run test` *(fails: TypeError: undefined is not an object ... z.object)*

------
https://chatgpt.com/codex/tasks/task_e_68be9a1b8e44832893eb5797db886f53