### PR TITLE
feat(frontend): animate sidebar and header for dark mode

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
-import { Bell } from 'lucide-react';
+import { Bell, Menu } from 'lucide-react';
+import { motion } from 'framer-motion';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,6 +13,8 @@ import { LanguageToggle } from '@/components/ui/language-toggle';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useAuth } from '@/features/auth/hooks';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { useSidebar } from '@/contexts/SidebarContext';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 
@@ -19,14 +22,30 @@ export default function Header() {
   const { user, logout } = useAuth();
   const { isRTL } = useLanguage();
   const { t } = useTranslation();
+  const { toggleSidebar } = useSidebar();
+  const isMobile = useIsMobile();
 
   return (
-    <header
+    <motion.header
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
       className={cn(
-        'flex items-center justify-between border-b bg-background px-4 py-2 md:px-8',
+        'glass flex items-center justify-between border-b px-4 py-2 md:px-8 shadow-sm dark:shadow-glow',
         isRTL && 'flex-row-reverse'
       )}
     >
+      <div className="flex items-center">
+        {isMobile && (
+          <button
+            onClick={toggleSidebar}
+            className="md:hidden rounded-md bg-secondary p-2 text-secondary-foreground hover:bg-secondary/80"
+            aria-label={t('header.toggle_sidebar')}
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        )}
+      </div>
 
       <div
         className={cn(
@@ -81,6 +100,6 @@ export default function Header() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-    </header>
+    </motion.header>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
+import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useSidebar } from "@/contexts/SidebarContext";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { 
   LayoutDashboard, 
   TrendingUp, 
@@ -9,7 +12,6 @@ import {
   ChevronLeft, 
   ChevronRight,
   Wallet,
-  BarChart4,
   Star,
   Users
 } from "lucide-react";
@@ -23,26 +25,26 @@ interface SidebarLinkProps {
   onClick?: () => void;
 }
 
-const SidebarLink = ({ 
-  icon: Icon, 
-  label, 
-  active = false, 
+const SidebarLink = ({
+  icon: Icon,
+  label,
+  active = false,
   collapsed = false,
-  onClick 
+  onClick
 }: SidebarLinkProps) => {
   return (
     <button
       onClick={onClick}
       className={cn(
         "flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all duration-200",
-        active 
-          ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium" 
+        active
+          ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium glow"
           : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         collapsed && "justify-center"
       )}
     >
       <Icon size={20} />
-      {!collapsed && <span>{label}</span>} {/* Show label only when not collapsed */}
+      {!collapsed && <span>{label}</span>}
     </button>
   );
 };
@@ -52,17 +54,32 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ className }: SidebarProps) {
-  const [collapsed, setCollapsed] = useState(false);
+  const { isCollapsed: collapsed, toggleSidebar } = useSidebar();
   const [activeLink, setActiveLink] = useState("Dashboard");
+  const isMobile = useIsMobile();
 
   return (
-    <div
-      className={cn(
-        "relative h-screen bg-sidebar border-r border-sidebar-border transition-all duration-300 ease-in-out",
-        collapsed ? "w-16" : "w-56",  // Sidebar width changes based on collapsed state
-        className
+    <>
+      {isMobile && !collapsed && (
+        <div
+          className="fixed inset-0 z-30 bg-background/80 backdrop-blur-sm md:hidden"
+          onClick={toggleSidebar}
+        />
       )}
-    >
+      <motion.aside
+        initial={false}
+        animate={
+          isMobile
+            ? { x: collapsed ? "-100%" : "0%" }
+            : { width: collapsed ? "4rem" : "14rem" }
+        }
+        transition={{ type: "spring", stiffness: 260, damping: 30 }}
+        className={cn(
+          "fixed top-0 left-0 z-40 h-screen bg-sidebar shadow-lg dark:shadow-glow border-r border-sidebar-border md:relative transition-all duration-300 ease-in-out",
+          !isMobile && (collapsed ? "w-16" : "w-56"),
+          className
+        )}
+      >
       {/* Sidebar Header with Logo and Collapse Toggle */}
       <div className="p-4">
         <div className={cn("flex items-center gap-2", collapsed && "justify-center")}>
@@ -75,15 +92,15 @@ export default function Sidebar({ className }: SidebarProps) {
             </>
           )}
 
-          {/* Sidebar Collapse Toggle */}
-          <div className="ml-auto">
-            <button
-              onClick={() => setCollapsed(!collapsed)}
+      {/* Sidebar Collapse Toggle */}
+      <div className="ml-auto">
+        <button
+              onClick={toggleSidebar}
               className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-            >
-              {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
-            </button>
-          </div>
+        >
+          {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+        </button>
+      </div>
         </div>
       </div>
 
@@ -155,14 +172,15 @@ export default function Sidebar({ className }: SidebarProps) {
 
       {/* Sidebar Settings */}
       <div className="absolute bottom-4 w-full px-2">
-        <SidebarLink 
-          icon={Settings} 
-          label="Settings" 
+        <SidebarLink
+          icon={Settings}
+          label="Settings"
           active={activeLink === "Settings"}
           collapsed={collapsed}
           onClick={() => setActiveLink("Settings")}
         />
       </div>
-    </div>
+    </motion.aside>
+  </>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,7 +62,7 @@
     --gradient-glass: linear-gradient(135deg, hsl(220 15% 100% / 0.95), hsl(220 20% 95% / 0.8));
 
     /* Shadow System */
-    --shadow-glow: 0 0 25px hsl(var(--accent-glow));
+    --shadow-glow: 0 0 20px hsl(var(--accent-glow));
     --shadow-glass: 0 8px 32px hsl(var(--glass-shadow));
     --shadow-elegant: 0 4px 16px hsl(220 25% 10% / 0.12);
 
@@ -137,7 +137,7 @@
     --gradient-glass: linear-gradient(135deg, hsl(220 25% 12% / 0.95), hsl(220 25% 8% / 0.8));
 
     /* Dark Shadows */
-    --shadow-glow: 0 0 30px hsl(var(--accent-glow));
+    --shadow-glow: 0 0 40px hsl(var(--accent-glow));
     --shadow-glass: 0 8px 32px hsl(210 40% 45% / 0.12);
     --shadow-elegant: 0 4px 16px hsl(210 40% 45% / 0.15);
 


### PR DESCRIPTION
## Summary
- add animated, responsive sidebar with glow effect
- enhance header with mobile sidebar toggle and motion entry
- intensify dark mode shadow glow styling

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A require style import is forbidden, ES2015 module syntax is preferred over namespaces)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2859cb7f08328b1f3df716703b506