### PR TITLE
feat(frontend): enhance sidebar with collapsible icons

### DIFF
--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,29 +1,28 @@
-import React, { useState } from 'react'; 
-import { menuItems } from '@/config/sidebar';
-import SidebarMenu from './SidebarMenu';
-import { useTranslation } from 'react-i18next';
-import BrandLogo from '../common/BrandLogo';
-import { cn } from '@/lib/utils'; // make sure cn is imported
-import { ChevronLeft, ChevronRight } from 'lucide-react'; // import the icons
+import React, { useState } from 'react'
+import { menuItems } from '@/config/sidebar'
+import SidebarMenu from './SidebarMenu'
+import { useTranslation } from 'react-i18next'
+import BrandLogo from '../common/BrandLogo'
+import { cn } from '@/lib/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 const Sidebar = () => {
-  const { t, i18n } = useTranslation();
-  const [collapsed, setCollapsed] = useState(false); // state for sidebar collapse
+  const { t, i18n } = useTranslation()
+  const [collapsed, setCollapsed] = useState(false)
 
-
-  const toggleSidebar = () => setCollapsed(!collapsed); // toggle function
+  const toggleSidebar = () => setCollapsed((c) => !c)
 
   return (
-        <aside
+    <aside
       className={cn(
-        "h-full bg-background text-white transition-all duration-300",
-        collapsed ? "w-20" : "w-64"
+        'h-full bg-sidebar text-sidebar-foreground transition-all duration-300',
+        collapsed ? 'w-20' : 'w-64'
       )}
       dir={i18n.dir()}
     >
       {/* Logo Section */}
       <div className="p-4 flex items-center justify-between">
-        <div className={cn("flex items-center gap-2")}>
+        <div className={cn('flex items-center gap-2')}>
           {collapsed ? (
             <BrandLogo variant="icon" className="text-primary-foreground h-8 w-8" />
           ) : (
@@ -34,17 +33,17 @@ const Sidebar = () => {
         {/* Sidebar Collapse Toggle */}
         <button
           onClick={toggleSidebar}
-          className="flex items-center justify-center h-6 w-6 rounded-full bg-gray-700 text-white hover:bg-gray-600 transition-colors"
+          className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-accent text-sidebar-foreground hover:bg-sidebar-primary hover:text-sidebar-primary-foreground transition-colors"
         >
           {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
         </button>
       </div>
-         <div className="p-4">
+      <div className="p-4">
         <h2 className="text-lg font-semibold">{t('sidebar.dashboard')}</h2>
       </div>
-      <SidebarMenu items={menuItems} />
+      <SidebarMenu items={menuItems} collapsed={collapsed} />
     </aside>
-  );
-};
+  )
+}
 
-export default Sidebar;
+export default Sidebar

--- a/frontend/src/components/sidebar/SidebarLink.tsx
+++ b/frontend/src/components/sidebar/SidebarLink.tsx
@@ -1,36 +1,67 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { cn } from '@/lib/utils';
-import type { MenuItem } from '@/config/sidebar';
+import React, { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { cn } from '@/lib/utils'
+import type { MenuItem } from '@/config/sidebar'
+import { ChevronDown } from 'lucide-react'
 
 interface SidebarLinkProps {
-  item: MenuItem;
-  collapsed?: boolean; // ← أضف هذه الخاصية
+  item: MenuItem
+  collapsed?: boolean // property to control collapsed state
 }
 
 const SidebarLink: React.FC<SidebarLinkProps> = ({ item, collapsed = false }) => {
+  const location = useLocation()
+  const hasChildren = !!item.children && item.children.length > 0
+  const isActive = location.pathname.startsWith(item.path)
+  const [open, setOpen] = useState(isActive)
+
+  const toggle = () => setOpen((o) => !o)
+
+  const linkClasses = cn(
+    'flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-colors',
+    collapsed && 'justify-center',
+    isActive
+      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+  )
+
+  const content = (
+    <div className={linkClasses}>
+      <item.icon size={20} />
+      {!collapsed && <span>{item.key}</span>}
+      {!collapsed && hasChildren && (
+        <ChevronDown
+          size={16}
+          className={cn('ml-auto transition-transform', open && 'rotate-180')}
+        />
+      )}
+    </div>
+  )
+
   return (
     <div>
-      <Link
-        to={item.path}
-        className={cn(
-          'flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all duration-200 hover:bg-gray-700',
-          collapsed && 'justify-center'
-        )}
-      >
-        <item.icon size={20} />
-        {!collapsed && <span>{item.key}</span>} {/* أو استخدم t(`sidebar.${item.key}`) */}
-      </Link>
+      {hasChildren ? (
+        <button onClick={toggle} className="w-full text-left">
+          {content}
+        </button>
+      ) : (
+        <Link to={item.path}>{content}</Link>
+      )}
 
-      {item.children && !collapsed && (
-        <div className="pl-6 space-y-1">
-          {item.children.map(child => (
+      {hasChildren && !collapsed && (
+        <div
+          className={cn(
+            'pl-6 space-y-1 overflow-hidden transition-all',
+            open ? 'max-h-96 animate-accordion-down' : 'max-h-0 animate-accordion-up'
+          )}
+        >
+          {item.children?.map((child) => (
             <SidebarLink key={child.key} item={child} collapsed={collapsed} />
           ))}
         </div>
       )}
     </div>
-  );
-};
+  )
+}
 
-export default SidebarLink;
+export default SidebarLink

--- a/frontend/src/components/sidebar/SidebarMenu.tsx
+++ b/frontend/src/components/sidebar/SidebarMenu.tsx
@@ -1,20 +1,20 @@
-import React from 'react';
-import SidebarLink from './SidebarLink';
-import type { MenuItem } from '@/config/sidebar';
+import React from 'react'
+import SidebarLink from './SidebarLink'
+import type { MenuItem } from '@/config/sidebar'
 
 interface SidebarMenuProps {
-  items: MenuItem[];
-  collapsed?: boolean;
+  items: MenuItem[]
+  collapsed?: boolean
 }
 
 const SidebarMenu: React.FC<SidebarMenuProps> = ({ items, collapsed = false }) => {
   return (
-    <div className="space-y-4">
-      {items.map(item => (
+    <div className="space-y-1">
+      {items.map((item) => (
         <SidebarLink key={item.key} item={item} collapsed={collapsed} />
       ))}
     </div>
-  );
-};
+  )
+}
 
-export default SidebarMenu;
+export default SidebarMenu


### PR DESCRIPTION
## Summary
- add mini icon sidebar collapse with theme-aware styles
- animate nested menu items and highlight active routes
- forward collapse state through sidebar components

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c223fde08328b506090f059a4608