### PR TITLE
Fix clients and unclients table rendering

### DIFF
--- a/frontend/src/components/clientsAndUnclients/ClientsTable.tsx
+++ b/frontend/src/components/clientsAndUnclients/ClientsTable.tsx
@@ -140,14 +140,54 @@ const ClientsTable = () => {
 
   return (
     <>
-  <DetailsTable 
-  data={clients} // Change from unclients to clients
-  columns={columns} // Pass the columns configuration
-  enableSorting
-  enableSearch
-  emptyMessage={t('clients.list.noClientsFound')} // Make sure this is added as well
-/>
-
+      <DetailsTable
+        data={clients}
+        columns={columns}
+        enableSorting
+        enableSearch
+        enableExport
+        enablePagination
+        exportFileName="clients"
+        isLoading={clientsQuery.isLoading}
+        emptyMessage={
+          clientsQuery.isLoading ? t('common.loading') : t('clients.list.empty')
+        }
+        onAdd={() => openDialog('create')}
+        addButtonLabel={t('clients.list.add')}
+        actionsHeader={t('clients.list.table.actions')}
+        renderActions={(client) => (
+          <div className="flex items-center justify-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => openDialog('view', client)}
+            >
+              <Eye className="h-4 w-4" />
+              <span className="sr-only">{t('clients.list.actions.view')}</span>
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => openDialog('edit', client)}
+            >
+              <Pencil className="h-4 w-4" />
+              <span className="sr-only">{t('clients.list.actions.edit')}</span>
+            </Button>
+            <Button
+              variant="destructive"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => setConfirmDelete(client)}
+              disabled={deleteMutation.isPending}
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="sr-only">{t('clients.list.actions.delete')}</span>
+            </Button>
+          </div>
+        )}
+      />
 
       <ClientFormDialog
         open={dialogOpen}
@@ -159,7 +199,11 @@ const ClientsTable = () => {
 
       <ConfirmDialog
         open={!!confirmDelete}
-        title={confirmDelete ? t('clients.list.confirmDeleteTitle', { name: confirmDelete.name }) : ''}
+        title={
+          confirmDelete
+            ? t('clients.list.confirmDeleteTitle', { name: confirmDelete.name })
+            : ''
+        }
         description={t('clients.list.confirmDeleteDescription')}
         confirmLabel={t('clients.list.confirmDelete')}
         cancelLabel={t('common.cancel')}

--- a/frontend/src/components/clientsAndUnclients/UnclientsTable.tsx
+++ b/frontend/src/components/clientsAndUnclients/UnclientsTable.tsx
@@ -100,7 +100,7 @@ const UnclientsTable = () => {
 
   return (
     <>
-      <DetailsTable<Unclient>
+      <DetailsTable
         data={unclients}
         columns={columns}
         enableSorting


### PR DESCRIPTION
## Summary
- restore the clients table layout so it renders the details table with actions and dialogs correctly
- adjust the unclients table invocation to avoid lov overlay instrumentation corrupting the JSX

## Testing
- pnpm lint *(fails: existing eslint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf8e46fc083288ec8478b67633405