### PR TITLE
Refine sidebar layout and mobile drawer

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -23,7 +23,7 @@ const AppShell: React.FC<AppShellProps> = ({ children, title }) => {
       {/* Desktop Layout */}
       <div className="flex h-screen">
         {/* Sidebar */}
-        <Sidebar isCollapsed={false} onToggle={() => {}} />
+        <Sidebar />
 
         {/* Main Content */}
         <div className="flex-1 flex flex-col min-w-0">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Moon, Sun, ChevronDown, User, LogOut, Menu } from 'lucide-react';
+import { Moon, Sun, ChevronDown, User, LogOut, Menu, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -25,7 +25,7 @@ export const Header: React.FC<HeaderProps> = ({ title, className }) => {
   const { theme, toggleTheme } = useTheme();
   const { language, toggleLanguage, t, isRTL } = useLanguage();
   const { user, logout } = useAuth();
-  const { toggleMobile } = useSidebar();
+  const { toggleMobile, toggleCollapsed, isCollapsed } = useSidebar();
 
   const headerSurface = { '--glass-surface': 'var(--gradient-header)' } as React.CSSProperties;
   const isDark = theme === 'dark';
@@ -61,6 +61,21 @@ export const Header: React.FC<HeaderProps> = ({ title, className }) => {
             aria-label={t('common.menu')}
           >
             <Menu className="h-4 w-4" />
+          </Button>
+
+          {/* Desktop collapse toggle */}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleCollapsed}
+            className={cn('hidden lg:inline-flex h-9 w-9', iconButtonClass)}
+            aria-label={isCollapsed ? t('nav.expand') : t('nav.collapse')}
+          >
+            {isCollapsed ? (
+              isRTL ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />
+            ) : (
+              isRTL ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />
+            )}
           </Button>
 
           {/* Desktop logo - hidden on mobile */}

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -73,9 +73,9 @@ const MobileDrawer: React.FC = () => {
 
           {/* Drawer */}
           <motion.aside
-            initial={{ 
+            initial={{
               x: isRTL ? '100%' : '-100%',
-              opacity: 0 
+              opacity: 0
             }}
             animate={{ 
               x: 0,
@@ -91,9 +91,9 @@ const MobileDrawer: React.FC = () => {
               stiffness: 200 
             }}
             className={cn(
-              'fixed top-0 z-50 h-full w-80 max-w-[85vw] glass border border-sidebar-border text-sidebar-foreground md:hidden',
+              'fixed top-0 z-50 h-full w-full glass border border-sidebar-border text-sidebar-foreground md:hidden',
               'flex flex-col shadow-elegant',
-              isRTL ? 'right-0 border-l' : 'left-0 border-r'
+              isRTL ? 'right-0' : 'left-0'
             )}
             style={{ '--glass-surface': 'var(--gradient-sidebar)' } as React.CSSProperties}
           >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,17 +18,12 @@ import {
   Search,
   BarChart3,
   Menu,
-  X
+  PanelsTopLeft
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { useSidebar } from '@/contexts/SidebarContext';
 import { cn } from '@/lib/utils';
-
-interface SidebarProps {
-  isCollapsed: boolean;
-  onToggle: () => void;
-}
 
 interface MenuItem {
   key: string;
@@ -36,43 +31,7 @@ interface MenuItem {
   children?: MenuItem[];
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
-  const { t, isRTL } = useLanguage();
-  const location = useLocation();
-  const isMobile = useIsMobile();
-  const [expandedItems, setExpandedItems] = useState<string[]>([]);
-
-  // Auto-expand parent items based on current route
-  useEffect(() => {
-    const currentPath = location.pathname;
-    const pathSegments = currentPath.split('/').filter(Boolean);
-    
-    if (pathSegments.length >= 2) {
-      const section = pathSegments[1]; // /dashboard/[section]
-      
-      // Find parent menu item for current route
-      const parentItem = menuItems.find(item => 
-        item.children?.some(child => String(child.key) === section)
-      );
-      
-      if (parentItem && !expandedItems.includes(parentItem.key)) {
-        setExpandedItems(prev => [...prev, parentItem.key]);
-      }
-    }
-  }, [location.pathname]);
-
-  // Handle mobile sidebar state
-  useEffect(() => {
-    if (isMobile && !isCollapsed) {
-      // Auto-collapse on mobile when route changes
-      const timer = setTimeout(() => {
-        onToggle();
-      }, 100);
-      return () => clearTimeout(timer);
-    }
-  }, [location.pathname, isMobile]);
-
-  const menuItems: MenuItem[] = [
+const menuItems: MenuItem[] = [
     {
       key: 'cases',
       icon: Gavel,
@@ -117,6 +76,31 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
     },
   ];
 
+const Sidebar: React.FC = () => {
+  const { t, isRTL } = useLanguage();
+  const location = useLocation();
+  const { isCollapsed, toggleCollapsed } = useSidebar();
+  const [expandedItems, setExpandedItems] = useState<string[]>([]);
+
+  // Auto-expand parent items based on current route
+  useEffect(() => {
+    const currentPath = location.pathname;
+    const pathSegments = currentPath.split('/').filter(Boolean);
+
+    if (pathSegments.length >= 2) {
+      const section = pathSegments[1]; // /dashboard/[section]
+
+      // Find parent menu item for current route
+      const parentItem = menuItems.find(item =>
+        item.children?.some(child => String(child.key) === section)
+      );
+
+      if (parentItem && !expandedItems.includes(parentItem.key)) {
+        setExpandedItems(prev => [...prev, parentItem.key]);
+      }
+    }
+  }, [location.pathname, expandedItems]);
+
   const toggleExpanded = (key: string) => {
     setExpandedItems(prev =>
       prev.includes(key)
@@ -139,14 +123,15 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
     );
 
     return (
-       <div key={item.key} className="w-full">
+      <div key={item.key} className="w-full">
         {hasChildren ? (
           <button
             onClick={() => !isCollapsed && toggleExpanded(item.key)}
             className={cn(
-              "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
+              "sidebar-link w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
               "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground glow-hover",
-              hasActiveChild && "bg-sidebar-accent text-sidebar-accent-foreground",
+              hasActiveChild &&
+                "bg-sidebar-accent text-sidebar-accent-foreground sidebar-link-active",
               level > 0 && !isCollapsed && (isRTL ? "mr-4" : "ml-4"),
               isCollapsed && "justify-center px-2"
             )}
@@ -173,15 +158,19 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
                 )}
               </>
             )}
+            {isCollapsed && (
+              <span className="sr-only">{t(`nav.${item.key}`)}</span>
+            )}
           </button>
         ) : (
           <NavLink
             to={`/dashboard/${item.key}`}
             className={({ isActive }) =>
               cn(
-                "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
+                "sidebar-link w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
                 "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground glow-hover",
-                isActive && "bg-sidebar-primary text-sidebar-primary-foreground shadow-elegant",
+                isActive &&
+                  "bg-sidebar-primary text-sidebar-primary-foreground shadow-elegant sidebar-link-active",
                 level > 0 && !isCollapsed && (isRTL ? "mr-4" : "ml-4"),
                 isCollapsed && "justify-center px-2"
               )
@@ -199,6 +188,9 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
                 {t(`nav.${item.key}`)}
               </span>
             )}
+            {isCollapsed && (
+              <span className="sr-only">{t(`nav.${item.key}`)}</span>
+            )}
           </NavLink>
         )}
 
@@ -212,64 +204,55 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle }) => {
   };
 
   return (
-    <>
-      {/* Mobile Overlay */}
-      {isMobile && !isCollapsed && (
-        <div 
-          className="fixed inset-0 bg-black/20 backdrop-blur-sm z-40"
-          onClick={onToggle}
-        />
+    <aside
+      className={cn(
+        "fixed top-16 z-40 hidden h-[calc(100vh-4rem)] flex-col border-sidebar-border/70 text-sidebar-foreground transition-all duration-300 ease-out lg:flex",
+        "glass shadow-elegant backdrop-blur-xl",
+        "bg-[hsl(var(--sidebar-background)/0.92)] dark:bg-[hsl(var(--sidebar-background)/0.85)]",
+        isCollapsed ? "w-[4.5rem]" : "w-[17rem]",
+        isRTL ? "right-0 border-l" : "left-0 border-r"
       )}
-
-      {/* Sidebar */}
-      <aside
-        className={cn(
-          "fixed top-0 z-50 h-full glass border-r border-sidebar-border text-sidebar-foreground transition-all duration-300",
-          "lg:relative lg:translate-x-0",
-          // Positioning based on RTL/LTR
-          isRTL ? "right-0" : "left-0",
-          // Width and visibility
-          isCollapsed ? "w-16" : "w-64",
-          // Mobile behavior
-          isMobile && isCollapsed && (isRTL ? "-translate-x-full" : "-translate-x-full"),
-          isMobile && !isCollapsed && "translate-x-0",
-          // Desktop behavior
-          !isMobile && "translate-x-0"
-        )}
-        style={{
-          direction: isRTL ? 'rtl' : 'ltr',
-          '--glass-surface': 'var(--gradient-sidebar)'
-        } as React.CSSProperties}
-      >
-        <div className="flex h-full flex-col">
-          {/* Header */}
-          <div className={cn(
-            "flex h-16 items-center border-b border-sidebar-border px-4",
+      style={{
+        direction: isRTL ? 'rtl' : 'ltr',
+        '--glass-surface': 'var(--gradient-sidebar)'
+      } as React.CSSProperties}
+    >
+      <div className="flex h-full flex-col">
+        <div
+          className={cn(
+            "flex h-14 items-center border-b border-sidebar-border/70 px-3",
             isCollapsed ? "justify-center" : "justify-between"
-          )}>
-            {!isCollapsed && (
-              <h2 className="text-lg font-semibold bg-gradient-primary bg-clip-text text-transparent truncate">
-                {t('nav.dashboard')}
-              </h2>
+          )}
+        >
+          {!isCollapsed && (
+            <h2 className="text-base font-semibold tracking-wide text-sidebar-foreground/90">
+              {t('nav.dashboard')}
+            </h2>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleCollapsed}
+            className={cn(
+              "h-8 w-8 rounded-full border border-transparent transition-colors",
+              "hover:border-sidebar-border hover:bg-sidebar-accent/60",
+              "dark:hover:bg-sidebar-accent/40"
             )}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onToggle}
-              className="h-8 w-8 hover:bg-sidebar-accent glow-hover flex-shrink-0"
-              aria-label={isCollapsed ? t('nav.expand') : t('nav.collapse')}
-            >
-              {isCollapsed ? <Menu className="h-4 w-4" /> : <X className="h-4 w-4" />}
-            </Button>
-          </div>
-
-          {/* Navigation */}
-          <nav className="flex-1 overflow-y-auto p-4 space-y-2 custom-scrollbar">
-            {menuItems.map(item => renderMenuItem(item))}
-          </nav>
+            aria-label={isCollapsed ? t('nav.expand') : t('nav.collapse')}
+          >
+            {isCollapsed ? (
+              <Menu className="h-4 w-4" />
+            ) : (
+              <PanelsTopLeft className="h-4 w-4" />
+            )}
+          </Button>
         </div>
-      </aside>
-    </>
+
+        <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-2 custom-scrollbar">
+          {menuItems.map(item => renderMenuItem(item))}
+        </nav>
+      </div>
+    </aside>
   );
 };
 

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -105,7 +105,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+      "command-item relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
       className,
     )}
     {...props}

--- a/frontend/src/contexts/SidebarContext.tsx
+++ b/frontend/src/contexts/SidebarContext.tsx
@@ -12,13 +12,19 @@ const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 
 export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isCollapsed, setIsCollapsed] = useState(() => {
-    const saved = localStorage.getItem('sidebar-collapsed');
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    const saved = window.localStorage.getItem('sidebar-collapsed');
     return saved ? JSON.parse(saved) : false;
   });
   const [isMobileOpen, setIsMobileOpen] = useState(false);
 
   useEffect(() => {
-    localStorage.setItem('sidebar-collapsed', JSON.stringify(isCollapsed));
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('sidebar-collapsed', JSON.stringify(isCollapsed));
+    }
   }, [isCollapsed]);
 
   const toggleCollapsed = () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,6 +61,12 @@
     --gradient-hero: linear-gradient(135deg, hsl(220 60% 20%) 0%, hsl(210 40% 30%) 50%, hsl(220 60% 25%) 100%);
     --gradient-glass: linear-gradient(135deg, hsl(220 15% 100% / 0.95), hsl(220 20% 95% / 0.8));
 
+    /* Neon Tech Accents */
+    --neon-primary: 208 85% 55%;
+    --neon-secondary: 188 80% 55%;
+    --neon-glow: 204 90% 60% / 0.32;
+    --neon-highlight: 198 95% 85% / 0.35;
+
     /* Shadow System */
     --shadow-glow: 0 0 25px hsl(var(--accent-glow));
     --shadow-glass: 0 8px 32px hsl(var(--glass-shadow));
@@ -136,6 +142,12 @@
     --gradient-hero: linear-gradient(135deg, hsl(220 25% 4%) 0%, hsl(210 40% 20%) 50%, hsl(220 25% 8%) 100%);
     --gradient-glass: linear-gradient(135deg, hsl(220 25% 12% / 0.95), hsl(220 25% 8% / 0.8));
 
+    /* Dark Neon Accents */
+    --neon-primary: 200 95% 60%;
+    --neon-secondary: 180 85% 55%;
+    --neon-glow: 195 95% 60% / 0.45;
+    --neon-highlight: 190 100% 82% / 0.4;
+
     /* Dark Shadows */
     --shadow-glow: 0 0 30px hsl(var(--accent-glow));
     --shadow-glass: 0 8px 32px hsl(210 40% 45% / 0.12);
@@ -150,6 +162,30 @@
     --sidebar-accent-foreground: 220 15% 95%;
     --sidebar-border: 220 25% 18%;
     --sidebar-ring: 210 40% 55%;
+  }
+}
+
+@keyframes techPulse {
+  0%,
+  100% {
+    transform: scale(0.98);
+    opacity: 0.45;
+  }
+  50% {
+    transform: scale(1.03);
+    opacity: 0.95;
+  }
+}
+
+@keyframes neonScan {
+  0% {
+    transform: translateX(-35%);
+  }
+  50% {
+    transform: translateX(35%);
+  }
+  100% {
+    transform: translateX(-35%);
   }
 }
 
@@ -240,5 +276,129 @@
 
   .dark ::-webkit-scrollbar-thumb:hover {
     background: hsl(var(--accent) / 0.8);
+  }
+}
+
+@layer components {
+  .sidebar-link {
+    @apply relative overflow-hidden transition-all;
+    isolation: isolate;
+    z-index: 0;
+  }
+
+  .sidebar-link::before,
+  .sidebar-link::after {
+    pointer-events: none;
+  }
+
+  .dark .sidebar-link-active {
+    color: hsl(var(--sidebar-primary-foreground));
+    background: linear-gradient(
+      135deg,
+      hsl(var(--neon-primary) / 0.18),
+      hsl(var(--neon-secondary) / 0.08)
+    );
+    box-shadow:
+      0 0 0 1px hsl(var(--neon-primary) / 0.35),
+      0 18px 45px hsl(var(--neon-glow));
+  }
+
+  .dark .sidebar-link-active::before {
+    content: "";
+    position: absolute;
+    inset: -30%;
+    border-radius: 999px;
+    background: radial-gradient(
+      circle at 35% 25%,
+      hsl(var(--neon-primary) / 0.6),
+      transparent 60%
+    );
+    filter: blur(12px);
+    opacity: 0.65;
+    animation: techPulse 3.2s ease-in-out infinite;
+    z-index: -2;
+  }
+
+  .dark .sidebar-link-active::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -40%;
+    width: 180%;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      transparent 30%,
+      hsl(var(--neon-highlight)),
+      transparent 70%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.38;
+    animation: neonScan 4.2s linear infinite;
+    z-index: -1;
+  }
+
+  .dark .sidebar-link-active svg {
+    filter: drop-shadow(0 0 6px hsl(var(--neon-primary) / 0.8));
+  }
+
+  .command-item {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+  }
+
+  .command-item::before,
+  .command-item::after {
+    pointer-events: none;
+  }
+
+  .dark .command-item[data-selected='true'] {
+    color: hsl(var(--accent-foreground));
+    background: linear-gradient(
+      135deg,
+      hsl(var(--neon-primary) / 0.25),
+      hsl(var(--neon-secondary) / 0.12)
+    );
+    box-shadow:
+      0 0 0 1px hsl(var(--neon-primary) / 0.25),
+      0 14px 38px hsl(var(--neon-glow));
+  }
+
+  .dark .command-item[data-selected='true']::before {
+    content: "";
+    position: absolute;
+    inset: -25%;
+    border-radius: 999px;
+    background: radial-gradient(
+      circle at 15% 15%,
+      hsl(var(--neon-primary) / 0.55),
+      transparent 65%
+    );
+    filter: blur(10px);
+    opacity: 0.7;
+    animation: techPulse 2.8s ease-in-out infinite;
+    z-index: -2;
+  }
+
+  .dark .command-item[data-selected='true']::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -45%;
+    width: 190%;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      transparent 35%,
+      hsl(var(--neon-highlight)),
+      transparent 65%
+    );
+    opacity: 0.42;
+    mix-blend-mode: screen;
+    animation: neonScan 3.6s linear infinite;
+    z-index: -1;
   }
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,22 +1,34 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Header } from '@/components/layout/Header';
 import Sidebar from '@/components/layout/Sidebar';
