### PR TITLE
feat(frontend): add bilingual landing page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -87,6 +87,7 @@
         "lovable-tagger": "^1.1.8",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
+        "tailwindcss-rtl": "^0.9.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
@@ -7974,6 +7975,13 @@
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
       }
+    },
+    "node_modules/tailwindcss-rtl": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-rtl/-/tailwindcss-rtl-0.9.0.tgz",
+      "integrity": "sha512-y7yC8QXjluDBEFMSX33tV6xMYrf0B3sa+tOB5JSQb6/G6laBU313a+Z+qxu55M1Qyn8tDMttjomsA8IsJD+k+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
       "version": "6.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,7 @@
     "lovable-tagger": "^1.1.8",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
+    "tailwindcss-rtl": "^0.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",

--- a/frontend/src/content/site-content.json
+++ b/frontend/src/content/site-content.json
@@ -1,0 +1,330 @@
+{
+  "site": {
+    "brand": {
+      "name_ar": "آفاق للمحاماة (Avocat)",
+      "name_en": "Afaq Law Firm (Avocat)"
+    },
+    "locales": [
+      "ar",
+      "en"
+    ],
+    "defaultLocale": "ar"
+  },
+  "nav": {
+    "ar": [
+      "الرئيسية",
+      "من نحن",
+      "خدماتنا",
+      "قدراتنا",
+      "ذكاء قانوني",
+      "تحول رقمي",
+      "جرائم إلكترونية",
+      "إنجازات",
+      "الفريق",
+      "تواصل"
+    ],
+    "en": [
+      "Home",
+      "About",
+      "Services",
+      "Capabilities",
+      "AI Legal",
+      "Digital Transformation",
+      "Cybercrime",
+      "Cases",
+      "Team",
+      "Contact"
+    ]
+  },
+  "hero": {
+    "ar": {
+      "headline": "حلول قانونية ذكية وسريعة مبنية على الثقة",
+      "subheadline": "منذ 2013 نعيد تعريف ممارسة المهنة برؤية رقمية حديثة تدعم الشفافية وتُيسر العدالة.",
+      "primaryCta": "ابدأ استشارتك",
+      "secondaryCta": "تعرّف علينا"
+    },
+    "en": {
+      "headline": "Smart, Trusted & Fast Legal Solutions",
+      "subheadline": "Since 2013, we’ve redefined legal practice with a digital, transparent, and client-first approach.",
+      "primaryCta": "Start a Consultation",
+      "secondaryCta": "Discover More"
+    }
+  },
+  "about": {
+    "founded_year": 2013,
+    "vision": {
+      "ar": "أن نكون الواجهة الأولى لعملائنا في عالم المحاماة المعاصر بتقديم حلول قانونية متكاملة، مبنية على الثقة والسرعة، تدعم العدالة الذكية وحقوق الأفراد والمؤسسات.",
+      "en": "To be the first choice in modern legal services, delivering integrated, trusted, and fast solutions that advance smart justice and protect rights."
+    },
+    "philosophy": {
+      "ar": "لا نكتفي بالممارسة التقليدية؛ نمزج الخبرة القانونية بالابتكار والتقنية لصناعة مستقبل قانوني أكثر كفاءة ومرونة.",
+      "en": "We go beyond tradition, blending deep legal expertise with innovation and technology to build a more efficient and agile legal future."
+    },
+    "client_commitment": {
+      "ar": "ثقة وشفافية وتبسيط للتعقيدات القانونية، مع استشارات مُصمَّمة لاحتياجات كل عميل ومتابعة دقيقة لضمان نتائج موثوقة.",
+      "en": "Trust, transparency, and simplification of legal complexity—tailored advice and meticulous follow-through for dependable outcomes."
+    }
+  },
+  "services": [
+    {
+      "ar": "التقاضي وحل النزاعات (جميع درجات المحاكم)",
+      "en": "Litigation & Dispute Resolution (all court tiers)"
+    },
+    {
+      "ar": "صياغة العقود والاتفاقيات وفق المعايير الدولية",
+      "en": "Contract & Agreement Drafting to international standards"
+    },
+    {
+      "ar": "استشارات قانونية متخصصة للأفراد والشركات",
+      "en": "Specialized Legal Advisory for individuals & corporations"
+    },
+    {
+      "ar": "تأسيس الشركات والامتثال والحوكمة",
+      "en": "Company Formation, Compliance & Governance"
+    },
+    {
+      "ar": "الملكية الفكرية والتسجيل والدفاع",
+      "en": "Intellectual Property (registration & defense)"
+    },
+    {
+      "ar": "التحكيم التجاري وتسوية المنازعات",
+      "en": "Commercial Arbitration & ADR"
+    },
+    {
+      "ar": "إدارة القضايا وأرشفة رقمية مؤمنة",
+      "en": "Case Management & Secure Digital Archiving"
+    }
+  ],
+  "capabilities": {
+    "ar": [
+      "إدارة مكاتب المحاماة والعمليات القانونية بمرونة عالية",
+      "تطبيقات قانونية مخصصة حسب احتياجات العمل",
+      "تكامل مباشر مع قواعد بيانات المحاكم لتسريع الإجراءات",
+      "منصة خدمات إلكترونية متاحة للجمهور 24/7",
+      "أرشفة رقمية آمنة للملفات والأحكام والمستندات",
+      "تحليلات ذكية لدعم اتخاذ القرار القانوني",
+      "أنظمة متابعة القضايا بمؤشرات تنبيه وتذكير",
+      "حماية معلومات وفق أعلى معايير الأمن السيبراني"
+    ],
+    "en": [
+      "Flexible law-office & legal operations management",
+      "Custom legal apps tailored to business needs",
+      "Direct integration with court databases to accelerate filings",
+      "24/7 public e-services portal",
+      "Secure digital archiving for files, rulings & documents",
+      "Smart analytics for legal decision-making",
+      "Case tracking with alerts & reminders",
+      "Data protection aligned with top cybersecurity standards"
+    ]
+  },
+  "ai_legal": {
+    "ar": {
+      "title": "منظومة ذكاء اصطناعي قانوني",
+      "points": [
+        "أتمتة الإجراءات القانونية وتوليد النماذج بدقة",
+        "تذكير تلقائي بالمواعيد والجلسات",
+        "مساعدة شاملة في التقديم الإلكتروني",
+        "بحث متقدم في الأحكام والدفوع",
+        "صياغة مسودات مذكرات وردود",
+        "متابعة سير الإجراءات بتنبيهات فورية",
+        "وضع استراتيجيات إطار قانوني لإدارة الأحداث"
+      ]
+    },
+    "en": {
+      "title": "AI-Powered Legal System",
+      "points": [
+        "Automated legal workflows & precise template generation",
+        "Auto-reminders for hearings & deadlines",
+        "End-to-end e-filing assistance",
+        "Advanced judgments & defenses research",
+        "Drafting support for memos & pleadings",
+        "Real-time procedural tracking & notifications",
+        "Strategic legal frameworks for incident management"
+      ]
+    }
+  },
+  "digital_transformation": {
+    "ar": {
+      "title": "التحوّل الرقمي القانوني",
+      "bullets": [
+        "إدارة كاملة للإجراءات والملفات عبر منصة موثّقة",
+        "توقيع إلكتروني معتمد وتعزيز حجية المستندات",
+        "تكامل مع الأنظمة الحكومية لتسريع المعاملات",
+        "لوحات تحكم توضّح سير القضايا والطلبات",
+        "تقليل الاعتماد على الورق وزيادة كفاءة الأداء"
+      ]
+    },
+    "en": {
+      "title": "Legal Digital Transformation",
+      "bullets": [
+        "End-to-end procedural & file management on a trusted platform",
+        "Qualified e-signature and enhanced evidentiary weight",
+        "Integration with government systems to speed transactions",
+        "Dashboards clarifying case & request status",
+        "Reduced paper reliance and higher operational efficiency"
+      ]
+    }
+  },
+  "cybercrime": {
+    "ar": {
+      "title": "مكافحة الجرائم الإلكترونية",
+      "bullets": [
+        "توثيق الأدلة الرقمية بدقة",
+        "تدريب متخصص وتأهيل الكوادر",
+        "نشر ثقافة قانونية رقمية آمنة",
+        "تأمين البيانات أثناء التعامل مع المنصات",
+        "حلول تقنية متوافقة مع التشريعات الدولية",
+        "تحديث مستمر للإجراءات ومعايير الحماية"
+      ]
+    },
+    "en": {
+      "title": "Cybercrime Response Program",
+      "bullets": [
+        "Rigorous digital-evidence preservation",
+        "Specialized training & capacity building",
+        "Public awareness of safe digital legal practices",
+        "Data security across platforms",
+        "Tech solutions aligned with international laws",
+        "Continuous updates to procedures & safeguards"
+      ]
+    }
+  },
+  "challenges": {
+    "ar": [
+      "ضعف الثقافة القانونية الرقمية ومقاومة الانتقال من الورقي",
+      "نقص الكفاءات المؤهلة لتشغيل الأنظمة الحديثة",
+      "قيود البنية التحتية التقنية",
+      "حماية الخصوصية والبيانات في بيئة متغيرة",
+      "الحاجة لتشريعات مرنة مواكِبة للتقنية",
+      "فجوة الثقة في الخدمات الرقمية الوليدة"
+    ],
+    "en": [
+      "Low digital-legal literacy & resistance to moving off paper",
+      "Shortage of qualified talent to run modern systems",
+      "Infrastructure constraints",
+      "Privacy & data protection in a changing environment",
+      "Need for flexible, tech-aware regulations",
+      "Trust gap in emerging digital services"
+    ]
+  },
+  "why_us": {
+    "ar": [
+      "نمزج بين التقنية والمعرفة القانونية العميقة",
+      "حلول تغطي احتياجات العملاء بتنوّع ومرونة",
+      "التزام صارم بالسرية والمعايير الدولية",
+      "تقليل التكاليف وزيادة الكفاءة",
+      "قدرة عالية على مواكبة التطورات التشريعية",
+      "استشارات مدعومة بالذكاء الاصطناعي",
+      "خدمات رقمية شفافة وسهلة الوصول",
+      "نتائج سريعة وموثوقة"
+    ],
+    "en": [
+      "Blend of technology with deep legal expertise",
+      "Flexible solutions covering diverse client needs",
+      "Strict confidentiality & international standards",
+      "Cost reduction with higher efficiency",
+      "Agile adaptation to regulatory changes",
+      "AI-assisted advisory",
+      "Transparent, accessible digital services",
+      "Fast and reliable outcomes"
+    ]
+  },
+  "case_highlights": [
+    {
+      "ar": {
+        "title": "حكم بالبراءة في تهمة النصب",
+        "summary": "انتهت المحكمة إلى انتفاء أركان الجريمة وعدم كفاية الدليل الفني، وقضي بالبراءة."
+      },
+      "en": {
+        "title": "Acquittal in Fraud Allegation",
+        "summary": "Court found elements unfulfilled and technical evidence insufficient; defendant acquitted."
+      }
+    },
+    {
+      "ar": {
+        "title": "براءة من مخالفة شروط الترخيص",
+        "summary": "ثبوت عدم توافر المخالفة الإدارية وشيوع الاتهام؛ قُضي بالبراءة."
+      },
+      "en": {
+        "title": "Cleared of Licensing-Terms Violation",
+        "summary": "Administrative breach not established; charge dismissed."
+      }
+    },
+    {
+      "ar": {
+        "title": "براءة من عدم الامتثال لأوامر إدارية",
+        "summary": "بطلان الدليل الإداري وغياب القصد الجنائي؛ قُضي بالبراءة."
+      },
+      "en": {
+        "title": "Acquittal: Non-Compliance with Administrative Orders",
+        "summary": "Administrative evidence void; no criminal intent."
+      }
+    }
+  ],
+  "team": {
+    "ar": {
+      "intro": "فريق قانوني وتقني يجمع الخبرة بالممارسة والابتكار.",
+      "members": [
+        {
+          "name": "عضو فريق 1",
+          "role": "محام بالنقض",
+          "bio": "خبرة واسعة في التقاضي والتحكيم وصياغة العقود."
+        },
+        {
+          "name": "عضو فريق 2",
+          "role": "مستشار قانوني وتقني",
+          "bio": "اختصاص في الجرائم الإلكترونية والتحول الرقمي القانوني."
+        }
+      ]
+    },
+    "en": {
+      "intro": "A cross-functional legal-tech team with deep practice and innovation.",
+      "members": [
+        {
+          "name": "Member 1",
+          "role": "Cassation Lawyer",
+          "bio": "Extensive experience in litigation, arbitration, and contract drafting."
+        },
+        {
+          "name": "Member 2",
+          "role": "Legal & Tech Counsel",
+          "bio": "Specialist in cybercrime and legal digital transformation."
+        }
+      ]
+    }
+  },
+  "contact": {
+    "ar": {
+      "address": "العنوان (حدّثه وفق بياناتكم الرسمية)",
+      "phone": [
+        "+20-XXX-XXXXXXX"
+      ],
+      "email": "info@example.com"
+    },
+    "en": {
+      "address": "Address (update to your official details)",
+      "phone": [
+        "+20-XXX-XXXXXXX"
+      ],
+      "email": "info@example.com"
+    }
+  },
+  "footer": {
+    "ar": "© آفاق للمحاماة — جميع الحقوق محفوظة.",
+    "en": "© Afaq Law Firm — All rights reserved."
+  },
+  "legal_disclaimer": {
+    "ar": "المذكور أعلاه أمثلة موجزة لأحكام/إنجازات بهدف العرض التسويقي فقط ولا يُعد استشارة قانونية.",
+    "en": "The above case notes are brief illustrative examples for marketing purposes and are not legal advice."
+  },
+  "titles": {
+    "challenges": {
+      "ar": "التحديات",
+      "en": "Challenges"
+    },
+    "why_us": {
+      "ar": "لماذا نحن",
+      "en": "Why Us"
+    }
+  }
+}

