### PR TITLE
feat: enhance sidebar with collapsible sections and translations

### DIFF
--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -3,20 +3,20 @@ import SidebarMenu from './SidebarMenu';
 import { useTranslation } from 'react-i18next';
 import { menuItems } from '@/config/sidebar';
 import BrandLogo from '../common/BrandLogo';
-import { cn } from '@/lib/utils'; // make sure cn is imported
-import { ChevronLeft, ChevronRight } from 'lucide-react'; // import the icons
+import { cn } from '@/lib/utils';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const Sidebar = () => {
-  const { t, i18n } = useTranslation();
-  const [collapsed, setCollapsed] = useState(false); // state for sidebar collapse
+  const { i18n } = useTranslation();
+  const [collapsed, setCollapsed] = useState(false);
 
   const toggleSidebar = () => setCollapsed(!collapsed); // toggle function
 
   return (
     <aside
       className={cn(
-        "h-full bg-gray-800 text-white transition-all duration-300",
-        collapsed ? "w-20" : "w-64"
+        'h-full bg-sidebar text-sidebar-foreground border-r border-sidebar-border transition-all duration-300',
+        collapsed ? 'w-20' : 'w-64'
       )}
       dir={i18n.dir()}
     >
@@ -33,7 +33,7 @@ const Sidebar = () => {
         {/* Sidebar Collapse Toggle */}
         <button
           onClick={toggleSidebar}
-          className="flex items-center justify-center h-6 w-6 rounded-full bg-gray-700 text-white hover:bg-gray-600 transition-colors"
+          className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-accent text-sidebar-accent-foreground hover:bg-sidebar-accent/80 transition-colors"
         >
           {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
         </button>

--- a/frontend/src/components/sidebar/SidebarLink.tsx
+++ b/frontend/src/components/sidebar/SidebarLink.tsx
@@ -1,35 +1,67 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import type { MenuItem } from '@/config/sidebar';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown } from 'lucide-react';
 
 interface SidebarLinkProps {
   item: MenuItem;
-  collapsed?: boolean; // ← أضف هذه الخاصية
+  collapsed?: boolean;
 }
 
 const SidebarLink: React.FC<SidebarLinkProps> = ({ item, collapsed = false }) => {
-  return (
-    <div>
-      <Link
-        to={item.path}
-        className={cn(
-          'flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all duration-200 hover:bg-gray-700',
-          collapsed && 'justify-center'
-        )}
-      >
-        <item.icon size={20} />
-        {!collapsed && <span>{item.key}</span>} {/* أو استخدم t(`sidebar.${item.key}`) */}
-      </Link>
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const hasChildren = item.children && item.children.length > 0;
 
-      {item.children && !collapsed && (
-        <div className="pl-6 space-y-1">
-          {item.children.map(child => (
-            <SidebarLink key={child.key} item={child} collapsed={collapsed} />
-          ))}
-        </div>
+  const content = (
+    <>
+      <item.icon size={20} />
+      {!collapsed && <span className="flex-1">{t(`sidebar.${item.key}`)}</span>}
+      {hasChildren && !collapsed && (
+        <ChevronDown
+          size={16}
+          className={cn('transition-transform', open ? 'rotate-180' : 'rotate-0')}
+        />
       )}
-    </div>
+    </>
+  );
+
+  if (hasChildren) {
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className={cn(
+            'flex w-full items-center gap-3 px-3 py-2.5 text-left rounded-md transition-all duration-200 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+            collapsed && 'justify-center'
+          )}
+        >
+          {content}
+        </button>
+        {!collapsed && open && (
+          <div className="pl-6 space-y-1">
+            {item.children!.map((child) => (
+              <SidebarLink key={child.key} item={child} collapsed={collapsed} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to={item.path}
+      className={cn(
+        'flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all duration-200 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        collapsed && 'justify-center'
+      )}
+    >
+      {content}
+    </Link>
   );
 };
 

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -86,6 +86,10 @@
     "expenses": "مصروفات",
     "revenues": "إيرادات",
     "account_settings": "إعدادات الحسابات",
+    "settings": "الإعدادات",
+    "office_settings": "إعدادات المكتب",
+    "court_settings": "إعدادات المحاكم",
+    "app_settings": "إعدادات التطبيق",
     "users": "المستخدمين",
     "users_list": "قائمة المستخدمين",
     "roles_permissions": "الأدوار والصلاحيات"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -86,6 +86,10 @@
     "expenses": "Expenses",
     "revenues": "Revenues",
     "account_settings": "Account Settings",
+    "settings": "Settings",
+    "office_settings": "Office Settings",
+    "court_settings": "Court Settings",
+    "app_settings": "App Settings",
     "users": "Users",
     "users_list": "Users List",
     "roles_permissions": "Roles & Permissions"


### PR DESCRIPTION
## Summary
- add collapsible nested items to sidebar with hover styling and theme-aware colors
- translate sidebar items for both English and Arabic

## Testing
- `npm test`
- `npm run lint` *(fails: no matching configuration or repo-wide lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c31dc158b88328b51a8ba66f181d92