### PR TITLE
feat: align header icons and translate new sidebar sections

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -50,30 +50,9 @@ export default function Header() {
       <div
         className={cn(
           'flex items-center gap-2 md:gap-4',
-          isRTL && 'flex-row-reverse'
+          isRTL ? 'flex-row' : 'flex-row-reverse'
         )}
       >
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button className="relative flex h-9 w-9 items-center justify-center rounded-full bg-secondary text-muted-foreground hover:text-foreground">
-              <Bell className="h-4 w-4" />
-              <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>
-              {t('header.notifications')}
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <div className="p-2 text-sm text-muted-foreground">
-              {t('header.no_notifications')}
-            </div>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <ThemeToggle />
-        <LanguageToggle />
-
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button className="flex items-center gap-2 focus:outline-none">
@@ -97,6 +76,27 @@ export default function Header() {
             <DropdownMenuItem onClick={logout}>
               {t('common.logout')}
             </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <ThemeToggle />
+        <LanguageToggle />
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="relative flex h-9 w-9 items-center justify-center rounded-full bg-secondary text-muted-foreground hover:text-foreground">
+              <Bell className="h-4 w-4" />
+              <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>
+              {t('header.notifications')}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <div className="p-2 text-sm text-muted-foreground">
+              {t('header.no_notifications')}
+            </div>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,51 +1,48 @@
-import { useState } from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useSidebar } from "@/contexts/SidebarContext";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { 
-  LayoutDashboard, 
-  TrendingUp, 
-  LineChart, 
-  List, 
-  Settings, 
-  ChevronLeft, 
-  ChevronRight,
-  Wallet,
-  Star,
-  Users
-} from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import BrandLogo from "../common/BrandLogo";
+import { NavLink } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { IconType } from "react-icons";
+import {
+  FaHome,
+  FaFolder,
+  FaUsers,
+  FaCogs,
+  FaFileInvoice,
+  FaBalanceScale,
+  FaMoneyBillWave,
+  FaBriefcase,
+  FaSearch,
+} from "react-icons/fa";
 
 interface SidebarLinkProps {
-  icon: React.ElementType;
+  to: string;
+  icon: IconType;
   label: string;
-  active?: boolean;
   collapsed?: boolean;
-  onClick?: () => void;
 }
 
-const SidebarLink = ({
-  icon: Icon,
-  label,
-  active = false,
-  collapsed = false,
-  onClick
-}: SidebarLinkProps) => {
+const SidebarLink = ({ to, icon: Icon, label, collapsed = false }: SidebarLinkProps) => {
   return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all duration-200",
-        active
-          ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium glow"
-          : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-        collapsed && "justify-center"
-      )}
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        cn(
+          "flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all duration-200",
+          isActive
+            ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium glow"
+            : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+          collapsed && "justify-center"
+        )
+      }
     >
       <Icon size={20} />
       {!collapsed && <span>{label}</span>}
-    </button>
+    </NavLink>
   );
 };
 
