### PR TITLE
fix: enable JSX in useI18n hook

### DIFF
--- a/frontend/src/hooks/useI18n.tsx
+++ b/frontend/src/hooks/useI18n.tsx
@@ -6,25 +6,23 @@ export type Locale = 'ar' | 'en';
 interface I18nContextValue {
   locale: Locale;
   dir: 'rtl' | 'ltr';
-  t: (path: string) => any;
+  t: (path: string) => unknown;
   setLocale: (locale: Locale) => void;
 }
 
 const I18nContext = createContext<I18nContextValue | undefined>(undefined);
 
-const resolvePath = (obj: any, path: string[], locale: Locale): any => {
+const isLocaleObject = (value: unknown): value is Record<Locale, unknown> =>
+  !!value && typeof value === 'object' && ('ar' in value || 'en' in value);
+
+const resolvePath = (obj: unknown, path: string[], locale: Locale): unknown => {
   if (!obj) return undefined;
   if (path.length === 0) return obj;
   const [key, ...rest] = path;
-  let next = obj[key];
+  let next = (obj as Record<string, unknown>)[key];
   if (Array.isArray(next)) {
-    next = next.map((item) => {
-      if (item && typeof item === 'object' && ('ar' in item || 'en' in item)) {
-        return item[locale];
-      }
-      return item;
-    });
-  } else if (next && typeof next === 'object' && ('ar' in next || 'en' in next)) {
+    next = next.map((item) => (isLocaleObject(item) ? item[locale] : item));
+  } else if (isLocaleObject(next)) {
     next = next[locale];
   }
   return resolvePath(next, rest, locale);


### PR DESCRIPTION
## Summary
- rename `useI18n` hook file to `.tsx`
- add type guard and unknown types to eliminate `any`

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and other lint errors across project)*
- `npm run build` *(fails: Cannot find module 'tailwindcss-rtl')*

------
https://chatgpt.com/codex/tasks/task_e_68c497e54fe083289542bcb7e360a29c