### PR TITLE
feat: auto-generate demo pages for sidebar sections

### DIFF
--- a/frontend/src/app/router/generateDemoRoutes.tsx
+++ b/frontend/src/app/router/generateDemoRoutes.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import DemoPage from '@/pages/DemoPage';
+import type { MenuItem } from '@/config/sidebar';
+
+export const generateDemoRoutes = (items: MenuItem[], skip: Set<string> = new Set()) => {
+  const routes: React.ReactElement[] = [];
+
+  const traverse = (list: MenuItem[]) => {
+    list.forEach((item) => {
+      if (!skip.has(item.path)) {
+        routes.push(
+          <Route key={item.path} path={item.path} element={<DemoPage titleKey={item.key} />} />
+        );
+      }
+      if (item.children) traverse(item.children);
+    });
+  };
+
+  traverse(items);
+  return routes;
+};
+
+export default generateDemoRoutes;

--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -4,6 +4,8 @@ import { Routes, Route } from 'react-router-dom';
 import BrandedLoader from '@/components/common/BrandedLoader';
 import Layout from '@/components/layout/Layout';
 import { ProtectedRoute, PublicRoute } from '@/features/auth/guards';
+import { menuItems } from '@/config/sidebar';
+import generateDemoRoutes from './generateDemoRoutes';
 
 // Public pages
 import LandingPage from '@/pages/LandingPage';
@@ -47,6 +49,18 @@ const AppRouter: React.FC = () => (
           <Route path="/procedures" element={<ProceduresPage />} />
           <Route path="/services" element={<ServicesPage />} />
           <Route path="/accounts" element={<AccountsPage />} />
+          {generateDemoRoutes(
+            menuItems,
+            new Set([
+              '/dashboard',
+              '/clients',
+              '/cases',
+              '/reports',
+              '/procedures',
+              '/services',
+              '/accounts',
+            ])
+          )}
         </Route>
       </Route>
 

--- a/frontend/src/components/sidebar/SidebarLink.tsx
+++ b/frontend/src/components/sidebar/SidebarLink.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import type { MenuItem } from '@/config/sidebar'
 import { ChevronDown } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 interface SidebarLinkProps {
   item: MenuItem
@@ -14,21 +15,22 @@ const SidebarLink: React.FC<SidebarLinkProps> = ({ item, collapsed = false }) =>
   const hasChildren = !!item.children && item.children.length > 0
   const isActive = location.pathname.startsWith(item.path)
   const [open, setOpen] = useState(isActive)
+  const { t } = useTranslation()
 
   const toggle = () => setOpen((o) => !o)
 
   const linkClasses = cn(
-    'flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-colors',
+    'flex items-center gap-3 px-3 py-2.5 rounded-md w-full transition-all',
     collapsed && 'justify-center',
     isActive
-      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+      ? 'bg-sidebar-accent text-sidebar-accent-foreground shadow-glow'
+      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-glow'
   )
 
   const content = (
     <div className={linkClasses}>
       <item.icon size={20} />
-      {!collapsed && <span>{item.key}</span>}
+      {!collapsed && <span>{t(`sidebar.${item.key}`)}</span>}
       {!collapsed && hasChildren && (
         <ChevronDown
           size={16}

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -210,5 +210,9 @@
       "contact": "تواصل",
       "copyright": "© ٢٠٢٥ أفوكات"
     }
+  },
+  "demo": {
+    "description": "هذه صفحة تجريبية لـ {{section}}",
+    "card_title": "بطاقة {{number}}"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -210,5 +210,9 @@
       "contact": "Contact",
       "copyright": "© 2025 Avocat"
     }
+  },
+  "demo": {
+    "description": "This is a demo page for {{section}}",
+    "card_title": "Card {{number}}"
   }
 }

--- a/frontend/src/pages/DemoPage.tsx
+++ b/frontend/src/pages/DemoPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface DemoPageProps {
+  titleKey: string;
+}
+
+const DemoPage: React.FC<DemoPageProps> = ({ titleKey }) => {
+  const { t } = useTranslation();
+  const title = t(`sidebar.${titleKey}`);
+  const description = t('demo.description', { section: title });
+
+  return (
+    <div className="p-6 space-y-6 animate-fade-in">
+      <div>
+        <h1 className="text-2xl font-bold mb-2">{title}</h1>
+        <p className="text-muted-foreground">{description}</p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3, 4, 5, 6].map((n) => (
+          <div
+            key={n}
+            className="p-4 rounded-xl border border-glass-border bg-glass-bg/50 dark:bg-glass-bg/20 backdrop-blur shadow-glass transition-all duration-300 hover:shadow-glow hover:-translate-y-1 hover:scale-105"
+          >
+            <p className="text-center">{t('demo.card_title', { number: n })}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DemoPage;


### PR DESCRIPTION
## Summary
- generate routes from sidebar config
- add translated demo page with animated glass cards
- highlight sidebar links with glow and i18n labels

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty-object-type, no-explicit-any, no-require-imports, no-namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e437f9f88328a099a424bc877e23