### PR TITLE
Revamp dashboard theming gradients

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Moon, Sun, Globe, ChevronDown, User, LogOut, Menu, Bell } from 'lucide-react';
+import { Moon, Sun, ChevronDown, User, LogOut, Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -23,17 +23,20 @@ interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ title, className }) => {
   const { theme, toggleTheme } = useTheme();
-const { language, toggleLanguage, t, isRTL } = useLanguage();
- 
-const isArabic = language === 'ar';
+  const { language, toggleLanguage, t, isRTL } = useLanguage();
   const { user, logout } = useAuth();
   const { toggleMobile } = useSidebar();
 
+  const headerSurface = { '--glass-surface': 'var(--gradient-header)' } as React.CSSProperties;
+
   return (
-    <header className={cn(
-      'sticky top-0 z-50 h-16 border-b border-border bg-background/80 backdrop-blur',
-      className
-    )}>
+    <header
+      className={cn(
+        'sticky top-0 z-50 h-16 glass border-b border-border/60 text-white shadow-elegant',
+        className
+      )}
+      style={headerSurface}
+    >
       <div className="flex h-full items-center justify-between px-4 gap-4">
         {/* Left side */}
         <div className={cn(
@@ -45,7 +48,7 @@ const isArabic = language === 'ar';
             variant="ghost"
             size="icon"
             onClick={toggleMobile}
-            className="md:hidden h-9 w-9"
+            className="md:hidden h-9 w-9 text-white hover:bg-white/15 hover:text-white focus-visible:ring-white/60 focus-visible:ring-offset-0"
             aria-label={t('common.menu')}
           >
             <Menu className="h-4 w-4" />
@@ -53,14 +56,12 @@ const isArabic = language === 'ar';
 
           {/* Desktop logo - hidden on mobile */}
           <div className="hidden md:block">
- 
-<BrandLogo variant="full" className="h-8" lang={language} />
-
+            <BrandLogo variant="full" className="h-8" lang={language} />
           </div>
 
           {/* Page title */}
           {title && (
-            <h1 className="hidden sm:block text-lg font-semibold text-foreground">
+            <h1 className="hidden sm:block text-lg font-semibold text-white/90">
               {title}
             </h1>
           )}
@@ -73,7 +74,7 @@ const isArabic = language === 'ar';
             variant="ghost"
             size="icon"
             onClick={toggleTheme}
-            className="rounded-full hover:bg-accent/20 glow-hover"
+            className="rounded-full text-white hover:bg-white/15 hover:text-white focus-visible:ring-white/60 focus-visible:ring-offset-0 glow-hover"
           >
             {theme === 'light' ? (
               <Moon className="h-5 w-5" />
@@ -82,21 +83,24 @@ const isArabic = language === 'ar';
             )}
           </Button>
 
-   <Button
-  variant="ghost"
-  size="icon"
-  onClick={toggleLanguage}
-  className="rounded-full hover:bg-accent/20 glow-hover"
-  aria-label="Toggle Language"
->
-  {language === 'ar' ? 'EN' : 'ع'}
-</Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleLanguage}
+            className="rounded-full text-white hover:bg-white/15 hover:text-white focus-visible:ring-white/60 focus-visible:ring-offset-0 glow-hover"
+            aria-label="Toggle Language"
+          >
+            {language === 'ar' ? 'EN' : 'ع'}
+          </Button>
 
           {/* User Menu */}
           {user && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="flex items-center space-x-2 rtl:space-x-reverse rounded-full hover:bg-accent/20 glow-hover">
+                <Button
+                  variant="ghost"
+                  className="flex items-center space-x-2 rtl:space-x-reverse rounded-full text-white hover:bg-white/15 hover:text-white focus-visible:ring-white/60 focus-visible:ring-offset-0 glow-hover"
+                >
                   <Avatar className="h-8 w-8">
                     <AvatarImage src={user.avatar} alt={user.name} />
                     <AvatarFallback className="bg-gradient-primary text-white">

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -91,10 +91,11 @@ const MobileDrawer: React.FC = () => {
               stiffness: 200 
             }}
             className={cn(
-              'fixed top-0 z-50 h-full w-80 max-w-[85vw] bg-sidebar-background border-border md:hidden',
-              'flex flex-col shadow-lg',
+              'fixed top-0 z-50 h-full w-80 max-w-[85vw] glass border border-sidebar-border text-sidebar-foreground md:hidden',
+              'flex flex-col shadow-elegant',
               isRTL ? 'right-0 border-l' : 'left-0 border-r'
             )}
+            style={{ '--glass-surface': 'var(--gradient-sidebar)' } as React.CSSProperties}
           >
             {/* Header */}
             <div className="flex items-center justify-between p-4 border-b border-sidebar-border">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -224,7 +224,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
       {/* Sidebar */}
       <aside
         className={cn(
-          "bg-[var(--gradient-sidebar)] fixed top-0 z-50 h-full glass border-r border-sidebar-border transition-all duration-300",
+          "fixed top-0 z-50 h-full glass border-r border-sidebar-border text-sidebar-foreground transition-all duration-300",
           "lg:relative lg:translate-x-0",
           // Positioning based on RTL/LTR
           isRTL ? "right-0" : "left-0",
@@ -237,8 +237,9 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
           !isMobile && "translate-x-0"
         )}
         style={{
-          direction: isRTL ? 'rtl' : 'ltr'
-        }}
+          direction: isRTL ? 'rtl' : 'ltr',
+          '--glass-surface': 'var(--gradient-sidebar)'
+        } as React.CSSProperties}
       >
         <div className="flex h-full flex-col">
           {/* Header */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,120 +3,159 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@layer base {
-    :root {
-  /* الخلفية والنص */
-  --background: 210 20% 95%;     /* رمادي فاتح دافئ */
-  --foreground: 210 30% 10%;     /* أسود غامق */
-
-  /* العناصر الثانوية */
-  --muted: 210 15% 85%;
-  --muted-foreground: 210 15% 45%;
-  --primary: 210 70% 30%; /* أزرق داكن */
-  --accent: 320 70% 60%;  /* وردي زاهي */
-  --background: 210 20% 95%; /* خلفية فاتحة */
-  --foreground: 210 30% 10%; /* نص داكن */
-
-  /* إضافات */
-  --hover-bg: rgba(0, 0, 0, 0.1); /* تأثير hover */ 
-  --accent-foreground: 0 0% 100%;
-  --secondary: 160 40% 50%;      /* أخضر متوسط */
-  --secondary-foreground: 0 0% 100%;
-
-  /* الحالات */
-  --success: 140 70% 50%;          /* أخضر مفعم بالحياة */
-  --success-foreground: 0 0% 100%;
-  --warning: 45 90% 60%;           /* ذهبي دافئ */
-  --warning-foreground: 35 40% 15%;
-  --destructive: 0 70% 50%;        /* أحمر مفعم بالحيوية */
-  --destructive-foreground: 0 0% 100%;
-
-  /* الحواف والزينة */
-  --border: 210 20% 80%;
-  --input: 210 20% 80%;
-  --ring: 210 80% 50%;
-  --card: 210 15% 98%;
-  --popover: 210 20% 95%;
- 
-  --gradient-sidebar: linear-gradient(135deg, #FFEB3B, #FFC107); /* تدرج أصفر دافئ */
-  --gradient-header: linear-gradient(135deg, #4CAF50, #8BC34A); /* تدرج أخضر فاتح */
-  --gradient-card: linear-gradient(135deg, #FF5722, #FF9800); /* تدرج برتقالي زاهي */
- 
-  /* Sidebar */
-  --sidebar: 210 15% 90%;
-  --sidebar-foreground: 210 25% 15%;
-  --sidebar-accent: 210 30% 70%;
-  --sidebar-accent-foreground: 210 25% 15%;
-  --sidebar-primary: 210 70% 30%;
-  --sidebar-primary-foreground: 0 0% 100%;
-
-  /* Glass Morphism */
-  --glass-bg: 210 15% 100% / 0.9;
-  --glass-border: 210 20% 90% / 0.3;
-}
-
-.dark {
-  /* الخلفية والنص */
-  --background: 210 30% 10%;      /* أسود دافئ */
-  --foreground: 210 20% 90%;     /* أبيض متوهج */
-
-  /* العناصر الثانوية */
-  --muted: 210 20% 25%;
-  --muted-foreground: 210 10% 70%;
-
-  /* الألوان الأساسية */
-  --primary: 210 80% 50%;        /* أزرق زاهي */
-  --primary-foreground: 0 0% 100%;
-  --accent: 320 80% 70%;         /* وردي مشرق */
-  --accent-foreground: 0 0% 100%;
-  --secondary: 160 50% 60%;      /* أخضر زاهي */
-  --secondary-foreground: 0 0% 100%;
-
-  /* الحالات */
-  --success: 140 70% 60%;          /* أخضر مشرق */
-  --success-foreground: 0 0% 100%;
-  --warning: 45 90% 70%;           /* ذهبي أكثر إشراقاً */
-  --warning-foreground: 45 20% 10%;
-  --destructive: 0 80% 60%;        /* أحمر مشرق */
-  --destructive-foreground: 0 0% 100%;
-
-  /* الحواف والزينة */
-  --border: 210 30% 20%;
-  --input: 210 30% 20%;
-  --ring: 210 80% 65%;
-  --card: 210 25% 15%;
-  --popover: 210 30% 20%;
-
-  /* Sidebar */
-  --sidebar: 210 30% 15%;
-  --sidebar-foreground: 210 20% 90%;
-  --sidebar-accent: 210 30% 30%;
-  --sidebar-accent-foreground: 210 20% 90%;
-  --sidebar-primary: 210 80% 50%;
-  --sidebar-primary-foreground: 0 0% 100%;
-.dark {
-  --gradient-sidebar: linear-gradient(135deg, #1E1E2F, #3A3A4A); /* تدرج داكن */
-  --gradient-header: linear-gradient(135deg, #9C27B0, #E91E63); /* تدرج بنفسجي مع لمسة وردية */
-  --gradient-card: linear-gradient(135deg, #3F51B5, #2196F3); /* تدرج أزرق متألق */
-}
-  /* Glass Morphism */
-  --glass-bg: 210 30% 20% / 0.7;
-  --glass-border: 210 30% 25% / 0.3;
-}
-
-/* التدرجات (موحدة) */
-:root, .dark {
-  
-  --gradient-hero: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--accent)));
-  --gradient-primary: linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)));
-  --gradient-success: linear-gradient(90deg, hsl(var(--success)), hsl(140 70% 40%));
-  --gradient-warning: linear-gradient(90deg, hsl(var(--warning)), hsl(45 90% 50%));
-  --gradient-destructive: linear-gradient(90deg, hsl(var(--destructive)), hsl(0 80% 40%));
-}
-}
-
 
 @layer base {
+  :root {
+    /* Base surfaces */
+    --background: 210 20% 96%;
+    --foreground: 214 32% 12%;
+
+    --muted: 210 15% 88%;
+    --muted-foreground: 214 18% 40%;
+
+    --card: 210 22% 98%;
+    --card-foreground: 214 32% 12%;
+
+    --popover: 210 20% 98%;
+    --popover-foreground: 214 32% 12%;
+
+    /* Brand palette */
+    --primary: 210 70% 35%;
+    --primary-foreground: 0 0% 100%;
+    --primary-hover: 210 70% 30%;
+
+    --accent: 320 70% 60%;
+    --accent-foreground: 0 0% 100%;
+    --accent-glow: 320 70% 60% / 0.35;
+
+    --secondary: 160 45% 48%;
+    --secondary-foreground: 0 0% 100%;
+
+    /* Status palette */
+    --success: 140 65% 45%;
+    --success-foreground: 0 0% 100%;
+    --warning: 45 90% 56%;
+    --warning-foreground: 30 50% 18%;
+    --destructive: 0 70% 50%;
+    --destructive-foreground: 0 0% 100%;
+
+    /* Borders & focus */
+    --border: 210 20% 82%;
+    --input: 210 20% 82%;
+    --ring: 210 80% 52%;
+    --hover-bg: hsla(210, 80%, 52%, 0.15);
+
+    /* Sidebar */
+    --sidebar-background: 210 65% 28%;
+    --sidebar-foreground: 210 40% 96%;
+    --sidebar-primary: 210 80% 45%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 210 60% 38%;
+    --sidebar-accent-foreground: 210 45% 96%;
+    --sidebar-border: 210 60% 32%;
+    --sidebar-ring: 210 80% 60%;
+
+    /* Glassmorphism */
+    --glass-bg: 210 30% 100% / 0.85;
+    --glass-border: 210 25% 88% / 0.35;
+
+    /* Shadows & radii */
+    --shadow-glass: 0 24px 48px -28px hsl(210 40% 20% / 0.28);
+    --shadow-glow: 0 0 0 1px hsl(var(--accent) / 0.25), 0 32px 48px -28px hsl(var(--accent) / 0.35);
+    --shadow-elegant: 0 26px 60px -32px hsl(210 40% 20% / 0.25);
+
+    --radius: 0.75rem;
+    --radius-lg: 1rem;
+    --radius-xl: 1.5rem;
+
+    --transition-smooth: all 0.25s ease;
+    --transition-bounce: all 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+
+    /* Gradients */
+    --gradient-sidebar: linear-gradient(160deg, hsla(210, 65%, 28%, 0.95) 0%, hsla(210, 70%, 34%, 0.95) 55%, hsla(320, 70%, 58%, 0.9) 100%);
+    --gradient-header: linear-gradient(135deg, hsla(160, 60%, 44%, 0.92), hsla(210, 80%, 52%, 0.92));
+    --gradient-card: linear-gradient(135deg, hsla(320, 70%, 60%, 0.9), hsla(45, 95%, 60%, 0.9));
+    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(210 80% 46%));
+    --gradient-accent: linear-gradient(135deg, hsl(var(--accent)), hsl(280 75% 60%));
+    --gradient-success: linear-gradient(135deg, hsl(var(--success)), hsl(140 65% 35%));
+    --gradient-warning: linear-gradient(135deg, hsl(var(--warning)), hsl(35 90% 52%));
+    --gradient-destructive: linear-gradient(135deg, hsl(var(--destructive)), hsl(0 80% 45%));
+    --gradient-hero: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--accent)));
+    --gradient-glass: linear-gradient(135deg, hsla(210, 30%, 98%, 0.85), hsla(210, 40%, 90%, 0.65));
+  }
+
+  .dark {
+    /* Base surfaces */
+    --background: 210 30% 10%;
+    --foreground: 210 20% 92%;
+
+    --muted: 210 25% 18%;
+    --muted-foreground: 210 20% 65%;
+
+    --card: 210 28% 14%;
+    --card-foreground: 210 20% 92%;
+
+    --popover: 210 28% 14%;
+    --popover-foreground: 210 20% 92%;
+
+    /* Brand palette */
+    --primary: 210 80% 60%;
+    --primary-foreground: 210 35% 12%;
+    --primary-hover: 210 80% 55%;
+
+    --accent: 320 70% 65%;
+    --accent-foreground: 210 35% 12%;
+    --accent-glow: 320 70% 65% / 0.4;
+
+    --secondary: 160 45% 45%;
+    --secondary-foreground: 210 30% 96%;
+
+    /* Status palette */
+    --success: 145 70% 48%;
+    --success-foreground: 210 30% 10%;
+    --warning: 45 95% 62%;
+    --warning-foreground: 30 55% 18%;
+    --destructive: 0 70% 58%;
+    --destructive-foreground: 210 30% 96%;
+
+    /* Borders & focus */
+    --border: 210 25% 24%;
+    --input: 210 25% 22%;
+    --ring: 210 80% 60%;
+    --hover-bg: hsla(210, 80%, 60%, 0.18);
+
+    /* Sidebar */
+    --sidebar-background: 210 45% 18%;
+    --sidebar-foreground: 210 20% 96%;
+    --sidebar-primary: 210 90% 62%;
+    --sidebar-primary-foreground: 210 35% 12%;
+    --sidebar-accent: 210 55% 26%;
+    --sidebar-accent-foreground: 210 25% 94%;
+    --sidebar-border: 210 50% 24%;
+    --sidebar-ring: 210 80% 68%;
+
+    /* Glassmorphism */
+    --glass-bg: 210 35% 12% / 0.75;
+    --glass-border: 210 30% 18% / 0.5;
+
+    /* Shadows */
+    --shadow-glass: 0 30px 64px -32px hsl(210 70% 8% / 0.6);
+    --shadow-glow: 0 0 0 1px hsl(var(--accent) / 0.4), 0 28px 60px -32px hsl(var(--accent) / 0.45);
+    --shadow-elegant: 0 30px 70px -36px hsl(210 60% 8% / 0.55);
+
+    /* Gradients */
+    --gradient-sidebar: linear-gradient(160deg, hsla(210, 55%, 18%, 0.95) 0%, hsla(210, 60%, 24%, 0.9) 55%, hsla(320, 70%, 48%, 0.88) 100%);
+    --gradient-header: linear-gradient(135deg, hsla(280, 70%, 46%, 0.95), hsla(320, 70%, 55%, 0.9));
+    --gradient-card: linear-gradient(135deg, hsla(210, 70%, 48%, 0.9), hsla(210, 80%, 38%, 0.9));
+    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(210 80% 45%));
+    --gradient-accent: linear-gradient(135deg, hsl(var(--accent)), hsl(280 70% 58%));
+    --gradient-success: linear-gradient(135deg, hsl(var(--success)), hsl(145 70% 38%));
+    --gradient-warning: linear-gradient(135deg, hsl(var(--warning)), hsl(32 90% 50%));
+    --gradient-destructive: linear-gradient(135deg, hsl(var(--destructive)), hsl(0 70% 46%));
+    --gradient-hero: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--accent)));
+    --gradient-glass: linear-gradient(135deg, hsla(210, 35%, 16%, 0.85), hsla(210, 30%, 12%, 0.65));
+  }
+
   * {
     @apply border-border;
   }
