### PR TITLE
feat: add RTL direction handling

### DIFF
--- a/frontend/src/context/LanguageContext.tsx
+++ b/frontend/src/context/LanguageContext.tsx
@@ -37,6 +37,10 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   const isRTL = language === 'ar';
 
+  useEffect(() => {
+    document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
+  }, [isRTL]);
+
   return (
     <LanguageContext.Provider value={{
       language,

--- a/frontend/src/context/__tests__/LanguageContext.test.tsx
+++ b/frontend/src/context/__tests__/LanguageContext.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook, act } from '@testing-library/react'
+import { LanguageProvider, useLanguage } from '../LanguageContext'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { changeLanguage: vi.fn(), language: 'en' } })
+}))
+
+describe('LanguageProvider', () => {
+  it('updates document direction on toggle', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <LanguageProvider>{children}</LanguageProvider>
+    )
+    const { result } = renderHook(() => useLanguage(), { wrapper })
+
+    expect(document.documentElement.dir).toBe('ltr')
+    act(() => result.current.toggleLanguage())
+    expect(document.documentElement.dir).toBe('rtl')
+  })
+})

--- a/frontend/src/shared/components/Sidebar.tsx
+++ b/frontend/src/shared/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '../../features/auth/hooks';
 import { LanguageToggle } from '@/components/ui/language-toggle';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { BrandLogo } from '@/components/common/BrandLogo';
+import { useLanguage } from '@/context/LanguageContext';
 
 const navigationItems = [
   { key: 'dashboard', href: '/dashboard', icon: Home },
@@ -34,6 +35,7 @@ export const Sidebar: React.FC = () => {
   const { isOpen, toggle } = useSidebar();
   const { user } = useAuth();
   const { t } = useTranslation();
+  const { isRTL } = useLanguage();
 
   const filteredItems = navigationItems.filter(item => {
     if (!item.roles) return true;
@@ -52,9 +54,9 @@ export const Sidebar: React.FC = () => {
 
       {/* Sidebar */}
       <div className={`
-        fixed top-0 left-0 h-full bg-card border-r border-border z-50 transition-all duration-300
+        fixed top-0 ${isRTL ? 'right-0 border-l' : 'left-0 border-r'} h-full bg-card z-50 transition-all duration-300
         ${isOpen ? 'w-64' : 'w-16'}
-        ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
+        ${isOpen ? 'translate-x-0' : isRTL ? 'translate-x-full lg:translate-x-0' : '-translate-x-full lg:translate-x-0'}
       `}>
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">


### PR DESCRIPTION
## Summary
- adjust LanguageProvider to update document `dir` and persist orientation
- make Sidebar position react to RTL languages
- add unit test for language direction toggle

## Testing
- `npm test -- --run` *(fails: Failed to resolve imports in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f13dedb88328a0e400fb16bd321b