### PR TITLE
Enhance dark mode selection neon styling

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -144,9 +144,10 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
           <button
             onClick={() => !isCollapsed && toggleExpanded(item.key)}
             className={cn(
-              "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
+              "sidebar-link w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
               "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground glow-hover",
-              hasActiveChild && "bg-sidebar-accent text-sidebar-accent-foreground",
+              hasActiveChild &&
+                "bg-sidebar-accent text-sidebar-accent-foreground sidebar-link-active",
               level > 0 && !isCollapsed && (isRTL ? "mr-4" : "ml-4"),
               isCollapsed && "justify-center px-2"
             )}
@@ -179,9 +180,10 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
             to={`/dashboard/${item.key}`}
             className={({ isActive }) =>
               cn(
-                "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
+                "sidebar-link w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
                 "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground glow-hover",
-                isActive && "bg-sidebar-primary text-sidebar-primary-foreground shadow-elegant",
+                isActive &&
+                  "bg-sidebar-primary text-sidebar-primary-foreground shadow-elegant sidebar-link-active",
                 level > 0 && !isCollapsed && (isRTL ? "mr-4" : "ml-4"),
                 isCollapsed && "justify-center px-2"
               )

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -105,7 +105,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+      "command-item relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
       className,
     )}
     {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,6 +61,12 @@
     --gradient-hero: linear-gradient(135deg, hsl(220 60% 20%) 0%, hsl(210 40% 30%) 50%, hsl(220 60% 25%) 100%);
     --gradient-glass: linear-gradient(135deg, hsl(220 15% 100% / 0.95), hsl(220 20% 95% / 0.8));
 
+    /* Neon Tech Accents */
+    --neon-primary: 208 85% 55%;
+    --neon-secondary: 188 80% 55%;
+    --neon-glow: 204 90% 60% / 0.32;
+    --neon-highlight: 198 95% 85% / 0.35;
+
     /* Shadow System */
     --shadow-glow: 0 0 25px hsl(var(--accent-glow));
     --shadow-glass: 0 8px 32px hsl(var(--glass-shadow));
@@ -136,6 +142,12 @@
     --gradient-hero: linear-gradient(135deg, hsl(220 25% 4%) 0%, hsl(210 40% 20%) 50%, hsl(220 25% 8%) 100%);
     --gradient-glass: linear-gradient(135deg, hsl(220 25% 12% / 0.95), hsl(220 25% 8% / 0.8));
 
+    /* Dark Neon Accents */
+    --neon-primary: 200 95% 60%;
+    --neon-secondary: 180 85% 55%;
+    --neon-glow: 195 95% 60% / 0.45;
+    --neon-highlight: 190 100% 82% / 0.4;
+
     /* Dark Shadows */
     --shadow-glow: 0 0 30px hsl(var(--accent-glow));
     --shadow-glass: 0 8px 32px hsl(210 40% 45% / 0.12);
@@ -150,6 +162,30 @@
     --sidebar-accent-foreground: 220 15% 95%;
     --sidebar-border: 220 25% 18%;
     --sidebar-ring: 210 40% 55%;
+  }
+}
+
+@keyframes techPulse {
+  0%,
+  100% {
+    transform: scale(0.98);
+    opacity: 0.45;
+  }
+  50% {
+    transform: scale(1.03);
+    opacity: 0.95;
+  }
+}
+
+@keyframes neonScan {
+  0% {
+    transform: translateX(-35%);
+  }
+  50% {
+    transform: translateX(35%);
+  }
+  100% {
+    transform: translateX(-35%);
   }
 }
 
@@ -240,5 +276,129 @@
 
   .dark ::-webkit-scrollbar-thumb:hover {
     background: hsl(var(--accent) / 0.8);
+  }
+}
+
+@layer components {
+  .sidebar-link {
+    @apply relative overflow-hidden transition-all;
+    isolation: isolate;
+    z-index: 0;
+  }
+
+  .sidebar-link::before,
+  .sidebar-link::after {
+    pointer-events: none;
+  }
+
+  .dark .sidebar-link-active {
+    color: hsl(var(--sidebar-primary-foreground));
+    background: linear-gradient(
+      135deg,
+      hsl(var(--neon-primary) / 0.18),
+      hsl(var(--neon-secondary) / 0.08)
+    );
+    box-shadow:
+      0 0 0 1px hsl(var(--neon-primary) / 0.35),
+      0 18px 45px hsl(var(--neon-glow));
+  }
+
+  .dark .sidebar-link-active::before {
+    content: "";
+    position: absolute;
+    inset: -30%;
+    border-radius: 999px;
+    background: radial-gradient(
+      circle at 35% 25%,
+      hsl(var(--neon-primary) / 0.6),
+      transparent 60%
+    );
+    filter: blur(12px);
+    opacity: 0.65;
+    animation: techPulse 3.2s ease-in-out infinite;
+    z-index: -2;
+  }
+
+  .dark .sidebar-link-active::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -40%;
+    width: 180%;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      transparent 30%,
+      hsl(var(--neon-highlight)),
+      transparent 70%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.38;
+    animation: neonScan 4.2s linear infinite;
+    z-index: -1;
+  }
+
+  .dark .sidebar-link-active svg {
+    filter: drop-shadow(0 0 6px hsl(var(--neon-primary) / 0.8));
+  }
+
+  .command-item {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+  }
+
+  .command-item::before,
+  .command-item::after {
+    pointer-events: none;
+  }
+
+  .dark .command-item[data-selected='true'] {
+    color: hsl(var(--accent-foreground));
+    background: linear-gradient(
+      135deg,
+      hsl(var(--neon-primary) / 0.25),
+      hsl(var(--neon-secondary) / 0.12)
+    );
+    box-shadow:
+      0 0 0 1px hsl(var(--neon-primary) / 0.25),
+      0 14px 38px hsl(var(--neon-glow));
+  }
+
+  .dark .command-item[data-selected='true']::before {
+    content: "";
+    position: absolute;
+    inset: -25%;
+    border-radius: 999px;
+    background: radial-gradient(
+      circle at 15% 15%,
+      hsl(var(--neon-primary) / 0.55),
+      transparent 65%
+    );
+    filter: blur(10px);
+    opacity: 0.7;
+    animation: techPulse 2.8s ease-in-out infinite;
+    z-index: -2;
+  }
+
+  .dark .command-item[data-selected='true']::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -45%;
+    width: 190%;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      transparent 35%,
+      hsl(var(--neon-highlight)),
+      transparent 65%
+    );
+    opacity: 0.42;
+    mix-blend-mode: screen;
+    animation: neonScan 3.6s linear infinite;
+    z-index: -1;
   }
 }


### PR DESCRIPTION
## Summary
- add neon accent CSS variables, animations, and component layer helpers for dark mode technology glow
- update sidebar menu and command items to leverage the neon-active styling hooks

## Testing
- npm run lint *(fails: pre-existing lint errors about explicit any types and hook dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1ffca7988328be90ba1f417d018d