### PR TITLE
feat(frontend): expand mobile sidebar

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -22,8 +22,10 @@ const AppShell: React.FC<AppShellProps> = ({ children, title }) => {
     >
       {/* Desktop Layout */}
       <div className="flex h-screen">
-        {/* Sidebar */}
-        <Sidebar isCollapsed={false} onToggle={() => {}} />
+        {/* Sidebar - hidden on small screens */}
+        <div className="hidden md:block">
+          <Sidebar isCollapsed={false} onToggle={() => {}} />
+        </div>
 
         {/* Main Content */}
         <div className="flex-1 flex flex-col min-w-0">

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -90,12 +90,12 @@ const MobileDrawer: React.FC = () => {
               damping: 25,
               stiffness: 200 
             }}
-            className={cn(
-              'fixed top-0 z-50 h-full w-80 max-w-[85vw] bg-sidebar-background border-border md:hidden',
-              'flex flex-col shadow-lg',
-              isRTL ? 'right-0 border-l' : 'left-0 border-r'
-            )}
-          >
+              className={cn(
+                'fixed top-0 z-50 h-full w-full bg-sidebar-background border-border md:hidden overflow-y-auto',
+                'flex flex-col shadow-lg',
+                isRTL ? 'right-0 border-l' : 'left-0 border-r'
+              )}
+            >
             {/* Header */}
             <div className="flex items-center justify-between p-4 border-b border-sidebar-border">
               <BrandLogo variant="full" className="h-8" />


### PR DESCRIPTION
## Summary
- Hide desktop sidebar on small screens
- Make mobile drawer fill the screen for a full-page experience

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c772e47e048328bc27252f0310329c