### PR TITLE
feat: add auth context hook and update imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,13 +8,14 @@ import { Toaster as Sonner } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { store } from './app/store';
 import AppRouter from './app/router';
-import { useAuthInit } from './auth/hooks';
+import { useAuthInit } from '@/auth/hooks';
 import { LoadingSpinner } from './components/common/LoadingSpinner';
 import { ErrorBoundary } from './components/common/ErrorBoundary';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 import { ThemeProvider } from './contexts';
 import { LanguageProvider } from './contexts/LanguageContext';
+import { AuthProvider } from './contexts/AuthContext';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -49,15 +50,17 @@ const App = () => (
       <ThemeProvider>
         <ErrorBoundary>
           <Provider store={store}>
-            <QueryClientProvider client={queryClient}>
-              <TooltipProvider>
-                <BrowserRouter>
-                  <AppInitializer />
-                </BrowserRouter>
-                <Toaster />
-                <Sonner />
-              </TooltipProvider>
-            </QueryClientProvider>
+            <AuthProvider>
+              <QueryClientProvider client={queryClient}>
+                <TooltipProvider>
+                  <BrowserRouter>
+                    <AppInitializer />
+                  </BrowserRouter>
+                  <Toaster />
+                  <Sonner />
+                </TooltipProvider>
+              </QueryClientProvider>
+            </AuthProvider>
           </Provider>
         </ErrorBoundary>
       </ThemeProvider>

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useAuth, useRole } from './hooks';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRole } from './hooks';
 import BrandedLoader from '@/components/common/BrandedLoader';
 
 export const ProtectedRoute: React.FC = () => {

--- a/frontend/src/auth/hooks.ts
+++ b/frontend/src/auth/hooks.ts
@@ -21,7 +21,7 @@ import {
 /**
  * Main auth hook for managing authentication state
  */
-export const useAuth = () => {
+export const useAuthState = () => {
   const dispatch = useDispatch<AppDispatch>();
   const auth = useSelector((state: RootState) => state.auth);
 
@@ -73,7 +73,7 @@ export const useAuth = () => {
  * Automatically redirects to login if not authenticated
  */
 export const useRequireAuth = (redirectTo = '/login') => {
-  const auth = useAuth();
+  const auth = useAuthState();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -91,7 +91,7 @@ export const useRequireAuth = (redirectTo = '/login') => {
  * Hook for role-based access control
  */
 export const useRole = () => {
-  const { user } = useAuth();
+  const { user } = useAuthState();
 
   const hasRole = (requiredRole: string | string[]) => {
     if (!user) return false;
@@ -124,7 +124,7 @@ export const useRole = () => {
  * Should be called in the app root to verify auth status on load
  */
 export const useAuthInit = () => {
-  const { checkAuth, isInitialized } = useAuth();
+  const { checkAuth, isInitialized } = useAuthState();
   const dispatch = useDispatch<AppDispatch>();
   const location = useLocation();
   const publicPaths = ['/', '/login', '/register', '/forgot-password', '/reset-password'];

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { Moon, Sun, Globe, User, Bell, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
-import { useAuth } from '@/auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils'; 
 import { useNavigate } from 'react-router-dom';

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext } from 'react';
+import { useAuthState } from '@/auth/hooks';
+
+// Context type is derived from the auth hook return type
+export type AuthContextType = ReturnType<typeof useAuthState>;
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const auth = useAuthState();
+  return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { useAuth } from '@/auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
-import { useAuth } from '@/auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 
 const schema = z
   .object({

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useAuth } from '@/auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 import LanguageSwitcher from '../../components/LanguageSwitcher';
 import { LoadingSpinner } from '../../components/common/LoadingSpinner';
 import { Button } from '../../components/ui/button';

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { useAuth } from '@/auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 import LanguageSwitcher from '../../components/LanguageSwitcher';
 import { LoadingSpinner } from '../../components/common/LoadingSpinner';
 import { Button } from '../../components/ui/button';

--- a/frontend/src/routes/ProtectedRoute.tsx
+++ b/frontend/src/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 
 interface ProtectedRouteProps {

--- a/frontend/src/routes/PublicRoute.tsx
+++ b/frontend/src/routes/PublicRoute.tsx
@@ -1,5 +1,5 @@
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../auth/hooks';
+import { useAuth } from '@/contexts/AuthContext';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
 import React from 'react';
 

--- a/frontend/src/routes/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/routes/__tests__/ProtectedRoute.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react'
 import { ProtectedRoute } from '../ProtectedRoute'
 
 const mockUseAuth = vi.fn()
-vi.mock('../../auth/hooks', () => ({
+vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => mockUseAuth()
 }))
 


### PR DESCRIPTION
## Summary
- add AuthContext with provider and consumer hook
- wrap app in AuthProvider and expose `useAuth`
- update auth hooks and components to use new context path

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in notifications/slice.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bcb362348328affbac269f756470