### PR TITLE
Add TypeScript types for backend tables

### DIFF
--- a/frontend/src/types/appeal_pdfs.ts
+++ b/frontend/src/types/appeal_pdfs.ts
@@ -1,0 +1,8 @@
+export interface AppealPdf {
+  id: number;
+  cassation_rule_id: number;
+  file_name: string;
+  file_path: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/appeal_sub_types.ts
+++ b/frontend/src/types/appeal_sub_types.ts
@@ -1,0 +1,7 @@
+export interface AppealSubType {
+  id: number;
+  appeal_type_id: number;
+  appeal_sub_type: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/appeal_types.ts
+++ b/frontend/src/types/appeal_types.ts
@@ -1,0 +1,6 @@
+export interface AppealType {
+  id: number;
+  appeal_type: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/attorney_types.ts
+++ b/frontend/src/types/attorney_types.ts
@@ -1,0 +1,6 @@
+export interface AttorneyType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/cache.ts
+++ b/frontend/src/types/cache.ts
@@ -1,0 +1,5 @@
+export interface Cache {
+  key: string;
+  value: string;
+  expiration: number;
+}

--- a/frontend/src/types/cache_locks.ts
+++ b/frontend/src/types/cache_locks.ts
@@ -1,0 +1,5 @@
+export interface CacheLock {
+  key: string;
+  owner: string;
+  expiration: number;
+}

--- a/frontend/src/types/case_documents.ts
+++ b/frontend/src/types/case_documents.ts
@@ -1,0 +1,10 @@
+export interface CaseDocument {
+  id: number;
+  leg_case_id: number;
+  client_id?: number;
+  unclient_id?: number;
+  description: string;
+  file_path: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/case_sub_types.ts
+++ b/frontend/src/types/case_sub_types.ts
@@ -1,0 +1,7 @@
+export interface CaseSubType {
+  id: number;
+  name: string;
+  case_type_id: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/case_types.ts
+++ b/frontend/src/types/case_types.ts
@@ -1,0 +1,6 @@
+export interface CaseType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/cassation_judges.ts
+++ b/frontend/src/types/cassation_judges.ts
@@ -1,0 +1,7 @@
+export interface CassationJudge {
+  id: number;
+  cassation_rules_id: number;
+  judge_name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/cassation_rule_subjects.ts
+++ b/frontend/src/types/cassation_rule_subjects.ts
@@ -1,0 +1,6 @@
+export interface CassationRuleSubject {
+  id: number;
+  rule_description: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/cassation_rules.ts
+++ b/frontend/src/types/cassation_rules.ts
@@ -1,0 +1,12 @@
+export interface CassationRule {
+  id: number;
+  appeal_type_id: number;
+  appeal_sub_type_id: number;
+  appeal_number: string;
+  appeal_year: string;
+  session_date: string;
+  cassation_rule_subjects_id: number;
+  legal_summary?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/clients.ts
+++ b/frontend/src/types/clients.ts
@@ -1,0 +1,18 @@
+export interface Client {
+  id: number;
+  slug: string;
+  name: string;
+  email?: string;
+  phone_number?: string;
+  address: string;
+  nationality?: string;
+  work?: string;
+  emergency_number?: string;
+  date_of_birth?: string;
+  gender: 'ذكر' | 'أنثى';
+  religion: 'مسلم' | 'مسيحي';
+  identity_number?: string;
+  status: 'active' | 'inactive';
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/court_levels.ts
+++ b/frontend/src/types/court_levels.ts
@@ -1,0 +1,6 @@
+export interface CourtLevel {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/court_types.ts
+++ b/frontend/src/types/court_types.ts
@@ -1,0 +1,6 @@
+export interface CourtType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/courts.ts
+++ b/frontend/src/types/courts.ts
@@ -1,0 +1,8 @@
+export interface Court {
+  id: number;
+  name: string;
+  court_type_id: number;
+  court_level_id: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/divisions.ts
+++ b/frontend/src/types/divisions.ts
@@ -1,0 +1,7 @@
+export interface Division {
+  id: number;
+  name: string;
+  court_id: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/doc_sub_types.ts
+++ b/frontend/src/types/doc_sub_types.ts
@@ -1,0 +1,7 @@
+export interface DocSubType {
+  id: number;
+  name: string;
+  doc_type_id: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/doc_types.ts
+++ b/frontend/src/types/doc_types.ts
@@ -1,0 +1,6 @@
+export interface DocType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -1,0 +1,9 @@
+export interface Event {
+  id: number;
+  user_id: number;
+  date: string;
+  title?: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/expense_categories.ts
+++ b/frontend/src/types/expense_categories.ts
@@ -1,0 +1,6 @@
+export interface ExpenseCategory {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/expenses.ts
+++ b/frontend/src/types/expenses.ts
@@ -1,0 +1,16 @@
+export interface Expense {
+  id: number;
+  service_id?: number;
+  leg_case_id?: number;
+  created_by?: number;
+  legal_session_id?: number;
+  expense_category_id: number;
+  client_id?: number;
+  unclients_id?: number;
+  description?: string;
+  note?: string;
+  expense_date?: string;
+  amount?: Record<string, any>;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/failed_jobs.ts
+++ b/frontend/src/types/failed_jobs.ts
@@ -1,0 +1,9 @@
+export interface FailedJob {
+  id: number;
+  uuid: string;
+  connection: string;
+  queue: string;
+  payload: string;
+  exception: string;
+  failed_at: string;
+}

--- a/frontend/src/types/invoices.ts
+++ b/frontend/src/types/invoices.ts
@@ -1,0 +1,12 @@
+export interface Invoice {
+  id: number;
+  leg_case_id?: number;
+  service_id?: number;
+  invoice_number: string;
+  status: 'Draft' | 'Sent' | 'Paid' | 'Overdue';
+  issue_date: string;
+  due_date: string;
+  total_amount: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/job_batches.ts
+++ b/frontend/src/types/job_batches.ts
@@ -1,0 +1,12 @@
+export interface JobBatch {
+  id: string;
+  name: string;
+  total_jobs: number;
+  pending_jobs: number;
+  failed_jobs: number;
+  failed_job_ids: string;
+  options?: string;
+  cancelled_at?: number;
+  created_at: number;
+  finished_at?: number;
+}

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -1,0 +1,9 @@
+export interface Job {
+  id: number;
+  queue: string;
+  payload: string;
+  attempts: number;
+  reserved_at?: number;
+  available_at: number;
+  created_at: number;
+}

--- a/frontend/src/types/lawyers.ts
+++ b/frontend/src/types/lawyers.ts
@@ -1,0 +1,16 @@
+export interface Lawyer {
+  id: number;
+  name: string;
+  birthdate: string;
+  identity_number: string;
+  law_reg_num: string;
+  lawyer_class: 'نقض' | 'إستئناف' | 'إبتدائي' | 'جدول عام';
+  email: string;
+  phone_number?: string;
+  gender: 'ذكر' | 'أنثى';
+  address?: string;
+  religion: 'مسلم' | 'مسيحى';
+  user_id?: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/leg_case_client.ts
+++ b/frontend/src/types/leg_case_client.ts
@@ -1,0 +1,5 @@
+export interface LegCaseClient {
+  id: number;
+  leg_case_id: number;
+  client_id: number;
+}

--- a/frontend/src/types/leg_case_court.ts
+++ b/frontend/src/types/leg_case_court.ts
@@ -1,0 +1,6 @@
+export interface LegCaseCourt {
+  leg_case_id: number;
+  court_id?: number;
+  case_number?: string;
+  case_year?: string;
+}

--- a/frontend/src/types/leg_case_lawyer.ts
+++ b/frontend/src/types/leg_case_lawyer.ts
@@ -1,0 +1,7 @@
+export interface LegCaseLawyer {
+  id: number;
+  leg_case_id: number;
+  lawyer_id: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/leg_cases.ts
+++ b/frontend/src/types/leg_cases.ts
@@ -1,0 +1,24 @@
+export interface LegCase {
+  id: number;
+  is_deleted: boolean;
+  slug: string;
+  title?: string;
+  description?: string;
+  fees?: number;
+  total_expenses?: number;
+  total_payments?: number;
+  expenses?: number;
+  case_type_id: string;
+  case_sub_type_id: string;
+  created_by: number;
+  updated_by?: number;
+  litigants_name?: string;
+  litigants_address?: string;
+  litigants_phone?: string;
+  litigants_lawyer_name?: string;
+  litigants_lawyer_phone?: string;
+  client_capacity: 'مدعى عليه' | 'مجنى عليه' | 'مدعى' | 'متهم';
+  status: 'قيد التجهيز' | 'متداولة' | 'منتهية' | 'معلقة';
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/legal_ad_types.ts
+++ b/frontend/src/types/legal_ad_types.ts
@@ -1,0 +1,6 @@
+export interface LegalAdType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/legal_ads.ts
+++ b/frontend/src/types/legal_ads.ts
@@ -1,0 +1,20 @@
+export interface LegalAd {
+  id: number;
+  description: string;
+  results?: string;
+  send_date: string;
+  receive_date?: string;
+  lawyer_send_id: string;
+  legal_ad_type_id: number;
+  lawyer_receive_id?: string;
+  status: 'قيد التجهيز' | 'تم التسليم' | 'تم الإستلام';
+  leg_case_id: number;
+  court_id: number;
+  cost1?: number;
+  cost2?: number;
+  cost3?: number;
+  created_by: number;
+  updated_by?: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/legal_docs.ts
+++ b/frontend/src/types/legal_docs.ts
@@ -1,0 +1,12 @@
+export interface LegalDoc {
+  id: number;
+  path: string;
+  thumbnail_path?: string;
+  word_path?: string;
+  pdf_path?: string;
+  description?: string;
+  doc_type_id: number;
+  doc_sub_type_id: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/legal_session_types.ts
+++ b/frontend/src/types/legal_session_types.ts
@@ -1,0 +1,4 @@
+export interface LegalSessionType {
+  id: number;
+  name: string;
+}

--- a/frontend/src/types/legal_sessions.ts
+++ b/frontend/src/types/legal_sessions.ts
@@ -1,0 +1,21 @@
+export interface LegalSession {
+  id: number;
+  court_session?: string;
+  legal_session_type_id: string;
+  leg_case_id: string;
+  court_id: string;
+  session_date: string;
+  cost1?: number;
+  cost2?: number;
+  cost3?: number;
+  session_roll?: string;
+  Judgment_operative?: string;
+  status: 'تمت' | 'لم ينفذ' | 'جارى التنفيذ';
+  lawyer_id: string;
+  orders?: string;
+  result?: string;
+  notes?: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -1,0 +1,10 @@
+export interface Notification {
+  id: number;
+  user_id: number;
+  event_id: number;
+  type: string;
+  message: string;
+  read: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/password_reset_tokens.ts
+++ b/frontend/src/types/password_reset_tokens.ts
@@ -1,0 +1,5 @@
+export interface PasswordResetToken {
+  email: string;
+  token: string;
+  created_at?: string;
+}

--- a/frontend/src/types/payments.ts
+++ b/frontend/src/types/payments.ts
@@ -1,0 +1,9 @@
+export interface Payment {
+  id: number;
+  invoice_id: number;
+  payment_date: string;
+  payment_method: 'Cash' | 'Card' | 'Bank Transfer';
+  amount: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/personal_access_tokens.ts
+++ b/frontend/src/types/personal_access_tokens.ts
@@ -1,0 +1,12 @@
+export interface PersonalAccessToken {
+  id: number;
+  tokenable_type: string;
+  tokenable_id: number;
+  name: string;
+  token: string;
+  abilities?: string;
+  last_used_at?: string;
+  expires_at?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/power_of_attorneys.ts
+++ b/frontend/src/types/power_of_attorneys.ts
@@ -1,0 +1,17 @@
+export interface PowerOfAttorney {
+  id: number;
+  attorney_num: string;
+  attorney_date: string;
+  attorney_chart: string;
+  attorney_place: string;
+  title: string;
+  description?: string;
+  client_id: number;
+  lawyer_insert: string;
+  image?: string;
+  created_by: number;
+  updated_by?: number;
+  created_at: string;
+  updated_at: string;
+  attorney_type_id: number;
+}

--- a/frontend/src/types/power_types.ts
+++ b/frontend/src/types/power_types.ts
@@ -1,0 +1,6 @@
+export interface PowerType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/procedure_place_types.ts
+++ b/frontend/src/types/procedure_place_types.ts
@@ -1,0 +1,6 @@
+export interface ProcedurePlaceType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/procedure_types.ts
+++ b/frontend/src/types/procedure_types.ts
@@ -1,0 +1,6 @@
+export interface ProcedureType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/procedures.ts
+++ b/frontend/src/types/procedures.ts
@@ -1,0 +1,22 @@
+export interface Procedure {
+  id: number;
+  procedure_type_id: string;
+  leg_case_id: string;
+  procedure_place_name?: string;
+  procedure_place_type_id?: number;
+  lawyer_id?: string;
+  job: string;
+  result?: string;
+  note?: string;
+  status: 'تمت' | 'لم ينفذ' | 'جاري التنفيذ';
+  event_id?: number;
+  date_start?: string;
+  date_end?: string;
+  cost1?: number;
+  cost2?: number;
+  cost3?: number;
+  created_by: string;
+  updated_by?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/public_documents.ts
+++ b/frontend/src/types/public_documents.ts
@@ -1,0 +1,10 @@
+export interface PublicDocument {
+  id: number;
+  title: string;
+  description?: string;
+  service_id?: number;
+  file_path: string;
+  created_at: string;
+  updated_at: string;
+  leg_case_id?: number;
+}

--- a/frontend/src/types/revenue_categories.ts
+++ b/frontend/src/types/revenue_categories.ts
@@ -1,0 +1,6 @@
+export interface RevenueCategory {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/revenues.ts
+++ b/frontend/src/types/revenues.ts
@@ -1,0 +1,11 @@
+export interface Revenue {
+  id: number;
+  client_id?: number;
+  service_id?: number;
+  leg_case_id?: number;
+  amount: number;
+  from_client: boolean;
+  from_unclients: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/search_case_types.ts
+++ b/frontend/src/types/search_case_types.ts
@@ -1,0 +1,9 @@
+export interface SearchCaseType {
+  id: number;
+  degree_value: string;
+  court_value: string;
+  case_type_name: string;
+  case_type_value: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/search_courts.ts
+++ b/frontend/src/types/search_courts.ts
@@ -1,0 +1,8 @@
+export interface SearchCourt {
+  id: number;
+  degree_value: string;
+  court_name: string;
+  court_value: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/search_degrees.ts
+++ b/frontend/src/types/search_degrees.ts
@@ -1,0 +1,7 @@
+export interface SearchDegree {
+  id: number;
+  degree_name: string;
+  degree_value: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/service_client.ts
+++ b/frontend/src/types/service_client.ts
@@ -1,0 +1,7 @@
+export interface ServiceClient {
+  id: number;
+  service_id: string;
+  client_id: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/service_documents.ts
+++ b/frontend/src/types/service_documents.ts
@@ -1,0 +1,8 @@
+export interface ServiceDocument {
+  id: number;
+  service_id: number;
+  client_id?: number;
+  file_path: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/service_procedures.ts
+++ b/frontend/src/types/service_procedures.ts
@@ -1,0 +1,22 @@
+export interface ServiceProcedure {
+  id: number;
+  service_id?: number;
+  title?: string;
+  lawyer_id: number;
+  job?: string;
+  procedure_place_name?: string;
+  procedure_place_type_id?: number;
+  result?: string;
+  note?: string;
+  status: 'تمت' | 'لم ينفذ' | 'جارى التنفيذ';
+  event_id?: number;
+  date_start: string;
+  date_end: string;
+  cost1?: number;
+  cost2?: number;
+  cost3?: number;
+  created_by: number;
+  updated_by?: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/service_types.ts
+++ b/frontend/src/types/service_types.ts
@@ -1,0 +1,6 @@
+export interface ServiceType {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/service_unclient.ts
+++ b/frontend/src/types/service_unclient.ts
@@ -1,0 +1,7 @@
+export interface ServiceUnclient {
+  id: number;
+  service_id: string;
+  unclient_id: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/services.ts
+++ b/frontend/src/types/services.ts
@@ -1,0 +1,13 @@
+export interface Service {
+  id: number;
+  slug: string;
+  description?: string;
+  service_place_name?: string;
+  service_year?: string;
+  created_by: number;
+  updated_by?: number;
+  created_at: string;
+  updated_at: string;
+  status: 'قيد التنفيذ' | 'جارى التنفيذ' | 'منتهية' | 'متداولة' | 'استيفاء';
+  service_type_id: string;
+}

--- a/frontend/src/types/sessions.ts
+++ b/frontend/src/types/sessions.ts
@@ -1,0 +1,8 @@
+export interface Session {
+  id: string;
+  user_id?: string;
+  ip_address?: string;
+  user_agent?: string;
+  payload: string;
+  last_activity: number;
+}

--- a/frontend/src/types/unclients.ts
+++ b/frontend/src/types/unclients.ts
@@ -1,0 +1,16 @@
+export interface Unclient {
+  id: number;
+  slug: string;
+  name: string;
+  email?: string;
+  phone_number: string;
+  address?: string;
+  work?: string;
+  emergency_number?: string;
+  date_of_birth: string;
+  gender?: 'ذكر' | 'أنثى';
+  religion?: 'مسلم' | 'مسيحي';
+  identity_number: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -1,0 +1,11 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  email_verified_at?: string;
+  role: '1' | '2' | '3';
+  password: string;
+  remember_token?: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- add TypeScript interface files describing the users, password reset tokens, and session tables
- mirror the remaining Laravel migration schemas (cases, services, finance, documents, etc.) with matching TypeScript definitions under `frontend/src/types`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8ed9b4f6c8328a7c5339b406eaab3