### PR TITLE
Refine client management hooks and types

### DIFF
--- a/frontend/src/components/clientsAndUnclients/ClientFormDialog.tsx
+++ b/frontend/src/components/clientsAndUnclients/ClientFormDialog.tsx
@@ -12,8 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useToast } from '@/components/ui/use-toast';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { createClient, updateClient } from '@/api/clients.service';
-import type { Client } from '@/types/clients';
-import type { ClientFormMode } from './types';
+import type { Client, ClientFormMode } from '@/types/clients';
 
 interface ClientFormDialogProps {
   open: boolean;

--- a/frontend/src/components/clientsAndUnclients/ClientsTable.tsx
+++ b/frontend/src/components/clientsAndUnclients/ClientsTable.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Eye, Pencil, Trash2 } from 'lucide-react';
 
 import DetailsTable, { DetailsTableColumn } from '@/components/common/DetailsTable';
@@ -8,13 +8,11 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { useLanguage } from '@/contexts/LanguageContext';
 import {
-  getClients,
   updateClient,
-  deleteClient,
 } from '@/api/clients.service';
-import type { Client } from '@/types/clients';
+import { useClients, useDeleteClient } from '@/hooks/useClients';
+import type { Client, ClientFormMode } from '@/types/clients';
 import ClientFormDialog from './ClientFormDialog';
-import type { ClientFormMode } from './types';
 
 const statusLabelKey: Record<Client['status'], string> = {
   active: 'clients.status.active',
@@ -30,35 +28,16 @@ const ClientsTable = () => {
   const { t } = useLanguage();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { clients, isLoading: isClientsLoading } = useClients();
+  const {
+    deleteClient: deleteClientMutation,
+    isLoading: isDeletingClient,
+  } = useDeleteClient();
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<ClientFormMode>('create');
   const [selectedClient, setSelectedClient] = useState<Client | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<Client | null>(null);
-
-  const clientsQuery = useQuery({
-    queryKey: ['clients'],
-    queryFn: async () => {
-      const { data } = await getClients();
-      return data ?? [];
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => deleteClient(String(id)),
-    onSuccess: () => {
-      toast({ title: t('clients.messages.deleteSuccess') });
-      queryClient.invalidateQueries({ queryKey: ['clients'] });
-    },
-    onError: () => {
-      toast({
-        title: t('clients.messages.deleteErrorTitle'),
-        description: t('clients.messages.deleteErrorDescription'),
-        variant: 'destructive',
-      });
-    },
-    onSettled: () => setConfirmDelete(null),
-  });
 
   const toggleStatusMutation = useMutation({
     mutationFn: (client: Client) =>
@@ -77,7 +56,7 @@ const ClientsTable = () => {
     },
   });
 
-  const clients = clientsQuery.data ?? [];
+  const safeClients = clients ?? [];
 
   const columns = useMemo<DetailsTableColumn<Client>[]>(
     () => [
@@ -141,16 +120,16 @@ const ClientsTable = () => {
   return (
     <>
       <DetailsTable
-        data={clients}
+        data={safeClients}
         columns={columns}
         enableSorting
         enableSearch
         enableExport
         enablePagination
         exportFileName="clients"
-        isLoading={clientsQuery.isLoading}
+        isLoading={isClientsLoading}
         emptyMessage={
-          clientsQuery.isLoading ? t('common.loading') : t('clients.list.empty')
+          isClientsLoading ? t('common.loading') : t('clients.list.empty')
         }
         onAdd={() => openDialog('create')}
         addButtonLabel={t('clients.list.add')}
@@ -180,7 +159,7 @@ const ClientsTable = () => {
               size="icon"
               className="h-8 w-8"
               onClick={() => setConfirmDelete(client)}
-              disabled={deleteMutation.isPending}
+              disabled={isDeletingClient}
             >
               <Trash2 className="h-4 w-4" />
               <span className="sr-only">{t('clients.list.actions.delete')}</span>
@@ -210,7 +189,19 @@ const ClientsTable = () => {
         onClose={() => setConfirmDelete(null)}
         onConfirm={() => {
           if (confirmDelete) {
-            deleteMutation.mutate(confirmDelete.id);
+            deleteClientMutation(String(confirmDelete.id), {
+              onSuccess: () => {
+                toast({ title: t('clients.messages.deleteSuccess') });
+              },
+              onError: () => {
+                toast({
+                  title: t('clients.messages.deleteErrorTitle'),
+                  description: t('clients.messages.deleteErrorDescription'),
+                  variant: 'destructive',
+                });
+              },
+              onSettled: () => setConfirmDelete(null),
+            });
           }
         }}
       />

--- a/frontend/src/components/clientsAndUnclients/types.ts
+++ b/frontend/src/components/clientsAndUnclients/types.ts
@@ -1,8 +1,9 @@
-import type { Client } from '@/types/clients';
+import type { Client, ClientFormMode } from '@/types/clients';
 import type { Unclient } from '@/types/unclients';
 
-export type ClientFormMode = 'create' | 'edit' | 'view';
 export type UnclientFormMode = 'create' | 'edit' | 'view';
 
 export type ClientRecord = Client;
 export type UnclientRecord = Unclient;
+
+export type { ClientFormMode };

--- a/frontend/src/hooks/useClients.ts
+++ b/frontend/src/hooks/useClients.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { deleteClient, getClients } from '@/api/clients.service';
+import type { Client } from '@/types/clients';
+
+export const useClients = () => {
+  const { data, isLoading, isError, error } = useQuery<Client[], Error>({
+    queryKey: ['clients'],
+    queryFn: async () => {
+      const response = await getClients();
+      return response.data ?? [];
+    },
+  });
+
+  return {
+    clients: data,
+    isLoading,
+    isError,
+    error,
+  };
+};
+
+export const useDeleteClient = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isLoading, isError, error } = useMutation<void, Error, string>({
+    mutationFn: async (clientId: string) => {
+      await deleteClient(clientId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['clients'] });
+    },
+    onError: (deleteError) => {
+      console.error('Delete error:', deleteError);
+    },
+  });
+
+  return {
+    deleteClient: mutate,
+    isLoading,
+    isError,
+    error,
+  };
+};

--- a/frontend/src/types/clients.ts
+++ b/frontend/src/types/clients.ts
@@ -1,3 +1,5 @@
+export type ClientFormMode = 'create' | 'edit' | 'view';
+
 export interface Client {
   id: number;
   slug: string;


### PR DESCRIPTION
## Summary
- expose the ClientFormMode union alongside the Client interface for reuse across the app
- update client form and table components to consume the shared type and new client data hooks
- add dedicated useClients and useDeleteClient hooks to centralize client fetching and mutation logic

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0ea25c78832884a8cd35613a045c