### PR TITLE
feat: implement clients and unclients management UI

### DIFF
--- a/frontend/src/components/clientsAndUnclients/UnclientFormDialog.tsx
+++ b/frontend/src/components/clientsAndUnclients/UnclientFormDialog.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useState } from 'react';
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/components/ui/use-toast';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { createUnclient, updateUnclient } from '@/api/unclients.service';
+import type { Unclient } from '@/types/unclients';
+import type { UnclientFormMode } from './types';
+
+interface UnclientFormDialogProps {
+  open: boolean;
+  mode: UnclientFormMode;
+  initialData?: Unclient;
+  onOpenChange: (open: boolean) => void;
+  onSaved?: () => void;
+}
+
+const DEFAULT_UNCLIENT: Partial<Unclient> = {
+  slug: '',
+  name: '',
+  identity_number: '',
+  phone_number: '',
+  email: '',
+  address: '',
+  work: '',
+  emergency_number: '',
+  date_of_birth: '',
+  gender: 'ذكر',
+  religion: 'مسلم',
+};
+
+const UnclientFormDialog: React.FC<UnclientFormDialogProps> = ({
+  open,
+  mode,
+  initialData,
+  onOpenChange,
+  onSaved,
+}) => {
+  const { t } = useLanguage();
+  const { toast } = useToast();
+  const [formState, setFormState] = useState<Partial<Unclient>>(DEFAULT_UNCLIENT);
+  const [loading, setLoading] = useState(false);
+
+  const isReadOnly = mode === 'view';
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (initialData) {
+      setFormState({
+        ...DEFAULT_UNCLIENT,
+        ...initialData,
+        date_of_birth: initialData.date_of_birth?.slice(0, 10),
+      });
+    } else {
+      setFormState(DEFAULT_UNCLIENT);
+    }
+  }, [open, initialData]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const updateField = <K extends keyof Unclient>(key: K, value: Unclient[K]) => {
+    setFormState((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isReadOnly) {
+      handleClose();
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const payload = {
+        ...formState,
+        date_of_birth: formState.date_of_birth || null,
+      };
+
+      if (mode === 'edit' && initialData) {
+        await updateUnclient(String(initialData.id), payload);
+        toast({ title: t('unclients.form.messages.updateSuccess') });
+      } else {
+        await createUnclient(payload as Omit<Unclient, 'id'>);
+        toast({ title: t('unclients.form.messages.createSuccess') });
+      }
+
+      onSaved?.();
+      handleClose();
+    } catch (error) {
+      console.error('Failed to save unclient', error);
+      toast({
+        title: t('unclients.form.messages.errorTitle'),
+        description: t('unclients.form.messages.errorDescription'),
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'create'
+              ? t('unclients.form.titleCreate')
+              : mode === 'edit'
+                ? t('unclients.form.titleEdit')
+                : t('unclients.form.titleView')}
+          </DialogTitle>
+          {mode === 'view' && (
+            <DialogDescription>{t('unclients.form.readOnlyNotice')}</DialogDescription>
+          )}
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField label={t('unclients.form.labels.slug')} required>
+              <Input
+                value={formState.slug ?? ''}
+                onChange={(event) => updateField('slug', event.target.value)}
+                disabled={isReadOnly}
+                placeholder={t('unclients.form.placeholders.slug')}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.name')} required>
+              <Input
+                value={formState.name ?? ''}
+                onChange={(event) => updateField('name', event.target.value)}
+                disabled={isReadOnly}
+                placeholder={t('unclients.form.placeholders.name')}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.identity')}>
+              <Input
+                value={formState.identity_number ?? ''}
+                onChange={(event) => updateField('identity_number', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.phone')}>
+              <Input
+                value={formState.phone_number ?? ''}
+                onChange={(event) => updateField('phone_number', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.email')}>
+              <Input
+                type="email"
+                value={formState.email ?? ''}
+                onChange={(event) => updateField('email', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.address')}>
+              <Input
+                value={formState.address ?? ''}
+                onChange={(event) => updateField('address', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.work')}>
+              <Input
+                value={formState.work ?? ''}
+                onChange={(event) => updateField('work', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.emergency')}>
+              <Input
+                value={formState.emergency_number ?? ''}
+                onChange={(event) => updateField('emergency_number', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.dateOfBirth')}>
+              <Input
+                type="date"
+                value={formState.date_of_birth ?? ''}
+                onChange={(event) => updateField('date_of_birth', event.target.value)}
+                disabled={isReadOnly}
+              />
+            </FormField>
+            <FormField label={t('unclients.form.labels.gender')}>
+              <Select
+                value={formState.gender ?? 'ذكر'}
+                onValueChange={(value) => updateField('gender', value as Unclient['gender'])}
+                disabled={isReadOnly}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ذكر">{t('unclients.form.genderOptions.male')}</SelectItem>
+                  <SelectItem value="أنثى">{t('unclients.form.genderOptions.female')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </FormField>
+            <FormField label={t('unclients.form.labels.religion')}>
+              <Select
+                value={formState.religion ?? 'مسلم'}
+                onValueChange={(value) => updateField('religion', value as Unclient['religion'])}
+                disabled={isReadOnly}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="مسلم">{t('unclients.form.religionOptions.muslim')}</SelectItem>
+                  <SelectItem value="مسيحي">{t('unclients.form.religionOptions.christian')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </FormField>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              {t('common.cancel')}
+            </Button>
+            {!isReadOnly && (
+              <Button type="submit" disabled={loading}>
+                {loading ? t('common.loading') : t('unclients.form.actions.save')}
+              </Button>
+            )}
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface FormFieldProps {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+const FormField: React.FC<FormFieldProps> = ({ label, required, children }) => (
+  <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+    <span>
+      {label}
+      {required && <span className="text-destructive"> *</span>}
+    </span>
+    {children}
+  </label>
+);
+
+export default UnclientFormDialog;

--- a/frontend/src/components/clientsAndUnclients/UnclientsTable.tsx
+++ b/frontend/src/components/clientsAndUnclients/UnclientsTable.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Eye, Pencil, Trash2 } from 'lucide-react';
+
+import DetailsTable, { DetailsTableColumn } from '@/components/legalCases/Details/DetailsTable';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { getUnclients, deleteUnclient } from '@/api/unclients.service';
+import type { Unclient } from '@/types/unclients';
+import UnclientFormDialog from './UnclientFormDialog';
+import type { UnclientFormMode } from './types';
+
+const UnclientsTable = () => {
+  const { t } = useLanguage();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<UnclientFormMode>('create');
+  const [selectedUnclient, setSelectedUnclient] = useState<Unclient | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<Unclient | null>(null);
+
+  const unclientsQuery = useQuery({
+    queryKey: ['unclients'],
+    queryFn: async () => {
+      const { data } = await getUnclients();
+      return Array.isArray(data) ? (data as unknown as Unclient[]) : data.unclients ?? [];
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteUnclient(String(id)),
+    onSuccess: () => {
+      toast({ title: t('unclients.messages.deleteSuccess') });
+      queryClient.invalidateQueries({ queryKey: ['unclients'] });
+    },
+    onError: () => {
+      toast({
+        title: t('unclients.messages.deleteErrorTitle'),
+        description: t('unclients.messages.deleteErrorDescription'),
+        variant: 'destructive',
+      });
+    },
+    onSettled: () => setConfirmDelete(null),
+  });
+
+  const unclients = unclientsQuery.data ?? [];
+
+  const columns = useMemo<DetailsTableColumn<Unclient>[]>(
+    () => [
+      {
+        key: 'slug',
+        header: t('unclients.list.table.slug'),
+        accessor: (unclient) => unclient.slug ?? '',
+        render: (unclient) => unclient.slug ?? '—',
+        sortable: true,
+      },
+      {
+        key: 'name',
+        header: t('unclients.list.table.name'),
+        accessor: (unclient) => unclient.name ?? '',
+        render: (unclient) => unclient.name ?? '—',
+        sortable: true,
+      },
+      {
+        key: 'identity',
+        header: t('unclients.list.table.identity'),
+        accessor: (unclient) => unclient.identity_number ?? '',
+        render: (unclient) => unclient.identity_number ?? '—',
+        sortable: true,
+      },
+      {
+        key: 'phone',
+        header: t('unclients.list.table.phone'),
+        accessor: (unclient) => unclient.phone_number ?? '',
+        render: (unclient) => unclient.phone_number ?? '—',
+        sortable: true,
+      },
+      {
+        key: 'email',
+        header: t('unclients.list.table.email'),
+        accessor: (unclient) => unclient.email ?? '',
+        render: (unclient) => unclient.email ?? '—',
+        sortable: true,
+      },
+    ],
+    [t],
+  );
+
+  const openDialog = (mode: UnclientFormMode, unclient?: Unclient) => {
+    setDialogMode(mode);
+    setSelectedUnclient(unclient ?? null);
+    setDialogOpen(true);
+  };
+
+  return (
+    <>
+      <DetailsTable<Unclient>
+        data={unclients}
+        columns={columns}
+        enableSorting
+        enableSearch
+        enableExport
+        enablePagination
+        exportFileName="unclients"
+        isLoading={unclientsQuery.isLoading}
+        emptyMessage={
+          unclientsQuery.isLoading ? t('common.loading') : t('unclients.list.empty')
+        }
+        onAdd={() => openDialog('create')}
+        addButtonLabel={t('unclients.list.add')}
+        actionsHeader={t('unclients.list.table.actions')}
+        renderActions={(unclient) => (
+          <div className="flex items-center justify-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => openDialog('view', unclient)}
+            >
+              <Eye className="h-4 w-4" />
+              <span className="sr-only">{t('unclients.list.actions.view')}</span>
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => openDialog('edit', unclient)}
+            >
+              <Pencil className="h-4 w-4" />
+              <span className="sr-only">{t('unclients.list.actions.edit')}</span>
+            </Button>
+            <Button
+              variant="destructive"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => setConfirmDelete(unclient)}
+              disabled={deleteMutation.isPending}
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="sr-only">{t('unclients.list.actions.delete')}</span>
+            </Button>
+          </div>
+        )}
+      />
+
+      <UnclientFormDialog
+        open={dialogOpen}
+        mode={dialogMode}
+        initialData={selectedUnclient ?? undefined}
+        onOpenChange={setDialogOpen}
+        onSaved={() => queryClient.invalidateQueries({ queryKey: ['unclients'] })}
+      />
+
+      <ConfirmDialog
+        open={!!confirmDelete}
+        title={
+          confirmDelete
+            ? t('unclients.list.confirmDeleteTitle', { name: confirmDelete.name })
+            : ''
+        }
+        description={t('unclients.list.confirmDeleteDescription')}
+        confirmLabel={t('unclients.list.confirmDelete')}
+        cancelLabel={t('common.cancel')}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={() => {
+          if (confirmDelete) {
+            deleteMutation.mutate(confirmDelete.id);
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default UnclientsTable;

--- a/frontend/src/components/common/GlobalSpinner.tsx
+++ b/frontend/src/components/common/GlobalSpinner.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from 'lucide-react';
+
+const GlobalSpinner: React.FC = () => (
+  <div className="flex items-center justify-center py-12">
+    <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+  </div>
+);
+
+export default GlobalSpinner;

--- a/frontend/src/pages/ClientsPage.tsx
+++ b/frontend/src/pages/ClientsPage.tsx
@@ -1,28 +1,24 @@
- 
-const ClientList = lazy(() => import('@/components/ClientsAndUnClients/clients/index.tsx'));
+import { Suspense, lazy } from 'react';
+import { FaUserTie } from 'react-icons/fa';
+
+import GlobalSpinner from '@/components/common/GlobalSpinner';
+
+const ClientList = lazy(() => import('@/components/clientsAndUnclients/Clients'));
 
 const ClientPage: React.FC = () => {
   return (
-    <section className="flex flex-col items-center justify-start min-h-screen bg-gray-100 dark:bg-gray-900 p-6">
-      <div className="flex space-x-4 bg-white dark:bg-gray-800 shadow-md rounded-lg p-2 mt-4">
-        <button
-          className="flex items-center px-6 py-3 rounded-lg transition-all duration-300 text-lg font-medium cursor-pointer bg-gradient-to-r from-pink-500 to-purple-500 text-white shadow-lg"
-        >
-          <span className="text-2xl mr-2">
+    <section className="flex min-h-screen flex-col items-center justify-start bg-gray-100 p-6 dark:bg-gray-900">
+      <div className="mt-4 flex space-x-4 rounded-lg bg-white p-2 shadow-md dark:bg-gray-800">
+        <button className="flex cursor-pointer items-center rounded-lg bg-gradient-to-r from-pink-500 to-purple-500 px-6 py-3 text-lg font-medium text-white shadow-lg transition-all duration-300">
+          <span className="mr-2 text-2xl">
             <FaUserTie />
           </span>
           عملاء بوكالة
         </button>
       </div>
 
-      <Suspense
-        fallback={
-          <div className="text-center text-gray-500">
-            <GlobalSpinner />
-          </div>
-        }
-      >
-        <div className="mt-8 w-full max-w-5xl p-6 bg-white dark:bg-gray-800 rounded-lg shadow-md">
+      <Suspense fallback={<GlobalSpinner />}>
+        <div className="mt-8 w-full max-w-5xl rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
           <ClientList />
         </div>
       </Suspense>

--- a/frontend/src/pages/UnClientsPage.tsx
+++ b/frontend/src/pages/UnClientsPage.tsx
@@ -1,28 +1,24 @@
- 
-const UnClientList = lazy(() => import('../components/ClientsAndUnClients/unclients/index.tsx'));
+import { Suspense, lazy } from 'react';
+import { FaUserAltSlash } from 'react-icons/fa';
+
+import GlobalSpinner from '@/components/common/GlobalSpinner';
+
+const UnClientList = lazy(() => import('@/components/clientsAndUnclients/UnClients'));
 
 const UnClientPage: React.FC = () => {
   return (
-    <section className="flex flex-col items-center justify-start min-h-screen bg-gray-100 dark:bg-gray-900 p-6">
-      <div className="flex space-x-4 bg-white dark:bg-gray-800 shadow-md rounded-lg p-2 mt-4">
-        <button
-          className="flex items-center px-6 py-3 rounded-lg transition-all duration-300 text-lg font-medium cursor-pointer bg-gradient-to-r from-pink-500 to-purple-500 text-white shadow-lg"
-        >
-          <span className="text-2xl mr-2">
+    <section className="flex min-h-screen flex-col items-center justify-start bg-gray-100 p-6 dark:bg-gray-900">
+      <div className="mt-4 flex space-x-4 rounded-lg bg-white p-2 shadow-md dark:bg-gray-800">
+        <button className="flex cursor-pointer items-center rounded-lg bg-gradient-to-r from-pink-500 to-purple-500 px-6 py-3 text-lg font-medium text-white shadow-lg transition-all duration-300">
+          <span className="mr-2 text-2xl">
             <FaUserAltSlash />
           </span>
           عملاء بدون وكالة
         </button>
       </div>
 
-      <Suspense
-        fallback={
-          <div className="text-center text-gray-500">
-            <GlobalSpinner />
-          </div>
-        }
-      >
-        <div className="mt-8 w-full max-w-5xl p-6 bg-white dark:bg-gray-800 rounded-lg shadow-md">
+      <Suspense fallback={<GlobalSpinner />}>
+        <div className="mt-8 w-full max-w-5xl rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
           <UnClientList />
         </div>
       </Suspense>


### PR DESCRIPTION
## Summary
- add a reusable global spinner component for suspense fallbacks
- implement unclient CRUD dialog and data table mirroring the clients flow
- fix client and unclient pages to lazy-load the correct components with loading states

## Testing
- npm run lint *(fails: pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb764115c83289768e73bb3ccc57e