+import { useSidebar } from '@/contexts/SidebarContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { cn } from '@/lib/utils';
 
 const Dashboard: React.FC = () => {
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { isCollapsed } = useSidebar();
+  const { isRTL } = useLanguage();
 
-  const toggleSidebar = () => {
-    setSidebarCollapsed(!sidebarCollapsed);
-  };
+  const sidebarWidth = isCollapsed ? '4.5rem' : '17rem';
 
   return (
-    <div className="min-h-screen bg-background">
+    <div
+      className="min-h-screen bg-background text-foreground"
+      style={{ '--sidebar-width': sidebarWidth } as React.CSSProperties}
+    >
       <Header />
-      <div className="flex h-[calc(100vh-4rem)]">
-        <Sidebar isCollapsed={sidebarCollapsed} onToggle={toggleSidebar} />
-        <main className="flex-1 overflow-y-auto">
-          <div className="p-6">
+      <Sidebar />
+      <div
+        className={cn(
+          'relative flex min-h-[calc(100vh-4rem)] flex-col transition-[margin] duration-300 ease-out',
+          isRTL
+            ? 'lg:mr-[var(--sidebar-width)]'
+            : 'lg:ml-[var(--sidebar-width)]'
+        )}
+      >
+        <main className="flex-1 overflow-y-auto px-4 py-6 sm:px-6">
+          <div className="mx-auto w-full max-w-6xl space-y-6">
             <Outlet />
           </div>
         </main>


### PR DESCRIPTION
## Summary
- reposition the desktop sidebar beneath the sticky header, hide it on small screens, and drive its state from the shared SidebarContext with refreshed dark-mode styling
- offset dashboard content by the live sidebar width so the main area animates cleanly when the sidebar collapses or expands
- surface collapse controls in the header, widen the mobile drawer to full width, and harden sidebar state persistence for server-safe rendering

## Testing
- npm run lint *(fails: existing lint violations for legacy `any` usage and react-refresh warnings throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1ffca7988328be90ba1f417d018d