@@ -127,26 +166,22 @@
     font-variation-settings: "opsz" 32;
   }
 
-  /* Arabic Typography */
   [lang="ar"], [dir="rtl"] {
     @apply font-cairo;
   }
 
-  /* English Typography */
   [lang="en"], [dir="ltr"] {
     @apply font-inter;
   }
 
-  /* Glass Morphism Base */
   .glass {
-    background: hsl(var(--glass-bg));
+    background: var(--glass-surface, hsl(var(--glass-bg)));
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
     border: 1px solid hsl(var(--glass-border));
     box-shadow: var(--shadow-glass);
   }
 
-  /* Glow Effects */
   .glow {
     box-shadow: var(--shadow-glow);
   }
@@ -156,7 +191,6 @@
     transition: var(--transition-smooth);
   }
 
-  /* Smooth Transitions */
   .smooth {
     transition: var(--transition-smooth);
   }
@@ -165,14 +199,23 @@
     transition: var(--transition-bounce);
   }
 
-  /* Background Patterns */
   .bg-grid-pattern {
     background-image: linear-gradient(rgba(255, 255, 255, 0.1) 1px, transparent 1px),
-                      linear-gradient(90deg, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
+      linear-gradient(90deg, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
     background-size: 20px 20px;
   }
 
-  /* Custom Scrollbar */
+  .hero-gradient {
+    background-image: var(--gradient-hero);
+  }
+
+  .gradient-text {
+    background-image: var(--gradient-primary);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
@@ -192,7 +235,6 @@
     background: hsl(var(--accent) / 0.8);
   }
 
-  /* Dark mode scrollbar */
   .dark ::-webkit-scrollbar-track {
     background: hsl(var(--muted));
   }

--- a/frontend/src/pages/dashboard/StatsCards.tsx
+++ b/frontend/src/pages/dashboard/StatsCards.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Case, Client, Session } from './api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 
 export default function StatsCards() {
   const { t } = useTranslation();
@@ -25,33 +26,38 @@ export default function StatsCards() {
     return <div className="text-center text-red-500 p-4">Failed to load stats</div>;
   }
 
+  const totalCases = casesQuery.data?.length ?? 0;
+  const activeClients = clientsQuery.data?.filter(c => c.status === 'active')?.length ?? 0;
+  const upcomingSessions = sessionsQuery.data?.filter(s => s.status === 'scheduled')?.length ?? 0;
+  const totalRevenue = casesQuery.data?.reduce((sum, c) => sum + c.revenue, 0) ?? 0;
+
   const stats = [
     {
       label: t('dashboard.total_cases'),
-      value: casesQuery.data?.length ?? 0,
+      value: totalCases.toLocaleString(),
       icon: Briefcase,
-      gradient: 'from-blue-500 to-blue-700',
+      background: 'bg-gradient-primary',
       change: 12,
     },
     {
       label: t('dashboard.active_clients'),
-      value: clientsQuery.data?.filter(c => c.status === 'active').length ?? 0,
+      value: activeClients.toLocaleString(),
       icon: Users,
-      gradient: 'from-green-500 to-green-700',
+      background: 'bg-gradient-success',
       change: 5,
     },
     {
       label: t('dashboard.upcoming_sessions'),
-      value: sessionsQuery.data?.filter(s => s.status === 'scheduled').length ?? 0,
+      value: upcomingSessions.toLocaleString(),
       icon: Calendar,
-      gradient: 'from-purple-500 to-purple-700',
+      background: 'bg-gradient-accent',
       change: -2,
     },
     {
       label: t('dashboard.total_revenue'),
-      value: `$${casesQuery.data?.reduce((sum, c) => sum + c.revenue, 0).toLocaleString()}`,
+      value: `$${totalRevenue.toLocaleString()}`,
       icon: DollarSign,
-      gradient: 'from-orange-500 to-orange-700',
+      background: 'bg-gradient-warning',
       change: 8,
     },
   ];
@@ -61,18 +67,35 @@ export default function StatsCards() {
       {stats.map(stat => {
         const Icon = stat.icon;
         const Arrow = stat.change >= 0 ? ArrowUpRight : ArrowDownRight;
-        const changeColor = stat.change >= 0 ? 'text-emerald-300' : 'text-red-300';
+        const isPositive = stat.change >= 0;
+        const changeBadge = isPositive
+          ? 'bg-[color:hsla(var(--success)/0.32)]'
+          : 'bg-[color:hsla(var(--destructive)/0.32)]';
+        const changeText = `${isPositive ? '+' : '−'}${Math.abs(stat.change)}%`;
         return (
-          <Card key={stat.label} className={`text-white border-none shadow-sm bg-gradient-to-br ${stat.gradient}`}>
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium">{stat.label}</CardTitle>
-              <Icon className="h-5 w-5" />
+          <Card
+            key={stat.label}
+            className={cn(
+              'relative overflow-hidden border-none text-white shadow-elegant',
+              stat.background
+            )}
+          >
+            <CardHeader className="flex flex-row items-center justify-between pb-3">
+              <CardTitle className="text-sm font-medium text-white/90">{stat.label}</CardTitle>
+              <div className="rounded-full bg-white/15 p-2 shadow-inner">
+                <Icon className="h-5 w-5" />
+              </div>
             </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{stat.value}</div>
-              <div className={`flex items-center text-xs mt-1 ${changeColor}`}>
-                <Arrow className="h-4 w-4 mr-1" />
-                {Math.abs(stat.change)}%
+            <CardContent className="space-y-3">
+              <div className="text-2xl font-semibold tracking-tight">{stat.value}</div>
+              <div
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm',
+                  changeBadge
+                )}
+              >
+                <Arrow className="h-4 w-4" />
+                <span>{changeText}</span>
               </div>
             </CardContent>
           </Card>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -82,6 +82,13 @@ export default {
         'gradient-primary': 'var(--gradient-primary)',
         'gradient-hero': 'var(--gradient-hero)',
         'gradient-glass': 'var(--gradient-glass)',
+        'gradient-header': 'var(--gradient-header)',
+        'gradient-sidebar': 'var(--gradient-sidebar)',
+        'gradient-card': 'var(--gradient-card)',
+        'gradient-accent': 'var(--gradient-accent)',
+        'gradient-success': 'var(--gradient-success)',
+        'gradient-warning': 'var(--gradient-warning)',
+        'gradient-destructive': 'var(--gradient-destructive)',
       },
       boxShadow: {
         'glow': 'var(--shadow-glow)',


### PR DESCRIPTION
## Summary
- overhaul theme variables to define cohesive HSL palettes, gradients, and glass effects for light and dark modes
- apply the new gradient surfaces to the dashboard header, sidebar, and mobile drawer for a consistent look
- refresh the stats cards with themed gradients, formatted values, and badge styling that matches the new design

## Testing
- npm run lint *(fails: existing @typescript-eslint any/no-empty-object-type errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb273e288328a2e6ce38e90979c5