@@ -55,8 +52,20 @@ interface SidebarProps {
 
 export default function Sidebar({ className }: SidebarProps) {
   const { isCollapsed: collapsed, toggleSidebar } = useSidebar();
-  const [activeLink, setActiveLink] = useState("Dashboard");
   const isMobile = useIsMobile();
+  const { t } = useTranslation();
+
+  const links = [
+    { to: "/", icon: FaHome, label: t("sidebar.dashboard") },
+    { to: "/legcases", icon: FaFolder, label: t("sidebar.cases") },
+    { to: "/clients", icon: FaUsers, label: t("sidebar.clients") },
+    { to: "/legcase-services", icon: FaCogs, label: t("sidebar.services") },
+    { to: "/invoices", icon: FaFileInvoice, label: t("sidebar.invoices") },
+    { to: "/consultations", icon: FaBalanceScale, label: t("sidebar.consultations") },
+    { to: "/expenses", icon: FaMoneyBillWave, label: t("sidebar.expenses") },
+    { to: "/contracts", icon: FaBriefcase, label: t("sidebar.contracts") },
+    { to: "/search-courts-api", icon: FaSearch, label: t("sidebar.search_courts") },
+  ];
 
   return (
     <>
@@ -80,107 +89,40 @@ export default function Sidebar({ className }: SidebarProps) {
           className
         )}
       >
-      {/* Sidebar Header with Logo and Collapse Toggle */}
-      <div className="p-4">
-        <div className={cn("flex items-center gap-2", collapsed && "justify-center")}>
-          {/* Display only the icon logo when collapsed, and both icon and text logo when expanded */}
-          {collapsed ? (
-            <BrandLogo variant="icon" className="text-primary-foreground h-8 w-8" />
-          ) : (
-            <> 
+        {/* Sidebar Header with Logo and Collapse Toggle */}
+        <div className="p-4">
+          <div className={cn("flex items-center gap-2", collapsed && "justify-center")}> 
+            {collapsed ? (
+              <BrandLogo variant="icon" className="text-primary-foreground h-8 w-8" />
+            ) : (
               <BrandLogo variant="full" className="text-primary-foreground ml-2 h-8 w-auto" />
-            </>
-          )}
+            )}
 
-      {/* Sidebar Collapse Toggle */}
-      <div className="ml-auto">
-        <button
-              onClick={toggleSidebar}
-              className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-        >
-          {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
-        </button>
-      </div>
-        </div>
-      </div>
-
-      {/* Sidebar Links */}
-      <div className="px-2 mt-6 space-y-6">
-        <div className="space-y-1">
-          <SidebarLink 
-            icon={LayoutDashboard} 
-            label="Dashboard" 
-            active={activeLink === "Dashboard"}
-            collapsed={collapsed}
-            onClick={() => setActiveLink("Dashboard")}
-          />
-          <SidebarLink 
-            icon={List} 
-            label="Project List" 
-            active={activeLink === "Project List"}
-            collapsed={collapsed}
-            onClick={() => setActiveLink("Project List")}
-          />
-          <SidebarLink 
-            icon={Star} 
-            label="Top ROI" 
-            active={activeLink === "Top ROI"}
-            collapsed={collapsed}
-            onClick={() => setActiveLink("Top ROI")}
-          />
-          <SidebarLink 
-            icon={TrendingUp} 
-            label="Trending" 
-            active={activeLink === "Trending"}
-            collapsed={collapsed}
-            onClick={() => setActiveLink("Trending")}
-          />
-        </div>
-
-        <div className="pt-4 border-t border-sidebar-border">
-          <p className={cn(
-            "text-xs uppercase text-sidebar-foreground/60 mb-2 px-3",
-            collapsed && "text-center"
-          )}>
-            {collapsed ? "More" : "Analytics"}
-          </p>
-          <div className="space-y-1">
-            <SidebarLink 
-              icon={LineChart} 
-              label="Market Insights" 
-              active={activeLink === "Market Insights"}
-              collapsed={collapsed}
-              onClick={() => setActiveLink("Market Insights")}
-            />
-            <SidebarLink 
-              icon={Wallet} 
-              label="Portfolios" 
-              active={activeLink === "Portfolios"}
-              collapsed={collapsed}
-              onClick={() => setActiveLink("Portfolios")}
-            />
-            <SidebarLink 
-              icon={Users} 
-              label="Social Trends" 
-              active={activeLink === "Social Trends"}
-              collapsed={collapsed}
-              onClick={() => setActiveLink("Social Trends")}
-            />
+            {/* Sidebar Collapse Toggle */}
+            <div className="ml-auto">
+              <button
+                onClick={toggleSidebar}
+                className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+              >
+                {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Sidebar Settings */}
-      <div className="absolute bottom-4 w-full px-2">
-        <SidebarLink
-          icon={Settings}
-          label="Settings"
-          active={activeLink === "Settings"}
-          collapsed={collapsed}
-          onClick={() => setActiveLink("Settings")}
-        />
-      </div>
-    </motion.aside>
-  </>
+        {/* Sidebar Links */}
+        <div className="px-2 mt-6 space-y-1">
+          {links.map((link) => (
+            <SidebarLink
+              key={link.to}
+              to={link.to}
+              icon={link.icon}
+              label={link.label}
+              collapsed={collapsed}
+            />
+          ))}
+        </div>
+      </motion.aside>
+    </>
   );
 }

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -82,12 +82,16 @@
     "legal_procedures": "إجراءات",
     "accounts": "الحسابات",
     "financial": "المالية",
-    "expenses": "مصروفات",
+    "expenses": "المصروفات",
     "revenues": "إيرادات",
     "account_settings": "إعدادات الحسابات",
     "users": "المستخدمين",
     "users_list": "قائمة المستخدمين",
-    "roles_permissions": "الأدوار والصلاحيات"
+    "roles_permissions": "الأدوار والصلاحيات",
+    "invoices": "الفواتير",
+    "consultations": "الاستشارات",
+    "contracts": "العقود",
+    "search_courts": "بحث محاكم"
   },
   "dashboard": {
     "welcome_message": "مرحباً بك في نظام أفوكات القانوني",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -87,7 +87,11 @@
     "account_settings": "Account Settings",
     "users": "Users",
     "users_list": "Users List",
-    "roles_permissions": "Roles & Permissions"
+    "roles_permissions": "Roles & Permissions",
+    "invoices": "Invoices",
+    "consultations": "Consultations",
+    "contracts": "Contracts",
+    "search_courts": "Courts Search"
   },
   "dashboard": {
     "welcome_message": "Welcome to Avocat Legal System",


### PR DESCRIPTION
## Summary
- order header tools by user, theme, and language respecting RTL/LTR
- add translated sidebar links for invoices, consultations, contracts, etc.
- localize new sidebar entries in English and Arabic

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty-object-type, no-explicit-any, no-require-imports, no-namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d3d752f08328b72f85745d471f7a