--- a/frontend/src/hooks/useI18n.ts
+++ b/frontend/src/hooks/useI18n.ts
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState } from 'react';
+import content from '@/content/site-content.json';
+
+export type Locale = 'ar' | 'en';
+
+interface I18nContextValue {
+  locale: Locale;
+  dir: 'rtl' | 'ltr';
+  t: (path: string) => any;
+  setLocale: (locale: Locale) => void;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+const resolvePath = (obj: any, path: string[], locale: Locale): any => {
+  if (!obj) return undefined;
+  if (path.length === 0) return obj;
+  const [key, ...rest] = path;
+  let next = obj[key];
+  if (Array.isArray(next)) {
+    next = next.map((item) => {
+      if (item && typeof item === 'object' && ('ar' in item || 'en' in item)) {
+        return item[locale];
+      }
+      return item;
+    });
+  } else if (next && typeof next === 'object' && ('ar' in next || 'en' in next)) {
+    next = next[locale];
+  }
+  return resolvePath(next, rest, locale);
+};
+
+export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [locale, setLocale] = useState<Locale>((content.site.defaultLocale as Locale) || 'ar');
+  const t = (path: string) => resolvePath(content, path.split('.'), locale);
+  const dir = locale === 'ar' ? 'rtl' : 'ltr';
+  return (
+    <I18nContext.Provider value={{ locale, dir, t, setLocale }}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+export const useI18n = () => {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error('useI18n must be used within I18nProvider');
+  return ctx;
+};

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,175 +1,174 @@
 import React from 'react';
-import { ArrowRight, Shield, Users, FileText, BarChart3, Gavel, Globe } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
-import { GlassCard, GlassCardContent, GlassCardDescription, GlassCardHeader, GlassCardTitle } from '@/components/ui/glass-card';
-import { useLanguage } from '@/hooks/useLanguage';
+import { useI18n, I18nProvider } from '@/hooks/useI18n';
+import ContentGuard from '@/utils/contentGuard';
 
-const Landing: React.FC = () => {
-  const { t, isRTL } = useLanguage();
+ContentGuard();
 
-  const features = [
-    {
-      icon: Gavel,
-      title: isRTL ? 'إدارة القضايا' : 'Case Management',
-      description: isRTL ? 'نظام شامل لإدارة ومتابعة جميع القضايا القانونية' : 'Comprehensive system for managing and tracking all legal cases'
-    },
-    {
-      icon: Users,
-      title: isRTL ? 'إدارة العملاء' : 'Client Management', 
-      description: isRTL ? 'متابعة العملاء والوكلاء مع نظام تنبيهات ذكي' : 'Track clients and agents with smart notification system'
-    },
-    {
-      icon: FileText,
-      title: isRTL ? 'الوثائق القانونية' : 'Legal Documents',
-      description: isRTL ? 'تنظيم وأرشفة جميع الوثائق والمستندات القانونية' : 'Organize and archive all legal documents and files'
-    },
-    {
-      icon: BarChart3,
-      title: isRTL ? 'التقارير التحليلية' : 'Analytics Reports',
-      description: isRTL ? 'تقارير مفصلة حول الأداء والإحصائيات' : 'Detailed performance and statistical reports'
-    },
-    {
-      icon: Shield,
-      title: isRTL ? 'الأمان المتقدم' : 'Advanced Security',
-      description: isRTL ? 'حماية البيانات الحساسة بأعلى معايير الأمان' : 'Protect sensitive data with highest security standards'
-    },
-    {
-      icon: Globe,
-      title: isRTL ? 'الوصول السحابي' : 'Cloud Access',
-      description: isRTL ? 'وصول آمن من أي مكان وفي أي وقت' : 'Secure access from anywhere, anytime'
-    }
-  ];
+const LandingContent: React.FC = () => {
+  const { t, dir, locale, setLocale } = useI18n();
+  const navItems: string[] = t('nav') || [];
+  const hero = t('hero');
+  const about = t('about');
+  const services: string[] = t('services');
+  const capabilities: string[] = t('capabilities');
+  const aiLegal = t('ai_legal');
+  const digital = t('digital_transformation');
+  const cyber = t('cybercrime');
+  const challenges: string[] = t('challenges');
+  const whyUs: string[] = t('why_us');
+  const cases = t('case_highlights');
+  const team = t('team');
+  const contact = t('contact');
+  const footer = t('footer');
+  const titleChallenges = t('titles.challenges');
+  const titleWhyUs = t('titles.why_us');
 
   return (
-    <div className="min-h-screen">
-      {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-hero">
-        <div className="absolute inset-0 bg-grid-pattern opacity-10"></div>
-        <div className="container mx-auto px-4 py-20 relative z-10">
-          <div className="max-w-4xl mx-auto text-center text-white">
-            <h1 className="text-5xl md:text-7xl font-bold mb-6 animate-fade-in">
-              {t('landing.hero.title')}
-            </h1>
-            <p className="text-xl md:text-2xl mb-8 text-white/90 animate-fade-in">
-              {t('landing.hero.subtitle')}
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center animate-scale-in">
-              <Button asChild variant="hero" size="lg" className="w-full sm:w-auto">
-                <Link to="/signup">
-                  {t('landing.cta.signup')}
-                  <ArrowRight className={`h-5 w-5 ${isRTL ? 'rotate-180' : ''}`} />
-                </Link>
-              </Button>
-              <Button asChild variant="glass" size="lg" className="w-full sm:w-auto">
-                <Link to="/login">
-                  {t('landing.cta.login')}
-                </Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-        <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-background to-transparent"></div>
-      </section>
+    <div dir={dir} className="font-cairo">
+      <header className="flex justify-between items-center p-4 border-b">
+        <nav className="space-x-4">
+          {navItems.map((item, idx) => (
+            <a key={idx} href={`#section-${idx}`} className="mx-2">
+              {item}
+            </a>
+          ))}
+        </nav>
+        <button
+          onClick={() => setLocale(locale === 'ar' ? 'en' : 'ar')}
+          className="border px-3 py-1 rounded"
+        >
+          {locale === 'ar' ? 'English' : 'العربية'}
+        </button>
+      </header>
 
-      {/* Features Section */}
-      <section className="py-20 bg-background relative">
-        <div className="container mx-auto px-4">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-primary bg-clip-text text-transparent">
-              {isRTL ? 'مميزات النظام' : 'System Features'}
-            </h2>
-            <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              {isRTL ? 'اكتشف كيف يمكن لنظام Avocat تحويل طريقة إدارة مكتبك القانوني' : 'Discover how Avocat can transform your legal office management'}
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <GlassCard
-                key={index}
-                variant="primary"
-                hover="glow"
-                className="group animate-fade-in"
-                style={{ animationDelay: `${index * 0.1}s` }}
-              >
-                <GlassCardHeader>
-                  <div className="h-12 w-12 rounded-lg bg-gradient-primary flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
-                    <feature.icon className="h-6 w-6 text-white" />
-                  </div>
-                  <GlassCardTitle className="text-xl font-semibold">
-                    {feature.title}
-                  </GlassCardTitle>
-                </GlassCardHeader>
-                <GlassCardContent>
-                  <GlassCardDescription className="text-base leading-relaxed">
-                    {feature.description}
-                  </GlassCardDescription>
-                </GlassCardContent>
-              </GlassCard>
-            ))}
-          </div>
+      <section id="hero" className="p-10 text-center">
+        <h1 className="text-3xl font-bold mb-4">{hero.headline}</h1>
+        <p className="mb-4">{hero.subheadline}</p>
+        <div className="space-x-4">
+          <a href="#contact" className="bg-blue-600 text-white px-4 py-2 rounded">
+            {hero.primaryCta}
+          </a>
+          <a href="#about" className="border px-4 py-2 rounded">
+            {hero.secondaryCta}
+          </a>
         </div>
       </section>
 
-      {/* CTA Section */}
-      <section className="py-20 bg-gradient-primary relative overflow-hidden">
-        <div className="absolute inset-0 bg-grid-pattern opacity-20"></div>
-        <div className="container mx-auto px-4 text-center relative z-10">
-          <h2 className="text-4xl md:text-5xl font-bold text-white mb-6">
-            {isRTL ? 'ابدأ رحلتك الرقمية اليوم' : 'Start Your Digital Journey Today'}
-          </h2>
-          <p className="text-xl text-white/90 mb-8 max-w-2xl mx-auto">
-            {isRTL ? 'انضم إلى المئات من المكاتب القانونية التي تثق في نظام Avocat' : 'Join hundreds of law firms that trust Avocat system'}
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <Button asChild variant="glass" size="lg" className="w-full sm:w-auto bg-white/20 hover:bg-white/30 text-white border-white/20">
-              <Link to="/signup">
-                {t('landing.cta.signup')}
-                <ArrowRight className={`h-5 w-5 ${isRTL ? 'rotate-180' : ''}`} />
-              </Link>
-            </Button>
-          </div>
-        </div>
+      <section id="about" className="p-10 bg-gray-50">
+        <h2 className="text-2xl font-semibold mb-4">{navItems[1]}</h2>
+        <p className="mb-2">{about.vision}</p>
+        <p className="mb-2">{about.philosophy}</p>
+        <p className="mb-2">{about.client_commitment}</p>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-card border-t border-border">
-        <div className="container mx-auto px-4 py-12">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-            <div className="md:col-span-2">
-              <h3 className="text-2xl font-bold bg-gradient-primary bg-clip-text text-transparent mb-4">
-                Avocat
-              </h3>
-              <p className="text-muted-foreground mb-4">
-                {isRTL ? 'نظام إدارة المكاتب القانونية الأكثر تطوراً في المنطقة' : 'The most advanced legal office management system in the region'}
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold mb-4">{isRTL ? 'الخدمات' : 'Services'}</h4>
-              <ul className="space-y-2 text-muted-foreground">
-                <li>{isRTL ? 'إدارة القضايا' : 'Case Management'}</li>
-                <li>{isRTL ? 'إدارة العملاء' : 'Client Management'}</li>
-                <li>{isRTL ? 'التقارير' : 'Reports'}</li>
-                <li>{isRTL ? 'الأرشيف' : 'Archive'}</li>
-              </ul>
-            </div>
-            <div>
-              <h4 className="font-semibold mb-4">{isRTL ? 'التواصل' : 'Contact'}</h4>
-              <ul className="space-y-2 text-muted-foreground">
-                <li>info@avocat.com</li>
-                <li>+966 11 123 4567</li>
-                <li>{isRTL ? 'الرياض، المملكة العربية السعودية' : 'Riyadh, Saudi Arabia'}</li>
-              </ul>
-            </div>
-          </div>
-          <div className="border-t border-border mt-8 pt-8 text-center text-muted-foreground">
-            <p>&copy; 2024 Avocat. {isRTL ? 'جميع الحقوق محفوظة' : 'All rights reserved'}.</p>
-          </div>
-        </div>
+      <section id="services" className="p-10">
+        <h2 className="text-2xl font-semibold mb-4">{navItems[2]}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {services.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="capabilities" className="p-10 bg-gray-50">
+        <h2 className="text-2xl font-semibold mb-4">{navItems[3]}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {capabilities.map((c, i) => (
+            <li key={i}>{c}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="ai-legal" className="p-10">
+        <h2 className="text-2xl font-semibold mb-4">{aiLegal.title}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {aiLegal.points.map((p: string, i: number) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="digital" className="p-10 bg-gray-50">
+        <h2 className="text-2xl font-semibold mb-4">{digital.title}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {digital.bullets.map((p: string, i: number) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="cyber" className="p-10">
+        <h2 className="text-2xl font-semibold mb-4">{cyber.title}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {cyber.bullets.map((p: string, i: number) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="challenges" className="p-10 bg-gray-50">
+        <h2 className="text-2xl font-semibold mb-4">{titleChallenges}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {challenges.map((p: string, i: number) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="why-us" className="p-10">
+        <h2 className="text-2xl font-semibold mb-4">{titleWhyUs}</h2>
+        <ul className="list-disc pl-6 space-y-1">
+          {whyUs.map((p: string, i: number) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="cases" className="p-10 bg-gray-50">
+        <h2 className="text-2xl font-semibold mb-4">{navItems[7]}</h2>
+        <ul className="space-y-4">
+          {cases.map((c: any, i: number) => (
+            <li key={i} className="border p-4 rounded">
+              <h3 className="font-bold mb-2">{c.title}</h3>
+              <p>{c.summary}</p>
+            </li>
+          ))}
+        </ul>
+        <p className="text-sm mt-4">{t('legal_disclaimer')}</p>
+      </section>
+
+      <section id="team" className="p-10">
+        <h2 className="text-2xl font-semibold mb-4">{navItems[8]}</h2>
+        <p className="mb-4">{team.intro}</p>
+        <ul className="space-y-4">
+          {team.members.map((m: any, i: number) => (
+            <li key={i} className="border p-4 rounded">
+              <h3 className="font-bold">{m.name}</h3>
+              <p className="text-sm">{m.role}</p>
+              <p className="text-sm">{m.bio}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="contact" className="p-10 bg-gray-50">
+        <h2 className="text-2xl font-semibold mb-4">{navItems[9]}</h2>
+        <p>{contact.address}</p>
+        <p>{contact.phone.join(', ')}</p>
+        <p>{contact.email}</p>
+      </section>
+
+      <footer className="p-4 text-center border-t">
+        {footer}
       </footer>
     </div>
   );
 };
 
-export default Landing;
+const LandingPage: React.FC = () => (
+  <I18nProvider>
+    <LandingContent />
+  </I18nProvider>
+);
+
+export default LandingPage;

--- a/frontend/src/utils/contentGuard.ts
+++ b/frontend/src/utils/contentGuard.ts
@@ -1,0 +1,14 @@
+import content from '@/content/site-content.json';
+
+const requiredKeys = ['hero', 'about', 'services', 'contact'];
+
+export const ContentGuard = () => {
+  for (const key of requiredKeys) {
+    if (!(key in content)) {
+      throw new Error(`Missing required content key: ${key}`);
+    }
+  }
+  return true;
+};
+
+export default ContentGuard;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+import tailwindcssRtl from "tailwindcss-rtl";
 
 export default {
   darkMode: ["class"],
@@ -153,5 +155,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate, tailwindcssRtl],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add bilingual site content JSON and i18n hook
- render marketing landing page from JSON with language toggle
- enable RTL in Tailwind via tailwindcss-rtl

## Testing
- `npm install`
- `npm test`
- `npm run lint` *(fails: Unexpected any and no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f10a7fd48328aa6570a2c289d555