### PR TITLE
Defer auth verification on public pages

### DIFF
--- a/frontend/src/features/auth/hooks.ts
+++ b/frontend/src/features/auth/hooks.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { RootState, AppDispatch } from '../../app/store';
-import { verifyAuth, loginUser, registerUser, logoutUser } from './slice';
+import { verifyAuth, loginUser, registerUser, logoutUser, initialize } from './slice';
 import { LoginRequest, RegisterRequest } from './api';
 
 /**
@@ -96,12 +96,19 @@ export const useRole = () => {
  */
 export const useAuthInit = () => {
   const { checkAuth, isInitialized } = useAuth();
+  const dispatch = useDispatch<AppDispatch>();
+  const location = useLocation();
+  const publicPaths = ['/', '/login', '/register'];
 
   useEffect(() => {
     if (!isInitialized) {
-      checkAuth();
+      if (publicPaths.includes(location.pathname)) {
+        dispatch(initialize());
+      } else {
+        checkAuth();
+      }
     }
-  }, [checkAuth, isInitialized]);
+  }, [checkAuth, isInitialized, location.pathname, dispatch]);
 
-  return { isInitialized };
+  return { isInitialized: isInitialized || publicPaths.includes(location.pathname) };
 };

--- a/frontend/src/features/auth/slice.ts
+++ b/frontend/src/features/auth/slice.ts
@@ -96,6 +96,9 @@ const authSlice = createSlice({
       state.user = null;
       state.isAuthenticated = false;
       state.error = null;
+    },
+    initialize: (state) => {
+      state.isInitialized = true;
     }
   },
   extraReducers: (builder) => {
@@ -199,5 +202,5 @@ const authSlice = createSlice({
   }
 });
 
-export const { clearError, setUser, clearAuth } = authSlice.actions;
+export const { clearError, setUser, clearAuth, initialize } = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- add `initialize` reducer to mark auth as initialized without hitting verify endpoint
- skip auth verification on landing, login, and register pages

## Testing
- `npm test` *(fails: AddEditProcedureForm, AddEditClientForm)*

------
https://chatgpt.com/codex/tasks/task_e_68be9c1dd57883289f31c9bebb0d3955