### PR TITLE
Improve RTL and theme handling

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -17,8 +17,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export const Header = () => {
-  const { t } = useTranslation(); 
-  const { language, toggleLanguage, direction } = useLanguage();
+  const { t } = useTranslation();
+  const { language, toggleLanguage, isRTL } = useLanguage();
   const { logout } = useAuth();
   const navigate = useNavigate();
 
@@ -32,21 +32,26 @@ export const Header = () => {
         {/* Search */}
         <div className="flex items-center flex-1 max-w-md">
           <div className="relative w-full">
-            <Search className={`absolute top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground ${direction === 'rtl' ? 'right-3' : 'left-3'}`} />
+            <Search
+              className={cn(
+                'absolute top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground',
+                isRTL ? 'right-3' : 'left-3'
+              )}
+            />
             <Input
               placeholder={t('common.search')}
-              className={`glass border-0 ${direction === 'rtl' ? 'pr-10' : 'pl-10'}`}
+              className={cn('glass border-0', isRTL ? 'pr-10' : 'pl-10')}
             />
           </div>
         </div>
 
         {/* Right Side Controls */}
         <div className="flex items-center gap-2">
-                    {/* Notifications */}
+          {/* Notifications */}
           <Button
             variant="ghost"
             size="sm"
-            className="glass-button relative"
+            className="glass-button relative hover:shadow-glow transition-colors"
           >
             <Bell className="h-4 w-4" />
             <span className="absolute -top-1 -right-1 h-3 w-3 bg-destructive rounded-full animate-pulse" />
@@ -56,7 +61,7 @@ export const Header = () => {
             variant="ghost"
             size="sm"
             onClick={toggleLanguage}
-            className="glass-button"
+            className="glass-button hover:shadow-glow transition-colors"
           >
             <Globe className="h-4 w-4" />
             <span className="ml-2 font-medium">
@@ -79,10 +84,10 @@ export const Header = () => {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="glass-card border-white/20">
               <DropdownMenuItem>
-                {t('settings.profile')}
+                {t('common.profile')}
               </DropdownMenuItem>
               <DropdownMenuItem>
-                {t('settings.title')}
+                {t('common.settings')}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -92,7 +97,7 @@ export const Header = () => {
                   navigate('/login');
                 }}
               >
-                {t('auth.logout')}
+                {t('common.logout')}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,19 +1,20 @@
 import { ReactNode } from 'react';
 import { Outlet } from 'react-router-dom';
 import Sidebar from '@/components/sidebar/Sidebar';
- 
+
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Header } from './Header';
+import { cn } from '@/lib/utils';
 
 interface AppShellProps {
   children?: ReactNode; // optional, can also render <Outlet />
 }
 
 const AppShell = ({ children }: AppShellProps) => {
-  const { direction } = useLanguage();  // Use language context to check for RTL
- 
+  const { isRTL, direction } = useLanguage();
+
   return (
-    <div className="flex min-h-screen w-full" dir={direction}>
+    <div className={cn('flex min-h-screen w-full', isRTL ? 'flex-row-reverse' : '')} dir={direction}>
       {/* Sidebar */}
       <Sidebar />
 

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -10,6 +10,8 @@ const Sidebar = () => {
   const { t, i18n } = useTranslation()
   const [collapsed, setCollapsed] = useState(false)
 
+  const dir = i18n.dir()
+
   const toggleSidebar = () => setCollapsed((c) => !c)
 
   return (
@@ -18,18 +20,24 @@ const Sidebar = () => {
         'h-full bg-sidebar text-sidebar-foreground transition-all duration-300',
         collapsed ? 'w-20' : 'w-64'
       )}
-      dir={i18n.dir()}
+      dir={dir}
     >
       {/* Logo Section */}
-      <div className="p-4 flex items-center justify-between">
+      <div className={cn('p-4 flex items-center justify-between', dir === 'rtl' ? 'flex-row-reverse' : '')}>
 
 
         {/* Sidebar Collapse Toggle */}
         <button
           onClick={toggleSidebar}
-          className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-accent text-sidebar-foreground hover:bg-sidebar-primary hover:text-sidebar-primary-foreground transition-colors"
+          className="flex items-center justify-center h-6 w-6 rounded-full bg-sidebar-accent text-sidebar-foreground hover:bg-sidebar-primary hover:text-sidebar-primary-foreground transition-all duration-300 hover:shadow-glow"
         >
-          {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+          {collapsed
+            ? dir === 'rtl'
+              ? <ChevronLeft size={14} />
+              : <ChevronRight size={14} />
+            : dir === 'rtl'
+              ? <ChevronRight size={14} />
+              : <ChevronLeft size={14} />}
         </button>
                 <div className={cn('flex items-center gap-2')}>
           {collapsed ? (

--- a/frontend/src/components/ui/theme-toggle.tsx
+++ b/frontend/src/components/ui/theme-toggle.tsx
@@ -14,6 +14,7 @@ export const ThemeToggle: React.FC = () => {
       size="sm"
       onClick={toggleTheme}
       aria-label={t('header.toggle_theme')}
+      className="glass-button hover:shadow-glow transition-colors"
     >
       {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
     </Button>

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -5,6 +5,7 @@ interface LanguageContextType {
   language: 'en' | 'ar';
   toggleLanguage: () => void;
   isRTL: boolean;
+  direction: 'ltr' | 'rtl';
 }
 
 const LanguageContext = createContext<LanguageContextType | null>(null);
@@ -46,12 +47,14 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }, [i18n]);
 
   const isRTL = language === 'ar';
+  const direction = isRTL ? 'rtl' : 'ltr';
 
   return (
     <LanguageContext.Provider value={{
       language,
       toggleLanguage,
-      isRTL
+      isRTL,
+      direction,
     }}>
       {children}
     </LanguageContext.Provider>

--- a/frontend/src/hooks/useI18n.tsx
+++ b/frontend/src/hooks/useI18n.tsx
@@ -4,28 +4,32 @@ import content from '@/content/site-content.json';
 
 export type Locale = 'ar' | 'en';
 
-type TFunc = <T = string>(path: string) => T;
-
 interface I18nContextValue {
   locale: Locale;
   dir: 'rtl' | 'ltr';
-  t: TFunc;                          // ← مفيش unknown بعد كده
+  t: <T = string>(path: string) => T;
   setLocale: (locale: Locale) => void;
-  getRaw: <T = unknown>(path: string) => T; // لو عايز ترجع الأصل بدون تعريب
+  getRaw: <T = unknown>(path: string) => T;
 }
 
 const I18nContext = createContext<I18nContextValue | undefined>(undefined);
 
 // helpers
-const getByPath = (obj: any, path: string[]) =>
-  path.reduce((acc, k) => (acc ? acc[k] : undefined), obj);
+const getByPath = (obj: unknown, path: string[]): unknown =>
+  path.reduce<unknown>((acc, k) => {
+    if (acc && typeof acc === 'object') {
+      return (acc as Record<string, unknown>)[k];
+    }
+    return undefined;
+  }, obj);
 
-const localize = (value: any, locale: Locale): any => {
+const localize = (value: unknown, locale: Locale): unknown => {
   if (Array.isArray(value)) return value.map((v) => localize(v, locale));
   if (value && typeof value === 'object') {
-    if ('ar' in value || 'en' in value) return localize(value[locale], locale);
-    const out: any = {};
-    for (const [k, v] of Object.entries(value)) out[k] = localize(v as any, locale);
+    const record = value as Record<string, unknown>;
+    if ('ar' in record || 'en' in record) return localize(record[locale], locale);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(record)) out[k] = localize(v, locale);
     return out;
   }
   return value;
@@ -34,7 +38,7 @@ const localize = (value: any, locale: Locale): any => {
 const pickInitialLocale = (): Locale => {
   const saved = (typeof window !== 'undefined' && localStorage.getItem('locale')) as Locale | null;
   if (saved === 'ar' || saved === 'en') return saved;
-  const fromContent = (content as any)?.site?.defaultLocale as Locale | undefined;
+  const fromContent = (content as { site?: { defaultLocale?: Locale } }).site?.defaultLocale;
   if (fromContent === 'ar' || fromContent === 'en') return fromContent;
   return 'ar';
 };
@@ -49,9 +53,9 @@ export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children
     localStorage.setItem('locale', locale);
   }, [dir, locale]);
 
-  const t: TFunc = (path) => {
+  const t = <T = string>(path: string): T => {
     const raw = getByPath(content, path.split('.'));
-    return localize(raw, locale) as any;
+    return localize(raw, locale) as T;
   };
 
   const getRaw = <T,>(path: string): T => getByPath(content, path.split('.')) as T;

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -53,7 +53,9 @@
       "remember": "تذكرني",
       "submit": "تسجيل الدخول",
       "success": "تم تسجيل الدخول بنجاح!",
-      "error": "بيانات الاعتماد غير صحيحة. حاول مرة أخرى."
+      "error": "بيانات الاعتماد غير صحيحة. حاول مرة أخرى.",
+      "email_placeholder": "example@domain.com",
+      "password_placeholder": "••••••••"
     }
   },
   "sidebar": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -53,7 +53,9 @@
       "remember": "Remember me",
       "submit": "Login",
       "success": "Successfully logged in!",
-      "error": "Invalid credentials. Please try again."
+      "error": "Invalid credentials. Please try again.",
+      "email_placeholder": "example@domain.com",
+      "password_placeholder": "••••••••"
     }
   },
   "sidebar": {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,6 +37,10 @@
     --destructive-foreground: 0 0% 100%;
     --success: 175 100% 35%;
     --success-foreground: 0 0% 100%;
+    --info: 200 100% 50%;
+    --info-foreground: 0 0% 100%;
+    --warning: 40 100% 50%;
+    --warning-foreground: 0 0% 0%;
 
     /* UI Elements */
     --border: 200 16% 62%;
@@ -100,6 +104,10 @@
 
     --destructive: 331 100% 50%;
     --destructive-foreground: 0 0% 100%;
+    --info: 200 100% 50%;
+    --info-foreground: 0 0% 100%;
+    --warning: 40 100% 50%;
+    --warning-foreground: 0 0% 0%;
 
     --border: 200 16% 62%;
     --input: 200 16% 62%;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -14,6 +14,7 @@ import { Eye, EyeOff, ArrowRight, AlertCircle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import authBackground from '@/assets/auth-background.jpg';
 import BrandLogo from '@/components/common/BrandLogo';
+import { cn } from '@/lib/utils';
 
 type FormErrors = Partial<{ email: string; password: string }>;
 const emailRegex = /\S+@\S+\.\S+/;
@@ -104,9 +105,9 @@ const LoginPage: React.FC = () => {
 
       const nextUrl = searchParams.get('next') || '/dashboard';
       navigate(nextUrl, { replace: true });
-    } catch (err: any) {
+    } catch (err: unknown) {
       const message =
-        err?.message ||
+        (err as { message?: string })?.message ||
         t('auth.errors.invalid_credentials') ||
         t('auth.login.error') ||
         'Something went wrong.';
@@ -119,7 +120,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex">
+    <div className={cn('min-h-screen flex', isRTL ? 'flex-row-reverse' : '')} dir={isRTL ? 'rtl' : 'ltr'}>
       {/* Background Image Section */}
       <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden">
         <div 
@@ -168,7 +169,7 @@ const LoginPage: React.FC = () => {
                     ref={firstInvalidRef}
                     onChange={(e) => setField('email', e.target.value)}
                     className={errors.email ? 'border-destructive' : ''}
-                    placeholder="example@domain.com"
+                    placeholder={t('auth.login.email_placeholder')}
                     inputMode="email"
                     autoComplete="email"
                     aria-invalid={!!errors.email}
@@ -196,7 +197,7 @@ const LoginPage: React.FC = () => {
                       value={formData.password}
                       onChange={(e) => setField('password', e.target.value)}
                       className={errors.password ? 'border-destructive pr-10' : 'pr-10'}
-                      placeholder="••••••••"
+                      placeholder={t('auth.login.password_placeholder')}
                       autoComplete="current-password"
                       aria-invalid={!!errors.password}
                       aria-describedby={errors.password ? 'password-error' : undefined}

--- a/frontend/src/services/__tests__/apiClient.test.ts
+++ b/frontend/src/services/__tests__/apiClient.test.ts
@@ -6,8 +6,9 @@ vi.mock('axios');
 
 describe('apiClient', () => {
   it('initializes with credentials and base URL', async () => {
-    const create = vi.fn().mockReturnValue({});
-    (axios as any).create = create;
+    const create = vi
+      .spyOn(axios, 'create')
+      .mockReturnValue({} as ReturnType<typeof axios.create>);
 
     await import('../apiClient');
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,9 +77,8 @@ export interface Service {
   [key: string]: unknown; // Index signature for GlobalTable compatibility
 }
 
-export interface LegalService extends Service {
-  // Alias for backward compatibility
-}
+// Alias for backward compatibility
+export type LegalService = Service;
 
 export interface Session {
   id: string;
@@ -99,9 +98,8 @@ export interface Session {
   [key: string]: unknown; // Index signature for GlobalTable compatibility
 }
 
-export interface LegalSession extends Session {
-  // Alias for backward compatibility
-}
+// Alias for backward compatibility
+export type LegalSession = Session;
 
 export interface Court {
   id: string;

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -7,7 +7,13 @@ export interface ApiError {
   fields?: Record<string, string[]>;
 }
 
-export const handleApiError = (error: AxiosError): ApiError => {
+interface ErrorData {
+  message?: string;
+  errors?: Record<string, string[]>;
+  [key: string]: unknown;
+}
+
+export const handleApiError = (error: AxiosError<ErrorData>): ApiError => {
   // Network error
   if (!error.response) {
     return {
@@ -23,10 +29,10 @@ export const handleApiError = (error: AxiosError): ApiError => {
   switch (status) {
     case 400:
       return {
-        message: (data as any)?.message || 'Bad request. Please check your input.',
+        message: data?.message || 'Bad request. Please check your input.',
         status,
         code: 'BAD_REQUEST',
-        fields: (data as any)?.errors
+        fields: data?.errors
       };
 
     case 401:
@@ -55,7 +61,7 @@ export const handleApiError = (error: AxiosError): ApiError => {
         message: 'Validation failed. Please check your input.',
         status,
         code: 'VALIDATION_ERROR',
-        fields: (data as any)?.errors
+        fields: data?.errors
       };
 
     case 429:
@@ -74,13 +80,18 @@ export const handleApiError = (error: AxiosError): ApiError => {
 
     default:
       return {
-        message: (data as any)?.message || 'An unexpected error occurred.',
+        message: data?.message || 'An unexpected error occurred.',
         status,
         code: 'UNKNOWN_ERROR'
       };
   }
 };
 
-export const isApiError = (error: any): error is ApiError => {
-  return error && typeof error.message === 'string';
+export const isApiError = (error: unknown): error is ApiError => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  );
 };

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -54,14 +54,22 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				success: {
-					DEFAULT: 'hsl(var(--success))',
-					foreground: 'hsl(var(--success-foreground))'
-				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
+                                success: {
+                                        DEFAULT: 'hsl(var(--success))',
+                                        foreground: 'hsl(var(--success-foreground))'
+                                },
+                                info: {
+                                        DEFAULT: 'hsl(var(--info))',
+                                        foreground: 'hsl(var(--info-foreground))'
+                                },
+                                warning: {
+                                        DEFAULT: 'hsl(var(--warning))',
+                                        foreground: 'hsl(var(--warning-foreground))'
+                                },
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
 					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
 					accent: 'hsl(var(--sidebar-accent))',
 					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -2,10 +2,8 @@
 import '@testing-library/jest-dom';
 
 // Add custom matchers to expect
-declare global {
-  namespace Vi {
-    interface JestAssertion<T = any> extends jest.Matchers<void, T> {
-      toBeInTheDocument(): T;
-    }
+declare module 'vitest' {
+  interface JestAssertion<T = unknown> extends jest.Matchers<void, T> {
+    toBeInTheDocument(): T;
   }
 }


### PR DESCRIPTION
## Summary
- add direction awareness to language context and layout
- refine header/sidebar for RTL with neon hover effects
- extend theme colors and login form translations
- tighten typing in i18n utilities, error handler, and tests

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any etc. in forms and slices)*


------
https://chatgpt.com/codex/tasks/task_e_68c59abe91d88328ad3d4debb2e36f21