### PR TITLE
feat: add password reset flow

### DIFF
--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -8,6 +8,8 @@ import Layout from '../../shared/components/Layout';
 import LandingPage from '../../pages/LandingPage';
 import LoginPage from '../../pages/LoginPage';
 import RegisterPage from '../../pages/RegisterPage';
+import ForgotPassword from '../../pages/ForgotPassword';
+import ResetPassword from '../../pages/ResetPassword';
 
 // Protected pages
 const Dashboard = React.lazy(() => import('../../pages/Dashboard'));
@@ -34,6 +36,8 @@ const AppRouter: React.FC = () => (
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
       </Route>
 
       <Route element={<ProtectedRoute />}>

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -26,6 +26,17 @@ export interface AuthResponse {
   user: User;
 }
 
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+export interface ResetPasswordRequest {
+  token: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
 export const authApi = {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
     await axios.get('http://127.0.0.1:8000/sanctum/csrf-cookie', {
@@ -62,5 +73,25 @@ export const authApi = {
   async verifyAuth(): Promise<{ user: User; authenticated: boolean }> {
     const { data } = await apiClient.get('/auth/verify');
     return data;
+  },
+
+  async requestPasswordReset(payload: ForgotPasswordRequest): Promise<void> {
+    await axios.get('http://127.0.0.1:8000/sanctum/csrf-cookie', {
+      withCredentials: true,
+    });
+    await apiClient.post('/auth/forgot-password', payload);
+  },
+
+  async resetPassword(payload: ResetPasswordRequest): Promise<void> {
+    await axios.get('http://127.0.0.1:8000/sanctum/csrf-cookie', {
+      withCredentials: true,
+    });
+    const data = {
+      token: payload.token,
+      email: payload.email,
+      password: payload.password,
+      password_confirmation: payload.confirmPassword,
+    };
+    await apiClient.post('/auth/reset-password', data);
   },
 };

--- a/frontend/src/features/auth/hooks.ts
+++ b/frontend/src/features/auth/hooks.ts
@@ -2,8 +2,21 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { RootState, AppDispatch } from '../../app/store';
-import { verifyAuth, loginUser, registerUser, logoutUser, initialize } from './slice';
-import { LoginRequest, RegisterRequest } from './api';
+import {
+  verifyAuth,
+  loginUser,
+  registerUser,
+  logoutUser,
+  initialize,
+  requestPasswordReset,
+  resetPassword,
+} from './slice';
+import {
+  LoginRequest,
+  RegisterRequest,
+  ForgotPasswordRequest,
+  ResetPasswordRequest,
+} from './api';
 
 /**
  * Main auth hook for managing authentication state
@@ -30,12 +43,24 @@ export const useAuth = () => {
     await dispatch(verifyAuth());
   };
 
+  const requestPasswordResetFn = async (payload: ForgotPasswordRequest) => {
+    const result = await dispatch(requestPasswordReset(payload));
+    return result.type === 'auth/requestPasswordReset/fulfilled';
+  };
+
+  const resetPasswordFn = async (payload: ResetPasswordRequest) => {
+    const result = await dispatch(resetPassword(payload));
+    return result.type === 'auth/resetPassword/fulfilled';
+  };
+
   return {
     ...auth,
     login,
     register,
     logout,
-    checkAuth
+    checkAuth,
+    requestPasswordReset: requestPasswordResetFn,
+    resetPassword: resetPasswordFn,
   };
 };
 
@@ -98,7 +123,7 @@ export const useAuthInit = () => {
   const { checkAuth, isInitialized } = useAuth();
   const dispatch = useDispatch<AppDispatch>();
   const location = useLocation();
-  const publicPaths = ['/', '/login', '/register'];
+  const publicPaths = ['/', '/login', '/register', '/forgot-password', '/reset-password'];
 
   useEffect(() => {
     if (!isInitialized) {

--- a/frontend/src/features/auth/slice.ts
+++ b/frontend/src/features/auth/slice.ts
@@ -1,5 +1,13 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { authApi, User, LoginRequest, RegisterRequest, AuthResponse } from './api';
+import {
+  authApi,
+  User,
+  LoginRequest,
+  RegisterRequest,
+  AuthResponse,
+  ForgotPasswordRequest,
+  ResetPasswordRequest,
+} from './api';
 import { ApiError } from '../../shared/libs/errorHandler';
 
 export interface AuthState {
@@ -49,6 +57,30 @@ export const verifyAuth = createAsyncThunk(
     try {
       const response = await authApi.verifyAuth();
       return response;
+    } catch (error: any) {
+      return rejectWithValue(error as ApiError);
+    }
+  }
+);
+
+export const requestPasswordReset = createAsyncThunk(
+  'auth/requestPasswordReset',
+  async (payload: ForgotPasswordRequest, { rejectWithValue }) => {
+    try {
+      await authApi.requestPasswordReset(payload);
+      return null;
+    } catch (error: any) {
+      return rejectWithValue(error as ApiError);
+    }
+  }
+);
+
+export const resetPassword = createAsyncThunk(
+  'auth/resetPassword',
+  async (payload: ResetPasswordRequest, { rejectWithValue }) => {
+    try {
+      await authApi.resetPassword(payload);
+      return null;
     } catch (error: any) {
       return rejectWithValue(error as ApiError);
     }
@@ -162,6 +194,34 @@ const authSlice = createSlice({
       .addCase(logoutUser.rejected, (state, action) => {
         state.error = (action.payload as ApiError)?.message || 'Logout failed';
       })
+
+    // Request Password Reset
+    builder
+      .addCase(requestPasswordReset.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(requestPasswordReset.fulfilled, (state) => {
+        state.isLoading = false;
+      })
+      .addCase(requestPasswordReset.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = (action.payload as ApiError)?.message || 'Request failed';
+      });
+
+    // Reset Password
+    builder
+      .addCase(resetPassword.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(resetPassword.fulfilled, (state) => {
+        state.isLoading = false;
+      })
+      .addCase(resetPassword.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = (action.payload as ApiError)?.message || 'Reset failed';
+      });
 
     // Global 401 handler
     builder.addMatcher(

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../features/auth/hooks';
+import LanguageSwitcher from '../components/LanguageSwitcher';
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Mail } from 'lucide-react';
+import { Logo } from '../components/common/Logo';
+import { toast } from 'sonner';
+
+export const ForgotPassword = () => {
+  const { t } = useTranslation();
+  const { requestPasswordReset, isLoading } = useAuth();
+  const [email, setEmail] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const success = await requestPasswordReset({ email });
+    if (success) {
+      toast.success('Password reset link sent');
+    } else {
+      toast.error('Failed to send reset link');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-900/20 dark:to-indigo-900/20 flex items-center justify-center p-4">
+      <div className="absolute top-4 right-4">
+        <LanguageSwitcher />
+      </div>
+
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <Link to="/" className="inline-flex items-center justify-center">
+            <Logo />
+          </Link>
+        </div>
+
+        <Card className="shadow-xl border-0 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl font-bold text-gray-900 dark:text-white">
+              {t('auth.forgot_password')}
+            </CardTitle>
+            <CardDescription className="text-gray-600 dark:text-gray-400">
+              {t('auth.forgot_password_subtitle', { defaultValue: 'Enter your email to receive reset link' })}
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email" className="text-gray-700 dark:text-gray-300">
+                  {t('auth.email')}
+                </Label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                  <Input
+                    id="email"
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="pl-10 border-gray-300 dark:border-gray-600"
+                    placeholder="john@example.com"
+                  />
+                </div>
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg hover:shadow-xl transition-all duration-200"
+                disabled={isLoading}
+              >
+                {isLoading ? <LoadingSpinner size="sm" /> : t('auth.send_reset_link', { defaultValue: 'Send Reset Link' })}
+              </Button>
+            </form>
+
+            <div className="mt-6 text-center">
+              <Link
+                to="/login"
+                className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {t('auth.back_to_login', { defaultValue: 'Back to login' })}
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;
+

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../features/auth/hooks';
+import LanguageSwitcher from '../components/LanguageSwitcher';
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Lock } from 'lucide-react';
+import { Logo } from '../components/common/Logo';
+import { toast } from 'sonner';
+
+export const ResetPassword = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { resetPassword, isLoading } = useAuth();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') || '';
+  const email = searchParams.get('email') || '';
+
+  const [formData, setFormData] = useState({
+    password: '',
+    confirmPassword: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const success = await resetPassword({
+      token,
+      email,
+      password: formData.password,
+      confirmPassword: formData.confirmPassword,
+    });
+    if (success) {
+      toast.success('Password reset successfully');
+      navigate('/login');
+    } else {
+      toast.error('Failed to reset password');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-900/20 dark:to-indigo-900/20 flex items-center justify-center p-4">
+      <div className="absolute top-4 right-4">
+        <LanguageSwitcher />
+      </div>
+
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <Link to="/" className="inline-flex items-center justify-center">
+            <Logo />
+          </Link>
+        </div>
+
+        <Card className="shadow-xl border-0 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl font-bold text-gray-900 dark:text-white">
+              {t('auth.reset_password')}
+            </CardTitle>
+            <CardDescription className="text-gray-600 dark:text-gray-400">
+              {t('auth.reset_password_subtitle', { defaultValue: 'Enter your new password' })}
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="password" className="text-gray-700 dark:text-gray-300">
+                  {t('auth.password')}
+                </Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                  <Input
+                    id="password"
+                    name="password"
+                    type="password"
+                    required
+                    value={formData.password}
+                    onChange={handleChange}
+                    className="pl-10 border-gray-300 dark:border-gray-600"
+                    placeholder="••••••••"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword" className="text-gray-700 dark:text-gray-300">
+                  {t('auth.confirm_password')}
+                </Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                  <Input
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type="password"
+                    required
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                    className="pl-10 border-gray-300 dark:border-gray-600"
+                    placeholder="••••••••"
+                  />
+                </div>
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg hover:shadow-xl transition-all duration-200"
+                disabled={isLoading}
+              >
+                {isLoading ? <LoadingSpinner size="sm" /> : t('auth.reset_password', { defaultValue: 'Reset Password' })}
+              </Button>
+            </form>
+
+            <div className="mt-6 text-center">
+              <Link
+                to="/login"
+                className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {t('auth.back_to_login', { defaultValue: 'Back to login' })}
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;
+


### PR DESCRIPTION
## Summary
- add API and Redux logic for password reset
- add forgot/reset password pages and routes

## Testing
- `npm run lint` *(fails: Unexpected any & other existing lint errors)*
- `npm test` *(fails: existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bf04ff79548328bc42089bd9c7ecae