### PR TITLE
feat: add office settings page with expense categories management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { LawyerDetails, LawyersList } from '@/pages/LawyersPage';
 import Login from '@/pages/Login';
 import NotFound from '@/pages/NotFound';
 import ServicesPage from '@/pages/ServicesPage';
+import OfficeSettingsPage from '@/pages/OfficeSettingsPage';
 import Signup from '@/pages/Signup';
 import UnClientsPage from '@/pages/UnClientsPage';
 
@@ -65,7 +66,7 @@ const App = () => {
           <Route path="procedures" element={<DashboardPlaceholder sectionKey="procedures" />} />
           <Route path="reports" element={<DashboardPlaceholder sectionKey="reports" />} />
           <Route path="settings" element={<DashboardPlaceholder sectionKey="settings" />} />
-          <Route path="office_settings" element={<DashboardPlaceholder sectionKey="office_settings" />} />
+          <Route path="office_settings" element={<OfficeSettingsPage />} />
           <Route path="users_roles" element={<DashboardPlaceholder sectionKey="users_roles" />} />
           <Route path="archive" element={<DashboardPlaceholder sectionKey="archive" />} />
           <Route path="courts_search" element={<DashboardPlaceholder sectionKey="courts_search" />} />

--- a/frontend/src/api/officeSettings.service.ts
+++ b/frontend/src/api/officeSettings.service.ts
@@ -1,0 +1,56 @@
+import api from '@/api/axiosConfig';
+
+export interface ExpenseCategory {
+  id: number;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ExpenseCategoryInput {
+  name: string;
+}
+
+const extractCollection = <T>(raw: unknown): T[] => {
+  if (Array.isArray(raw)) {
+    if (raw.length === 1 && Array.isArray(raw[0])) {
+      return raw[0] as T[];
+    }
+
+    if (raw.every((item) => typeof item === 'object' || typeof item === 'string')) {
+      return raw as T[];
+    }
+  }
+
+  if (raw && typeof raw === 'object') {
+    const record = raw as Record<string, unknown>;
+    if (Array.isArray(record.data)) {
+      return record.data as T[];
+    }
+    if (Array.isArray(record.items)) {
+      return record.items as T[];
+    }
+  }
+
+  return [];
+};
+
+export const getExpenseCategories = async (): Promise<ExpenseCategory[]> => {
+  const { data } = await api.get('/api/expense_categories');
+  return extractCollection<ExpenseCategory>(data);
+};
+
+export const createExpenseCategory = async (payload: ExpenseCategoryInput) => {
+  const { data } = await api.post('/api/expense_categories', payload);
+  return data as ExpenseCategory;
+};
+
+export const updateExpenseCategory = async (id: number, payload: ExpenseCategoryInput) => {
+  const { data } = await api.put(`/api/expense_categories/${id}`, payload);
+  return data as ExpenseCategory;
+};
+
+export const deleteExpenseCategory = async (id: number) => {
+  await api.delete(`/api/expense_categories/${id}`);
+};
+

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -917,6 +917,78 @@
     "dateRange": "نطاق التاريخ",
     "generate": "إنشاء تقرير"
   },
+  "officeSettings": {
+    "title": "إعدادات المكتب",
+    "subtitle": "قم بضبط الموارد المشتركة المستخدمة في مكتبك.",
+    "actions": {
+      "refresh": "تحديث البيانات"
+    },
+    "tabs": {
+      "expenseCategories": "أنواع المصروفات",
+      "generalSettings": "الإعدادات العامة",
+      "serviceTypes": "أنواع الخدمات",
+      "procedurePlaceTypes": "أماكن الإجراءات",
+      "procedureTypes": "أنواع الإجراءات"
+    },
+    "expenseCategories": {
+      "title": "أنواع المصروفات",
+      "description": "أنشئ وعدل التصنيفات التي تجمع مصروفات المكتب.",
+      "add": "إضافة نوع",
+      "table": {
+        "name": "اسم النوع",
+        "actions": "الإجراءات",
+        "empty": "لا توجد أنواع مصروفات مسجلة.",
+        "error": "تعذّر تحميل أنواع المصروفات، يرجى إعادة المحاولة."
+      },
+      "pagination": {
+        "label": "الصفحة {{current}} من {{total}}"
+      },
+      "dialog": {
+        "createTitle": "إضافة نوع مصروف",
+        "editTitle": "تعديل نوع المصروف"
+      },
+      "form": {
+        "nameLabel": "اسم نوع المصروف",
+        "namePlaceholder": "أدخل اسم نوع المصروف",
+        "submitCreate": "إضافة",
+        "submitUpdate": "حفظ التعديلات"
+      },
+      "delete": {
+        "title": "حذف {{name}}؟",
+        "description": "لا يمكن التراجع عن هذه العملية، سيتم حذف النوع نهائيًا."
+      },
+      "messages": {
+        "createSuccess": "تم إنشاء نوع المصروف بنجاح.",
+        "updateSuccess": "تم تحديث نوع المصروف بنجاح.",
+        "deleteSuccess": "تم حذف نوع المصروف بنجاح.",
+        "saveErrorTitle": "تعذّر حفظ نوع المصروف",
+        "saveErrorDescription": "يرجى مراجعة البيانات والمحاولة مرة أخرى.",
+        "deleteErrorTitle": "تعذّر حذف نوع المصروف",
+        "deleteErrorDescription": "يرجى المحاولة لاحقًا."
+      }
+    },
+    "placeholders": {
+      "shared": {
+        "message": "نقوم حالياً بتجهيز هذه الشاشة، ترقّبوا المزيد!"
+      },
+      "generalSettings": {
+        "title": "الإعدادات العامة",
+        "description": "أدر تفاصيل وتفضيلات المكتب المشتركة."
+      },
+      "serviceTypes": {
+        "title": "أنواع الخدمات",
+        "description": "عرّف أنواع الخدمات التي يقدمها المكتب."
+      },
+      "procedurePlaceTypes": {
+        "title": "أماكن الإجراءات",
+        "description": "حافظ على قائمة أماكن الإجراءات ضمن سير عملك."
+      },
+      "procedureTypes": {
+        "title": "أنواع الإجراءات",
+        "description": "نظّم أنواع الإجراءات المستخدمة في إدارة القضايا."
+      }
+    }
+  },
   "settings": {
     "title": "الإعدادات",
     "profile": "إعدادات الملف الشخصي",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -914,6 +914,78 @@
     "dateRange": "Date Range",
     "generate": "Generate Report"
   },
+  "officeSettings": {
+    "title": "Office settings",
+    "subtitle": "Configure shared resources used across your office.",
+    "actions": {
+      "refresh": "Refresh data"
+    },
+    "tabs": {
+      "expenseCategories": "Expense categories",
+      "generalSettings": "General settings",
+      "serviceTypes": "Service types",
+      "procedurePlaceTypes": "Procedure place types",
+      "procedureTypes": "Procedure types"
+    },
+    "expenseCategories": {
+      "title": "Expense categories",
+      "description": "Create and update the categories that group office expenses.",
+      "add": "Add category",
+      "table": {
+        "name": "Category name",
+        "actions": "Actions",
+        "empty": "No expense categories found.",
+        "error": "We couldn't load expense categories. Try refreshing."
+      },
+      "pagination": {
+        "label": "Page {{current}} of {{total}}"
+      },
+      "dialog": {
+        "createTitle": "Add expense category",
+        "editTitle": "Edit expense category"
+      },
+      "form": {
+        "nameLabel": "Category name",
+        "namePlaceholder": "Enter category name",
+        "submitCreate": "Create",
+        "submitUpdate": "Save changes"
+      },
+      "delete": {
+        "title": "Delete {{name}}?",
+        "description": "This action cannot be undone. The category will be permanently removed."
+      },
+      "messages": {
+        "createSuccess": "Expense category created successfully.",
+        "updateSuccess": "Expense category updated successfully.",
+        "deleteSuccess": "Expense category deleted successfully.",
+        "saveErrorTitle": "Unable to save expense category",
+        "saveErrorDescription": "Please review the information and try again.",
+        "deleteErrorTitle": "Unable to delete expense category",
+        "deleteErrorDescription": "Please try again later."
+      }
+    },
+    "placeholders": {
+      "shared": {
+        "message": "We are preparing this section. Stay tuned!"
+      },
+      "generalSettings": {
+        "title": "General settings",
+        "description": "Manage office-wide details and preferences."
+      },
+      "serviceTypes": {
+        "title": "Service types",
+        "description": "Define the types of services that your office provides."
+      },
+      "procedurePlaceTypes": {
+        "title": "Procedure place types",
+        "description": "Maintain the list of procedure locations for your workflow."
+      },
+      "procedureTypes": {
+        "title": "Procedure types",
+        "description": "Organize the procedure types used in case management."
+      }
+    }
+  },
   "settings": {
     "title": "Settings",
     "profile": "Profile Settings",

--- a/frontend/src/pages/OfficeSettingsPage.tsx
+++ b/frontend/src/pages/OfficeSettingsPage.tsx
@@ -1,0 +1,417 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Building2, Pencil, Plus, Settings2, Trash2 } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import PageHeader from '@/components/common/PageHeader';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useToast } from '@/components/ui/use-toast';
+import { cn } from '@/lib/utils';
+import {
+  createExpenseCategory,
+  deleteExpenseCategory,
+  getExpenseCategories,
+  updateExpenseCategory,
+  type ExpenseCategory,
+} from '@/api/officeSettings.service';
+
+const ITEMS_PER_PAGE = 5;
+
+type ExpenseCategoryDialogMode = 'create' | 'edit';
+
+const ExpenseCategoriesSection = () => {
+  const { t, isRTL } = useLanguage();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<ExpenseCategoryDialogMode>('create');
+  const [selectedCategory, setSelectedCategory] = useState<ExpenseCategory | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<ExpenseCategory | null>(null);
+  const [page, setPage] = useState(1);
+  const [name, setName] = useState('');
+
+  const expenseCategoriesQuery = useQuery({
+    queryKey: ['expense-categories'],
+    queryFn: getExpenseCategories,
+  });
+
+  const categories = useMemo(
+    () => expenseCategoriesQuery.data ?? [],
+    [expenseCategoriesQuery.data],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(categories.length / ITEMS_PER_PAGE));
+  const paginatedCategories = useMemo(
+    () => categories.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE),
+    [categories, page],
+  );
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
+
+  const handleOpenDialog = (mode: ExpenseCategoryDialogMode, category?: ExpenseCategory | null) => {
+    setDialogMode(mode);
+    setSelectedCategory(category ?? null);
+    setName(category?.name ?? '');
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setSelectedCategory(null);
+    setName('');
+  };
+
+  const createMutation = useMutation({
+    mutationFn: createExpenseCategory,
+    onSuccess: () => {
+      toast({ title: t('officeSettings.expenseCategories.messages.createSuccess') });
+      queryClient.invalidateQueries({ queryKey: ['expense-categories'] });
+      handleCloseDialog();
+    },
+    onError: () => {
+      toast({
+        title: t('officeSettings.expenseCategories.messages.saveErrorTitle'),
+        description: t('officeSettings.expenseCategories.messages.saveErrorDescription'),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: { id: number; name: string }) => updateExpenseCategory(payload.id, { name: payload.name }),
+    onSuccess: () => {
+      toast({ title: t('officeSettings.expenseCategories.messages.updateSuccess') });
+      queryClient.invalidateQueries({ queryKey: ['expense-categories'] });
+      handleCloseDialog();
+    },
+    onError: () => {
+      toast({
+        title: t('officeSettings.expenseCategories.messages.saveErrorTitle'),
+        description: t('officeSettings.expenseCategories.messages.saveErrorDescription'),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteExpenseCategory(id),
+    onSuccess: () => {
+      toast({ title: t('officeSettings.expenseCategories.messages.deleteSuccess') });
+      queryClient.invalidateQueries({ queryKey: ['expense-categories'] });
+    },
+    onError: () => {
+      toast({
+        title: t('officeSettings.expenseCategories.messages.deleteErrorTitle'),
+        description: t('officeSettings.expenseCategories.messages.deleteErrorDescription'),
+        variant: 'destructive',
+      });
+    },
+    onSettled: () => {
+      setPendingDelete(null);
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim()) {
+      return;
+    }
+
+    if (dialogMode === 'edit' && selectedCategory) {
+      updateMutation.mutate({ id: selectedCategory.id, name: name.trim() });
+    } else {
+      createMutation.mutate({ name: name.trim() });
+    }
+  };
+
+  const handleDelete = (category: ExpenseCategory) => {
+    setPendingDelete(category);
+  };
+
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader
+        className={cn(
+          'gap-2 sm:flex-row sm:items-center sm:justify-between',
+          isRTL ? 'text-right sm:flex-row-reverse' : 'text-left',
+        )}
+      >
+        <div className="space-y-1">
+          <CardTitle className="text-xl font-semibold">
+            {t('officeSettings.expenseCategories.title')}
+          </CardTitle>
+          <CardDescription>{t('officeSettings.expenseCategories.description')}</CardDescription>
+        </div>
+        <Button type="button" onClick={() => handleOpenDialog('create')}>
+          <Plus className="h-4 w-4" />
+          <span>{t('officeSettings.expenseCategories.add')}</span>
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-lg border border-border/60">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className={cn('w-2/3', isRTL ? 'text-right' : 'text-left')}>
+                  {t('officeSettings.expenseCategories.table.name')}
+                </TableHead>
+                <TableHead className={cn('w-1/3', isRTL ? 'text-left' : 'text-right')}>
+                  {t('officeSettings.expenseCategories.table.actions')}
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {expenseCategoriesQuery.isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={2} className="text-center">
+                    {t('common.loading')}
+                  </TableCell>
+                </TableRow>
+              ) : expenseCategoriesQuery.isError ? (
+                <TableRow>
+                  <TableCell colSpan={2} className="text-center text-destructive">
+                    {t('officeSettings.expenseCategories.table.error')}
+                  </TableCell>
+                </TableRow>
+              ) : paginatedCategories.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={2} className="text-center text-muted-foreground">
+                    {t('officeSettings.expenseCategories.table.empty')}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                paginatedCategories.map((category) => (
+                  <TableRow key={category.id}>
+                    <TableCell className={cn('font-medium', isRTL ? 'text-right' : 'text-left')}>
+                      {category.name}
+                    </TableCell>
+                    <TableCell className={cn(isRTL ? 'text-left' : 'text-right')}>
+                      <div
+                        className={cn(
+                          'flex items-center gap-2',
+                          isRTL ? 'justify-start' : 'justify-end',
+                        )}
+                      >
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleOpenDialog('edit', category)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                          <span className="text-sm">{t('common.edit')}</span>
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => handleDelete(category)}
+                          disabled={deleteMutation.isPending && pendingDelete?.id === category.id}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          <span className="text-sm">{t('common.delete')}</span>
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <div
+          className={cn(
+            'flex flex-col gap-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between',
+            isRTL ? 'sm:flex-row-reverse' : '',
+          )}
+        >
+          <span>
+            {t('officeSettings.expenseCategories.pagination.label', {
+              current: page,
+              total: totalPages,
+            })}
+          </span>
+          <div className={cn('flex items-center gap-2', isRTL ? 'flex-row-reverse' : '')}>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+              disabled={page === 1}
+            >
+              {t('table.previous')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+              disabled={page === totalPages}
+            >
+              {t('table.next')}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+
+      <Dialog open={dialogOpen} onOpenChange={(open) => (!open ? handleCloseDialog() : setDialogOpen(open))}>
+        <DialogContent dir={isRTL ? 'rtl' : 'ltr'}>
+          <DialogHeader className={isRTL ? 'text-right' : 'text-left'}>
+            <DialogTitle>
+              {dialogMode === 'edit'
+                ? t('officeSettings.expenseCategories.dialog.editTitle')
+                : t('officeSettings.expenseCategories.dialog.createTitle')}
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="expense-category-name">
+                {t('officeSettings.expenseCategories.form.nameLabel')}
+              </Label>
+              <Input
+                id="expense-category-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder={t('officeSettings.expenseCategories.form.namePlaceholder')}
+                autoFocus
+              />
+            </div>
+            <DialogFooter
+              className={cn(
+                'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2',
+                isRTL ? 'sm:flex-row-reverse sm:space-x-reverse' : '',
+              )}
+            >
+              <Button type="button" variant="outline" onClick={handleCloseDialog} disabled={isSubmitting}>
+                {t('common.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {dialogMode === 'edit'
+                  ? t('officeSettings.expenseCategories.form.submitUpdate')
+                  : t('officeSettings.expenseCategories.form.submitCreate')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        title={t('officeSettings.expenseCategories.delete.title', {
+          name: pendingDelete?.name ?? '',
+        })}
+        description={t('officeSettings.expenseCategories.delete.description')}
+        confirmLabel={t('common.delete')}
+        cancelLabel={t('common.cancel')}
+        onConfirm={() => pendingDelete && deleteMutation.mutate(pendingDelete.id)}
+        onClose={() => setPendingDelete(null)}
+      />
+    </Card>
+  );
+};
+
+const PlaceholderSection = ({ section }: { section: 'generalSettings' | 'serviceTypes' | 'procedurePlaceTypes' | 'procedureTypes' }) => {
+  const { t, isRTL } = useLanguage();
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className={cn('space-y-2', isRTL ? 'text-right' : 'text-left')}>
+        <CardTitle>{t(`officeSettings.placeholders.${section}.title`)}</CardTitle>
+        <CardDescription>{t(`officeSettings.placeholders.${section}.description`)}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          {t('officeSettings.placeholders.shared.message')}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const OfficeSettingsPage = () => {
+  const { t, isRTL } = useLanguage();
+  const queryClient = useQueryClient();
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ['expense-categories'] });
+  };
+
+  return (
+    <div className="space-y-6" dir={isRTL ? 'rtl' : 'ltr'}>
+      <PageHeader
+        icon={<Building2 className="h-6 w-6" />}
+        title={t('officeSettings.title')}
+        subtitle={t('officeSettings.subtitle')}
+        actions={
+          <Button type="button" variant="outline" onClick={handleRefresh}>
+            <Settings2 className="h-4 w-4" />
+            <span>{t('officeSettings.actions.refresh')}</span>
+          </Button>
+        }
+      />
+
+      <Tabs defaultValue="expenseCategories" dir={isRTL ? 'rtl' : 'ltr'} className="space-y-6">
+        <TabsList
+          className={cn(
+            'flex w-full flex-wrap gap-2 rounded-md border border-border/60 bg-muted/40 p-1',
+            isRTL ? 'justify-end' : 'justify-start',
+          )}
+        >
+          <TabsTrigger value="expenseCategories" className="flex-1 sm:flex-none">
+            {t('officeSettings.tabs.expenseCategories')}
+          </TabsTrigger>
+          <TabsTrigger value="generalSettings" className="flex-1 sm:flex-none">
+            {t('officeSettings.tabs.generalSettings')}
+          </TabsTrigger>
+          <TabsTrigger value="serviceTypes" className="flex-1 sm:flex-none">
+            {t('officeSettings.tabs.serviceTypes')}
+          </TabsTrigger>
+          <TabsTrigger value="procedurePlaceTypes" className="flex-1 sm:flex-none">
+            {t('officeSettings.tabs.procedurePlaceTypes')}
+          </TabsTrigger>
+          <TabsTrigger value="procedureTypes" className="flex-1 sm:flex-none">
+            {t('officeSettings.tabs.procedureTypes')}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="expenseCategories">
+          <ExpenseCategoriesSection />
+        </TabsContent>
+        <TabsContent value="generalSettings">
+          <PlaceholderSection section="generalSettings" />
+        </TabsContent>
+        <TabsContent value="serviceTypes">
+          <PlaceholderSection section="serviceTypes" />
+        </TabsContent>
+        <TabsContent value="procedurePlaceTypes">
+          <PlaceholderSection section="procedurePlaceTypes" />
+        </TabsContent>
+        <TabsContent value="procedureTypes">
+          <PlaceholderSection section="procedureTypes" />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default OfficeSettingsPage;


### PR DESCRIPTION
## Summary
- add a dashboard office settings page with tabbed navigation and rtl-aware layout
- implement expense categories CRUD management with react-query, dialogs, and confirmations
- extend english and arabic locale files and add an API helper for expense categories

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf70f672d083289f69bfbe592ae605