### PR TITLE
Fix translation namespace configuration

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -20,8 +20,10 @@ i18n
   .init({
     resources,
     fallbackLng: 'en',
+    ns: ['common'],
+    defaultNS: 'common',
     debug: false,
-    
+
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
## Summary
- set the default i18next namespace to `common` so translation keys like `auth.login.*` resolve correctly

## Testing
- `npm run lint` *(fails: pre-existing lint errors for unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf64a1a4348328917b64d6050c2630