### PR TITLE
Fix session usage in AuthController

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -26,8 +26,6 @@ class AuthController extends Controller
 
         Auth::login($user);
         $token = $user->createToken('auth_token')->plainTextToken;
-
-        return response()->json(['user' => $user], 201);
         return response()->json([
             'user' => $user,
             'access_token' => $token,
@@ -46,11 +44,13 @@ class AuthController extends Controller
             return response()->json(['message' => 'Unauthorized'], 401);
         }
 
-        $request->session()->regenerate();
+        if ($request->hasSession()) {
+            $request->session()->regenerate();
+        }
+
         $user = Auth::user();
         $token = $user->createToken('auth_token')->plainTextToken;
 
-        return response()->json(['user' => $request->user()]);
         return response()->json([
             'user' => $user,
             'access_token' => $token,
@@ -62,8 +62,11 @@ class AuthController extends Controller
     {
         Auth::guard('web')->logout();
 
-        $request->session()->invalidate();
-        $request->session()->regenerateToken();
+        if ($request->hasSession()) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
+
         $request->user()->currentAccessToken()->delete();
 
         return response()->json(['message' => 'Logged out']);


### PR DESCRIPTION
## Summary
- avoid RuntimeException when sessions are unavailable by guarding session calls
- streamline registration response with token

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68beec930408832894980ef1619f1c5b