### PR TITLE
refactor: align frontend styling with design tokens

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -13,8 +13,8 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-hero flex items-center justify-center">
-        <div className="text-center text-white">
+      <div className="min-h-screen bg-gradient-hero flex items-center justify-center text-text-inverse">
+        <div className="text-center">
           <div className="h-8 w-8 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
           <p>{t('common.loading')}</p>
         </div>

--- a/frontend/src/components/common/DetailsTable.tsx
+++ b/frontend/src/components/common/DetailsTable.tsx
@@ -276,7 +276,7 @@ const DetailsTable = <T,>({
   const showingTo = enablePagination ? Math.min(page * pageSize, totalItems) : totalItems;
 
   return (
-    <div className="rounded-lg border border-border/60 bg-card/40 shadow-sm">
+    <div className="rounded-lg border border-border/60 bg-card/40 shadow-card">
       {controlsVisible && (
         <div className="flex flex-col gap-3 border-b border-border/60 bg-muted/30 px-4 py-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">

--- a/frontend/src/components/common/KpiCard.tsx
+++ b/frontend/src/components/common/KpiCard.tsx
@@ -34,15 +34,15 @@ const KpiCard: React.FC<KpiCardProps> = ({
     >
       <Card className={cn(
         'relative overflow-hidden transition-all duration-300',
-        'hover:shadow-lg hover:shadow-primary/5',
-        'border-border/50 bg-card/50 backdrop-blur',
+        'hover:shadow-glow',
+        'border-border/50 bg-card/60 backdrop-blur',
         className
       )}>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium text-muted-foreground">
             {title}
           </CardTitle>
-          <div className="h-8 w-8 rounded-lg bg-primary/10 flex items-center justify-center">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15">
             <Icon className="h-4 w-4 text-primary" />
           </div>
         </CardHeader>
@@ -52,10 +52,7 @@ const KpiCard: React.FC<KpiCardProps> = ({
           </div>
           {change && (
             <p className="text-xs text-muted-foreground">
-              <span className={cn(
-                'font-medium',
-                isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-              )}>
+              <span className={cn('font-medium', isPositive ? 'text-success' : 'text-destructive')}>
                 {isPositive ? '+' : ''}{change.value}%
               </span>
               {' '}

--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -9,7 +9,7 @@ interface PageHeaderProps {
 
 const PageHeader = ({ icon, title, subtitle, actions }: PageHeaderProps) => {
   return (
-    <div className="rounded-2xl border border-border/60 bg-gradient-to-r from-primary/5 via-background to-background p-6 shadow-sm">
+    <div className="rounded-2xl border border-border/60 bg-gradient-to-r from-primary/5 via-background to-background p-6 shadow-card">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">

--- a/frontend/src/components/lawyers/LawyerDetails.tsx
+++ b/frontend/src/components/lawyers/LawyerDetails.tsx
@@ -131,7 +131,7 @@ const LawyerDetails = () => {
             </div>
           </div>
 
-          <div className="rounded-2xl border border-border/60 bg-surface-100/70 p-5">
+          <div className="rounded-2xl border border-border/60 bg-surface-highlight/70 p-5">
             <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
               {t('lawyers.detail.contact')}
             </h2>

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -92,7 +92,7 @@ const MobileDrawer: React.FC = () => {
             }}
             className={cn(
               'fixed top-0 z-50 h-full w-full max-w-[100vw] bg-sidebar-background border-border md:hidden',
-              'flex flex-col shadow-lg',
+              'flex flex-col shadow-card',
               isRTL ? 'right-0 border-l' : 'left-0 border-r'
             )}
           >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -141,7 +141,7 @@ const Sidebar = ({ isCollapsed, onToggle }: SidebarProps) => {
           cn(
             'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200',
             'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground glow-hover',
-            (isActive || itemActive) && 'bg-sidebar-primary text-sidebar-primary-foreground shadow-elegant',
+            (isActive || itemActive) && 'bg-sidebar-primary text-sidebar-primary-foreground shadow-card',
             indentation,
             isCollapsed && 'justify-center px-2',
           )

--- a/frontend/src/components/legalCases/Details/CaseSection.tsx
+++ b/frontend/src/components/legalCases/Details/CaseSection.tsx
@@ -51,7 +51,7 @@ const CaseSection = ({
   return (
     <section
       className={cn(
-        'rounded-2xl border border-border/60 bg-card/60 p-6 shadow-sm backdrop-blur',
+        'rounded-2xl border border-border/60 bg-card/60 p-6 shadow-card backdrop-blur',
         className,
       )}
     >

--- a/frontend/src/components/legalCases/Details/ClientsSection.tsx
+++ b/frontend/src/components/legalCases/Details/ClientsSection.tsx
@@ -175,7 +175,7 @@ const ClientsSection = ({ caseId, clients, onChanged }: ClientsSectionProps) => 
                 placeholder={t('legalCaseDetails.clients.searchPlaceholder')}
               />
               {searchTerm && filteredClients.length > 0 && (
-                <div className="max-h-48 overflow-y-auto rounded-md border border-border/60 bg-background shadow-sm">
+                <div className="max-h-48 overflow-y-auto rounded-md border border-border/60 bg-background shadow-card">
                   {filteredClients.map((option) => (
                     <button
                       key={option.id}

--- a/frontend/src/components/legalCases/Details/LegalCaseDetails.tsx
+++ b/frontend/src/components/legalCases/Details/LegalCaseDetails.tsx
@@ -130,7 +130,7 @@ const LegalCaseDetails = () => {
             variant="ghost"
             size="icon"
             onClick={() => navigate(-1)}
-            className="rounded-full border border-border/50 bg-surface-100/80 backdrop-blur-sm transition hover:border-primary/50 hover:bg-primary/10"
+              className="rounded-full border border-border/50 bg-surface-highlight/80 backdrop-blur-sm transition hover:border-primary/50 hover:bg-primary/10"
           >
             <ArrowLeft className="h-4 w-4" />
             <span className="sr-only">{t('legalCaseDetails.back')}</span>
@@ -166,7 +166,7 @@ const LegalCaseDetails = () => {
               hover="glow"
               className="relative overflow-hidden border border-border/60 bg-gradient-card/10 p-6 md:p-8"
             >
-              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(7, 123, 255, 0.18),transparent_45%)]" />
+              <div className="pointer-events-none absolute inset-0 bg-card-highlight" />
               <div className="relative grid gap-8 md:grid-cols-2">
                 <InfoList
                   title={t('legalCaseDetails.sections.basicInfo')}
@@ -183,7 +183,7 @@ const LegalCaseDetails = () => {
                     initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.35, delay: 0.15 }}
-                    className="md:col-span-2 rounded-2xl border border-border/60 bg-surface-100/80 p-5 shadow-inner"
+                    className="md:col-span-2 rounded-2xl border border-border/60 bg-surface-highlight/80 p-5 shadow-inner"
                   >
                     <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
                       {t('legalCaseDetails.fields.description')}
@@ -217,21 +217,21 @@ const LegalCaseDetails = () => {
               <TabsList className="flex flex-wrap justify-start gap-2 md:justify-center">
                 <TabsTrigger
                   value="procedures"
-                  className="group flex items-center gap-2 rounded-full border border-border/50 bg-surface-100/70 px-4 py-2 text-sm font-semibold text-muted-foreground transition data-[state=active]:border-primary/60 data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
+                  className="group flex items-center gap-2 rounded-full border border-border/50 bg-surface-highlight/70 px-4 py-2 text-sm font-semibold text-muted-foreground transition data-[state=active]:border-primary/60 data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
                 >
                   <ClipboardList className="h-4 w-4 transition group-data-[state=active]:text-primary" />
                   {t('legalCaseDetails.tabs.procedures')}
                 </TabsTrigger>
                 <TabsTrigger
                   value="sessions"
-                  className="group flex items-center gap-2 rounded-full border border-border/50 bg-surface-100/70 px-4 py-2 text-sm font-semibold text-muted-foreground transition data-[state=active]:border-primary/60 data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
+                  className="group flex items-center gap-2 rounded-full border border-border/50 bg-surface-highlight/70 px-4 py-2 text-sm font-semibold text-muted-foreground transition data-[state=active]:border-primary/60 data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
                 >
                   <CalendarClock className="h-4 w-4 transition group-data-[state=active]:text-primary" />
                   {t('legalCaseDetails.tabs.sessions')}
                 </TabsTrigger>
                 <TabsTrigger
                   value="ads"
-                  className="group flex items-center gap-2 rounded-full border border-border/50 bg-surface-100/70 px-4 py-2 text-sm font-semibold text-muted-foreground transition data-[state=active]:border-primary/60 data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
+                  className="group flex items-center gap-2 rounded-full border border-border/50 bg-surface-highlight/70 px-4 py-2 text-sm font-semibold text-muted-foreground transition data-[state=active]:border-primary/60 data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
                 >
                   <Megaphone className="h-4 w-4 transition group-data-[state=active]:text-primary" />
                   {t('legalCaseDetails.tabs.ads')}
@@ -282,10 +282,10 @@ const InfoList = ({
           initial={{ opacity: 0, y: 6 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, delay: index * 0.05 }}
-          className="group flex items-center gap-3 rounded-2xl border border-border/50 bg-surface-100/80 px-4 py-3 shadow-inner backdrop-blur-sm transition hover:border-primary/60 hover:bg-primary/5"
+          className="group flex items-center gap-3 rounded-2xl border border-border/50 bg-surface-highlight/80 px-4 py-3 shadow-inner backdrop-blur-sm transition hover:border-primary/60 hover:bg-primary/5"
         >
           {item.icon && (
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary shadow-sm">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary shadow-card">
               <item.icon className="h-5 w-5" aria-hidden="true" />
             </span>
           )}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-card duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,56 +4,32 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        // Primary
         default:
-          "bg-primary text-primary-foreground hover:bg-primary-hover shadow-md hover:shadow-lg",
-
-        // Accent (Secondary brand)
+          "bg-primary text-primary-foreground shadow-card hover:bg-primary-hover hover:shadow-glow",
         accent:
-          "bg-accent text-accent-foreground hover:bg-accent/90 shadow-md hover:shadow-lg",
-
-        // Secondary Neutral
+          "bg-accent text-accent-foreground shadow-card hover:bg-accent/90 hover:shadow-glow",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-
-        // Outline (transparent background)
+          "bg-secondary text-secondary-foreground shadow-card hover:bg-secondary/85",
         outline:
-          "border border-border bg-background text-foreground hover:bg-accent hover:text-accent-foreground",
-
-        // Ghost (like link but lighter)
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground text-foreground",
-
-        // Link style
-        link: "text-primary underline-offset-4 hover:underline",
-
-        // Destructive
+          "border border-border bg-transparent text-text-strong shadow-card hover:border-accent hover:bg-accent-soft hover:text-accent-foreground",
+        ghost: "text-text-muted hover:bg-surface-muted hover:text-text-strong",
+        link: "text-primary underline-offset-4 hover:text-primary/80 hover:underline",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-md hover:shadow-lg",
-
-        // Success
+          "bg-destructive text-destructive-foreground shadow-card hover:bg-destructive/90 hover:shadow-glow",
         success:
-          "bg-success text-success-foreground hover:bg-success/90 shadow-md hover:shadow-lg",
-
-        // Warning
+          "bg-success text-success-foreground shadow-card hover:bg-success/90 hover:shadow-glow",
         warning:
-          "bg-warning text-warning-foreground hover:bg-warning/90 shadow-md hover:shadow-lg",
-
-        // Hero (gradient primary)
+          "bg-warning text-warning-foreground shadow-card hover:bg-warning/90 hover:shadow-glow",
         hero:
-          "bg-gradient-primary text-white border-0 shadow-glow hover:scale-105 font-semibold",
-
-        // Glass style
+          "bg-gradient-hero text-text-inverse shadow-glow font-semibold hover:scale-102",
         glass:
-          "glass text-foreground hover:bg-accent/20 border-glass-border",
-
-        // Glow style
+          "glass text-text-strong shadow-card hover:border-accent/40 hover:shadow-glow",
         glow:
-          "bg-accent text-accent-foreground shadow-glow hover:scale-105 animate-pulseGlow",
+          "bg-accent text-accent-foreground shadow-glow hover:scale-102 animate-pulseGlow",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-card", className)} {...props} />
 ));
 Card.displayName = "Card";
 

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -160,7 +160,7 @@ const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-card",
           className,
         )}
       >

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+  <DialogContent className="overflow-hidden p-0 shadow-card">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -44,7 +44,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -60,7 +60,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-card animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-card duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -44,7 +44,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -61,7 +61,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/glass-card.tsx
+++ b/frontend/src/components/ui/glass-card.tsx
@@ -20,7 +20,7 @@ const glassCardVariants = cva(
       },
       hover: {
         none: "",
-        lift: "hover:scale-[1.02] hover:shadow-elegant",
+        lift: "hover:scale-[1.02] hover:shadow-card",
         glow: "hover:shadow-glow hover:border-accent/40",
         float: "hover:animate-float",
       }

--- a/frontend/src/components/ui/hover-card.tsx
+++ b/frontend/src/components/ui/hover-card.tsx
@@ -16,7 +16,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-card outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}

--- a/frontend/src/components/ui/menubar.tsx
+++ b/frontend/src/components/ui/menubar.tsx
@@ -88,7 +88,7 @@ const MenubarContent = React.forwardRef<
       alignOffset={alignOffset}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-card data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/navigation-menu.tsx
+++ b/frontend/src/components/ui/navigation-menu.tsx
@@ -80,7 +80,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className,
       )}
       ref={ref}
@@ -102,7 +102,7 @@ const NavigationMenuIndicator = React.forwardRef<
     )}
     {...props}
   >
-    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-card" />
   </NavigationMenuPrimitive.Indicator>
 ));
 NavigationMenuIndicator.displayName = NavigationMenuPrimitive.Indicator.displayName;

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-card outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -66,7 +66,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background p-6 shadow-card transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -13,7 +13,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-card",
           description: "group-[.toast]:text-muted-foreground",
           actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -17,7 +17,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-card ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
       )}
     />
   </SwitchPrimitives.Root>

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -23,7 +23,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-card transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-card animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,100 +1,328 @@
-@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap");
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Cyber-Legal Design System – Avocat */
+/* Cyber-Legal Design System – Foundations */
 
 @layer base {
   :root {
-    /* Base */
-    --color-background: 220 15% 97%;
-    --color-foreground: 220 30% 12%;
+    /* Surfaces & Structure */
+    --color-background: 220 18% 97%;
+    --color-foreground: 220 28% 12%;
+    --color-surface: 220 20% 99%;
+    --color-surface-muted: 220 18% 95%;
+    --color-surface-highlight: 220 20% 92%;
+    --color-card: 220 18% 98%;
+    --color-card-foreground: 220 30% 14%;
+    --color-popover: 0 0% 100%;
+    --color-popover-foreground: 220 28% 12%;
+    --color-border: 220 18% 85%;
+    --color-border-strong: 220 22% 70%;
+    --color-input: 220 18% 96%;
+    --color-ring: 200 85% 45%;
 
     /* Typography */
-    --color-text-strong: 220 28% 15%;
-    --color-text-body: 220 22% 25%;
-    --color-text-muted: 220 16% 42%;
-    --color-text-subtle: 220 12% 55%;
+    --color-text-strong: 220 30% 12%;
+    --color-text-body: 220 24% 26%;
+    --color-text-muted: 220 18% 45%;
+    --color-text-subtle: 220 16% 55%;
     --color-text-inverse: 0 0% 100%;
-
-    /* Surfaces */
-    --color-card: 220 15% 99%;
-    --color-card-foreground: 220 30% 12%;
-    --surface-glass: 220 15% 100% / 0.85;
-    --border-glass: 220 20% 88% / 0.35;
 
     /* Brand */
     --color-primary: 225 70% 23%;
     --color-primary-hover: 225 70% 20%;
     --color-primary-foreground: 220 15% 98%;
-
-    /* Accent */
+    --color-primary-soft: 225 70% 94%;
     --color-accent: 200 85% 45%;
     --color-accent-foreground: 220 15% 98%;
-    --color-accent-glow: 200 90% 45% / 0.25;
+    --color-accent-soft: 200 90% 92%;
+    --color-accent-glow: 200 90% 45% / 0.28;
 
     /* Semantic */
     --color-success: 145 55% 32%;
     --color-success-foreground: 0 0% 100%;
+    --color-success-soft: 145 55% 88%;
     --color-warning: 35 90% 52%;
-    --color-warning-foreground: 220 30% 12%;
+    --color-warning-foreground: 220 28% 12%;
+    --color-warning-soft: 35 95% 88%;
     --color-destructive: 0 70% 50%;
     --color-destructive-foreground: 0 0% 100%;
+    --color-destructive-soft: 0 75% 92%;
+    --color-secondary: 220 20% 90%;
+    --color-secondary-foreground: 220 30% 14%;
 
-    /* Gradients */
-    --gradient-primary: linear-gradient(135deg, hsl(var(--color-primary)), hsl(var(--color-accent)));
-    --gradient-hero: linear-gradient(135deg, hsl(225 85% 18%), hsl(200 90% 50%));
-    --gradient-card: linear-gradient(135deg, hsl(220 15% 99%), hsl(210 30% 92%));
+    /* Sidebar */
+    --color-sidebar-background: 220 18% 97%;
+    --color-sidebar-foreground: 220 30% 14%;
+    --color-sidebar-primary: 225 70% 23%;
+    --color-sidebar-primary-foreground: 220 15% 98%;
+    --color-sidebar-accent: 220 20% 94%;
+    --color-sidebar-accent-foreground: 220 30% 14%;
+    --color-sidebar-border: 220 18% 85%;
+    --color-sidebar-ring: 200 85% 45%;
 
-    /* Elevation */
-    --shadow-card: 0 10px 30px hsl(220 30% 12% / 0.08);
-    --shadow-glow: 0 0 25px hsl(var(--color-accent-glow));
-
-    /* Radius */
     --radius: 0.5rem;
     --radius-lg: 0.75rem;
-    --radius-xl: 1rem;
+    --radius-xl: 1.15rem;
+
+    /* Gradients & Special backgrounds */
+    --gradient-primary: linear-gradient(135deg, hsl(var(--color-primary)), hsl(var(--color-accent)));
+    --gradient-hero: linear-gradient(135deg, hsl(225 70% 20%), hsl(200 85% 45%));
+    --gradient-card: linear-gradient(135deg, hsl(220 20% 99%), hsl(210 24% 94%));
+    --gradient-glass: linear-gradient(135deg, hsla(0 0% 100% / 0.9), hsla(0 0% 100% / 0.7));
+    --gradient-success: linear-gradient(135deg, hsl(var(--color-success)), hsl(145 55% 42%));
+    --gradient-accent: linear-gradient(135deg, hsl(var(--color-accent)), hsl(195 95% 55%));
+    --gradient-warning: linear-gradient(135deg, hsl(var(--color-warning)), hsl(45 100% 60%));
+    --gradient-hero-overlay-light: radial-gradient(circle at 25% 20%, hsl(var(--color-accent) / 0.22), transparent 58%), radial-gradient(circle at 80% 15%, hsla(225 70% 30% / 0.18), transparent 60%);
+    --gradient-hero-overlay-dark: radial-gradient(circle at 25% 20%, hsla(190 100% 70% / 0.16), transparent 58%), radial-gradient(circle at 80% 10%, hsla(210 100% 65% / 0.25), transparent 65%);
+    --gradient-card-highlight: radial-gradient(circle at 22% 15%, hsla(0 0% 100% / 0.28), transparent 60%);
+
+    /* Glassmorphism */
+    --glass-background: 220 20% 99% / 0.78;
+    --glass-border: 220 26% 88% / 0.36;
+    --glass-highlight: 200 90% 65% / 0.22;
+    --glass-blur: 18px;
+
+    /* Elevation */
+    --shadow-card: 0 18px 45px -18px hsl(220 32% 16% / 0.18);
+    --shadow-glow: 0 0 35px hsl(var(--color-accent-glow));
+
+    /* Scrollbars */
+    --color-scrollbar-track: 220 18% 94%;
+    --color-scrollbar-thumb: 200 70% 72%;
   }
 
   .dark {
     --color-background: 225 25% 7%;
     --color-foreground: 220 15% 95%;
+    --color-surface: 225 25% 9%;
+    --color-surface-muted: 225 25% 12%;
+    --color-surface-highlight: 225 28% 16%;
+    --color-card: 225 25% 11%;
+    --color-card-foreground: 220 15% 95%;
+    --color-popover: 225 25% 10%;
+    --color-popover-foreground: 220 15% 92%;
+    --color-border: 225 22% 22%;
+    --color-border-strong: 225 28% 38%;
+    --color-input: 225 25% 14%;
+    --color-ring: 190 100% 70%;
 
     --color-text-strong: 0 0% 100%;
-    --color-text-body: 220 15% 85%;
-    --color-text-muted: 220 15% 65%;
+    --color-text-body: 220 15% 82%;
+    --color-text-muted: 220 16% 68%;
+    --color-text-subtle: 220 14% 58%;
     --color-text-inverse: 0 0% 100%;
-
-    --color-card: 225 25% 9%;
-    --color-card-foreground: 220 15% 95%;
 
     --color-primary: 200 90% 55%;
     --color-primary-hover: 200 90% 50%;
     --color-primary-foreground: 225 25% 7%;
-
+    --color-primary-soft: 200 90% 22%;
     --color-accent: 190 100% 70%;
-    --color-accent-foreground: 225 25% 7%;
-    --color-accent-glow: 190 100% 70% / 0.4;
+    --color-accent-foreground: 225 25% 10%;
+    --color-accent-soft: 190 100% 22%;
+    --color-accent-glow: 190 100% 70% / 0.42;
 
     --color-success: 145 55% 42%;
+    --color-success-foreground: 0 0% 100%;
+    --color-success-soft: 145 60% 22%;
     --color-warning: 35 90% 55%;
+    --color-warning-foreground: 225 25% 7%;
+    --color-warning-soft: 35 95% 25%;
     --color-destructive: 0 70% 55%;
+    --color-destructive-foreground: 0 0% 100%;
+    --color-destructive-soft: 0 75% 30%;
+    --color-secondary: 225 22% 18%;
+    --color-secondary-foreground: 220 15% 92%;
+
+    --color-sidebar-background: 225 25% 9%;
+    --color-sidebar-foreground: 220 15% 92%;
+    --color-sidebar-primary: 200 90% 55%;
+    --color-sidebar-primary-foreground: 225 25% 8%;
+    --color-sidebar-accent: 225 25% 13%;
+    --color-sidebar-accent-foreground: 220 15% 92%;
+    --color-sidebar-border: 225 22% 20%;
+    --color-sidebar-ring: 190 100% 70%;
 
     --gradient-primary: linear-gradient(135deg, hsl(225 70% 20%), hsl(200 85% 45%));
-    --gradient-hero: linear-gradient(135deg, hsl(225 25% 12%), hsl(200 80% 20%));
+    --gradient-hero: linear-gradient(135deg, hsl(225 25% 12%), hsl(200 80% 22%));
     --gradient-card: linear-gradient(135deg, hsl(225 25% 12%), hsl(200 25% 20%));
+    --gradient-glass: linear-gradient(135deg, hsla(225 25% 16% / 0.85), hsla(200 30% 18% / 0.72));
+    --gradient-success: linear-gradient(135deg, hsl(var(--color-success)), hsl(145 60% 48%));
+    --gradient-accent: linear-gradient(135deg, hsl(var(--color-accent)), hsl(190 95% 65%));
+    --gradient-warning: linear-gradient(135deg, hsl(var(--color-warning)), hsl(45 100% 62%));
+    --gradient-hero-overlay-light: radial-gradient(circle at 22% 18%, hsla(200 90% 60% / 0.25), transparent 58%), radial-gradient(circle at 82% 15%, hsla(190 100% 70% / 0.3), transparent 62%);
+    --gradient-hero-overlay-dark: radial-gradient(circle at 22% 18%, hsla(190 100% 70% / 0.25), transparent 60%), radial-gradient(circle at 80% 12%, hsla(200 90% 55% / 0.35), transparent 65%);
+    --gradient-card-highlight: radial-gradient(circle at 20% 18%, hsla(190 100% 70% / 0.18), transparent 65%);
 
-    --shadow-card: 0 10px 30px hsl(200 80% 40% / 0.15);
-    --shadow-glow: 0 0 35px hsl(var(--color-accent-glow));
+    --glass-background: 225 25% 12% / 0.68;
+    --glass-border: 200 40% 60% / 0.28;
+    --glass-highlight: 190 95% 65% / 0.28;
+    --glass-blur: 20px;
+
+    --radius: 0.5rem;
+    --radius-lg: 0.75rem;
+    --radius-xl: 1.15rem;
+
+    --shadow-card: 0 22px 60px -25px hsl(225 70% 5% / 0.65);
+    --shadow-glow: 0 0 45px hsl(var(--color-accent-glow));
+
+    --color-scrollbar-track: 225 22% 14%;
+    --color-scrollbar-thumb: 190 100% 60%;
+  }
+
+  *,
+  *::before,
+  *::after {
+    border-color: hsl(var(--color-border));
   }
 
   body {
-    @apply bg-background text-foreground font-inter antialiased;
+    @apply bg-background text-text-body antialiased font-inter;
+    background-image: none;
   }
 
-  [lang="ar"], [dir="rtl"] {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: hsl(var(--color-text-strong));
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  p,
+  span,
+  li {
+    color: hsl(var(--color-text-body));
+  }
+
+  strong {
+    color: hsl(var(--color-text-strong));
+  }
+
+  ::selection {
+    background-color: hsl(var(--color-accent) / 0.28);
+    color: hsl(var(--color-text-inverse));
+  }
+
+  :root {
+    color-scheme: light;
+  }
+
+  .dark {
+    color-scheme: dark;
+  }
+
+  [lang="ar"],
+  [dir="rtl"] {
     @apply font-cairo;
+  }
+
+  body::-webkit-scrollbar {
+    width: 0.75rem;
+  }
+
+  body::-webkit-scrollbar-track {
+    background: hsl(var(--color-scrollbar-track));
+  }
+
+  body::-webkit-scrollbar-thumb {
+    background: linear-gradient(135deg, hsl(var(--color-accent)), hsl(var(--color-primary)));
+    border-radius: 999px;
+    border: 2px solid hsl(var(--color-scrollbar-track));
+  }
+}
+
+@layer components {
+  .glass {
+    background: hsla(var(--glass-background));
+    border: 1px solid hsla(var(--glass-border));
+    box-shadow: var(--shadow-card);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+
+  .glass-card {
+    background: var(--gradient-card);
+    border: 1px solid hsla(var(--glass-border));
+    box-shadow: var(--shadow-card);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+
+  .hero-gradient {
+    background-image: var(--gradient-hero);
+  }
+
+  .gradient-text {
+    background-image: var(--gradient-primary);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .bg-grid-pattern {
+    background-image:
+      linear-gradient(90deg, hsla(var(--color-border) / 0.25) 1px, transparent 1px),
+      linear-gradient(0deg, hsla(var(--color-border) / 0.2) 1px, transparent 1px);
+    background-size: 36px 36px;
+  }
+
+  .bg-card-highlight {
+    background-image: var(--gradient-card-highlight);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 18px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translate3d(0, -16px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes pulseGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 hsl(var(--color-accent-glow));
+  }
+  50% {
+    box-shadow: 0 0 35px 10px hsl(var(--color-accent-glow));
+  }
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
   }
 }

--- a/frontend/src/pages/ClientsPage.tsx
+++ b/frontend/src/pages/ClientsPage.tsx
@@ -19,7 +19,7 @@ const ClientPage: React.FC = () => {
       />
 
       <Suspense fallback={<GlobalSpinner />}>
-        <div className="rounded-2xl border border-border/60 bg-card p-6 shadow-sm">
+        <div className="rounded-2xl border border-border/60 bg-card p-6 shadow-card">
           <ClientList />
         </div>
       </Suspense>

--- a/frontend/src/pages/Landing/About.tsx
+++ b/frontend/src/pages/Landing/About.tsx
@@ -11,7 +11,7 @@ const About: React.FC = () => {
         </h2>
         <p className="text-lg text-text-body">{t("landing.about.description")}</p>
       </div>
-      <div className="overflow-hidden rounded-2xl shadow-elegant">
+      <div className="overflow-hidden rounded-2xl shadow-card">
         <img
           src="/images/law-team.jpg"
           alt={t("landing.about.imageAlt")}

--- a/frontend/src/pages/Landing/CallToAction.tsx
+++ b/frontend/src/pages/Landing/CallToAction.tsx
@@ -5,7 +5,7 @@ const CallToAction: React.FC = () => {
   const { t } = useLanguage();
 
   return (
-    <section className="relative overflow-hidden bg-gradient-primary py-24 text-center text-primary-foreground">
+    <section className="relative overflow-hidden bg-gradient-primary py-24 text-center text-text-inverse">
       <div className="absolute inset-0 bg-hero-overlay-light opacity-80 dark:bg-hero-overlay-dark dark:opacity-70" />
 
       <div className="relative z-10 container mx-auto px-6">
@@ -15,19 +15,24 @@ const CallToAction: React.FC = () => {
         </h2>
 
         {/* Subtitle */}
-        <p className="mx-auto mb-10 max-w-2xl text-lg text-primary-foreground/80 animate-fadeInDown [animation-delay:200ms]">
+        <p className="mx-auto mb-10 max-w-2xl text-lg text-text-inverse/85 animate-fadeInDown [animation-delay:200ms]">
           {t("landing.cta.subtitle")}
         </p>
 
         {/* Buttons */}
         <div className="flex flex-col justify-center gap-4 sm:flex-row sm:gap-6 animate-fadeInUp [animation-delay:400ms]">
-          <Button size="lg" variant="secondary" className="px-8 py-4 text-lg font-semibold shadow-card hover:-translate-y-1 hover:shadow-glow transition-transform duration-300 ease-elegant">
+          <Button
+            size="lg"
+            variant="hero"
+            className="px-8 py-4 text-lg"
+          >
             {t("landing.cta.primary")}
           </Button>
 
           <Button
             size="lg"
-            className="px-8 py-4 text-lg font-semibold bg-card text-primary shadow-card transition-transform duration-300 ease-elegant hover:-translate-y-1 hover:shadow-glow hover:bg-card/90"
+            variant="glass"
+            className="px-8 py-4 text-lg font-semibold text-text-inverse/90 hover:text-text-inverse"
           >
             {t("landing.cta.secondary")}
           </Button>

--- a/frontend/src/pages/Landing/Contact.tsx
+++ b/frontend/src/pages/Landing/Contact.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 const Contact: React.FC = () => {
@@ -14,7 +15,7 @@ const Contact: React.FC = () => {
       </p>
 
       {/* Form */}
-      <form className="mx-auto max-w-xl space-y-6 rounded-2xl border border-border bg-layer-card p-8 shadow-card animate-fadeInUp">
+      <form className="mx-auto max-w-xl space-y-6 rounded-2xl border border-border bg-surface-muted p-8 shadow-card animate-fadeInUp">
         <input
           type="text"
           placeholder={t("landing.contact.form.namePlaceholder")}
@@ -29,12 +30,14 @@ const Contact: React.FC = () => {
           placeholder={t("landing.contact.form.messagePlaceholder")}
           className="h-36 w-full rounded-lg border border-border bg-input p-4 text-text-body transition-colors duration-300 ease-smooth focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/60"
         />
-        <button
+        <Button
           type="submit"
-          className="w-full rounded-lg bg-primary p-4 text-lg font-semibold text-primary-foreground shadow-card transition-transform duration-300 ease-elegant hover:-translate-y-1 hover:shadow-glow"
+          variant="hero"
+          size="lg"
+          className="w-full"
         >
           {t("landing.contact.form.submit")}
-        </button>
+        </Button>
       </form>
     </section>
   );

--- a/frontend/src/pages/Landing/Features.tsx
+++ b/frontend/src/pages/Landing/Features.tsx
@@ -26,12 +26,12 @@ const Features: React.FC = () => {
         {features.map(({ key, icon: Icon }, i) => (
           <div
             key={key}
-            className="group relative rounded-xl border border-border bg-layer-card p-6 shadow-card transition-all duration-500 ease-elegant hover:-translate-y-2 hover:shadow-glow animate-fadeInUp"
+            className="group relative rounded-xl border border-border bg-surface-muted p-6 shadow-card transition-all duration-500 ease-elegant hover:-translate-y-2 hover:shadow-glow animate-fadeInUp"
             style={{ animationDelay: `${i * 120}ms` }}
           >
             {/* Icon with Glow */}
             <div className="mb-4 flex items-center justify-center">
-              <div className="rounded-full bg-accent/10 p-4 transition-colors duration-300 ease-smooth group-hover:bg-accent/20">
+              <div className="rounded-full bg-accent-soft p-4 transition-colors duration-300 ease-smooth group-hover:bg-accent">
                 <Icon className="h-10 w-10 text-accent animate-float" />
               </div>
             </div>

--- a/frontend/src/pages/Landing/Footer.tsx
+++ b/frontend/src/pages/Landing/Footer.tsx
@@ -19,7 +19,7 @@ const Footer: React.FC<FooterProps> = ({
   const { t, language } = useLanguage();
 
   return (
-    <footer className="border-t border-border bg-layer-base">
+    <footer className="border-t border-border bg-surface">
       <div className="container mx-auto px-4 py-12">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-4">
           <div className="md:col-span-2">

--- a/frontend/src/pages/Landing/Hero.tsx
+++ b/frontend/src/pages/Landing/Hero.tsx
@@ -8,20 +8,20 @@ const Hero: React.FC = () => {
   return (
     <section
       id="hero"
-      className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 text-center bg-gradient-hero"
+      className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-hero px-6 text-center text-text-inverse"
     >
       {/* Overlay (طبقة خلفية ناعمة) */}
-      <div className="absolute inset-0 bg-hero-overlay-light dark:bg-hero-overlay-dark" />
+      <div className="absolute inset-0 bg-hero-overlay-light opacity-80 dark:bg-hero-overlay-dark dark:opacity-70" />
 
       {/* محتوى الهيرو */}
       <div className="relative z-10 flex flex-col items-center space-y-8 animate-fadeIn">
         {/* العنوان */}
-        <h1 className="max-w-4xl text-4xl font-bold leading-tight text-text-strong md:text-6xl animate-fadeInUp">
+        <h1 className="max-w-4xl text-4xl font-bold leading-tight text-text-inverse md:text-6xl animate-fadeInUp">
           {t("landing.hero.title")}
         </h1>
 
         {/* الوصف */}
-        <p className="mx-auto max-w-2xl text-lg text-text-body md:text-xl animate-fadeInUp [animation-delay:200ms]">
+        <p className="mx-auto max-w-2xl text-lg text-text-inverse/80 md:text-xl animate-fadeInUp [animation-delay:200ms]">
           {t("landing.hero.subtitle")}
         </p>
 

--- a/frontend/src/pages/Landing/LandingNavbar.tsx
+++ b/frontend/src/pages/Landing/LandingNavbar.tsx
@@ -65,7 +65,7 @@ const LandingNavbar: React.FC = () => {
         className={cn(
           "fixed left-0 right-0 top-0 z-50 transition-all duration-300",
           isScrolled
-            ? "border-b border-border bg-background/90 backdrop-blur-lg shadow-lg"
+            ? "border-b border-border bg-background/90 backdrop-blur-lg shadow-card"
             : "bg-transparent",
         )}
       >
@@ -118,7 +118,7 @@ const LandingNavbar: React.FC = () => {
                 <Link to="/login">{t("landing.nav.login")}</Link>
               </Button>
 
-              <Button asChild size="sm" className="font-medium bg-primary text-primary-foreground hover:bg-primary-hover">
+              <Button asChild size="sm" variant="hero" className="font-medium">
                 <Link to="/register">{t("landing.nav.signup")}</Link>
               </Button>
             </div>
@@ -148,13 +148,13 @@ const LandingNavbar: React.FC = () => {
             className="fixed inset-x-0 top-16 z-40 px-4 lg:hidden"
           >
             <div className="container mx-auto">
-              <div className="space-y-4 rounded-xl border border-border bg-layer-card p-4 shadow-card">
+              <div className="space-y-4 rounded-xl border border-border bg-surface-muted p-4 shadow-card">
                 <div className={cn("flex flex-col gap-2", isRTL ? "text-right" : "text-left")}>
                   {navItems.map((item) => (
                     <button
                       key={item.key}
                       onClick={() => scrollToSection(item.href)}
-                      className="rounded-lg px-3 py-2 text-sm font-medium text-text-strong transition-colors duration-200 ease-smooth hover:bg-accent/10"
+                      className="rounded-lg px-3 py-2 text-sm font-medium text-text-strong transition-colors duration-200 ease-smooth hover:bg-accent-soft"
                     >
                       {item.label}
                     </button>
@@ -176,7 +176,7 @@ const LandingNavbar: React.FC = () => {
                   >
                     <Link to="/login">{t("landing.nav.login")}</Link>
                   </Button>
-                  <Button asChild className="justify-center text-sm font-semibold">
+                  <Button asChild variant="hero" className="justify-center text-sm font-semibold">
                     <Link to="/register">{t("landing.nav.signup")}</Link>
                   </Button>
                 </div>

--- a/frontend/src/pages/Landing/Services.tsx
+++ b/frontend/src/pages/Landing/Services.tsx
@@ -6,7 +6,7 @@ const Services: React.FC = () => {
   const { t } = useLanguage();
 
   return (
-    <section id="services" className="bg-layer-subtle py-20">
+    <section id="services" className="bg-surface-muted py-20">
       <div className="container mx-auto px-6 text-center">
         <h2 className="mb-6 text-3xl font-bold text-text-strong md:text-4xl animate-fadeIn">
           {t("landing.services.title")}
@@ -18,7 +18,7 @@ const Services: React.FC = () => {
           {services.map((key) => (
             <div
               key={key}
-              className="rounded-xl border border-border bg-card p-6 text-start shadow-card transition-all duration-500 ease-smooth hover:-translate-y-2 hover:shadow-elegant"
+              className="rounded-xl border border-border bg-card p-6 text-start shadow-card transition-all duration-500 ease-smooth hover:-translate-y-2 hover:shadow-glow"
             >
               <h3 className="mb-2 text-xl font-semibold text-text-strong">
                 {t(`landing.services.items.${key}.title`)}

--- a/frontend/src/pages/Landing/Testimonials.tsx
+++ b/frontend/src/pages/Landing/Testimonials.tsx
@@ -6,7 +6,7 @@ const Testimonials: React.FC = () => {
   const { t } = useLanguage();
 
   return (
-    <section id="testimonials" className="bg-layer-subtle py-20">
+    <section id="testimonials" className="bg-surface-muted py-20">
       <div className="container mx-auto px-6 text-center">
         <h2 className="mb-12 text-3xl font-bold text-text-strong md:text-4xl animate-fadeIn">
           {t("landing.testimonials.title")}
@@ -15,7 +15,7 @@ const Testimonials: React.FC = () => {
           {testimonials.map((key) => (
             <div
               key={key}
-              className="rounded-xl border border-border bg-card p-6 text-start shadow-card transition-shadow duration-500 ease-smooth hover:shadow-elegant"
+              className="rounded-xl border border-border bg-card p-6 text-start shadow-card transition-shadow duration-500 ease-smooth hover:shadow-glow"
             >
               <p className="mb-4 text-lg italic text-text-body">
                 “{t(`landing.testimonials.items.${key}.quote`)}”

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -136,7 +136,7 @@ await login(email, password);
 
         {/* محتوى متوسّط بالكامل */}
         <div className="relative z-10 flex items-center justify-center w-full h-full">
-          <div className="text-white text-center max-w-md">
+          <div className="text-text-inverse text-center max-w-md">
             <BrandLogo
               variant="text"
               lang={language}
@@ -157,7 +157,7 @@ await login(email, password);
           </div>
 
           {/* Login Card */}
-          <Card className="glass-card animate-fade-in border-x-0">
+          <Card className="glass-card animate-fadeIn border-x-0">
             <CardHeader className="text-center space-y-2">
               <BrandLogo className='mx-auto h-16 w-16 drop-shadow-none shadow-none' variant='icon' />
               <CardTitle className="heading-md">{t('auth.login.title')}</CardTitle>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -67,10 +67,10 @@ const Signup: React.FC = () => {
     <div className="min-h-screen bg-gradient-hero flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-grid-pattern opacity-10"></div>
       
-      <GlassCard variant="primary" size="lg" className="w-full max-w-md relative z-10">
+      <GlassCard variant="primary" size="lg" className="relative z-10 w-full max-w-md">
         <GlassCardHeader className="text-center">
-          <div className="mx-auto mb-4 h-16 w-16 rounded-full bg-gradient-primary flex items-center justify-center">
-            <User className="h-8 w-8 text-white" />
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-primary">
+            <User className="h-8 w-8 text-text-inverse" />
           </div>
           <GlassCardTitle className="text-2xl font-bold">
             {t('auth.signup.title')}

--- a/frontend/src/pages/UnClientsPage.tsx
+++ b/frontend/src/pages/UnClientsPage.tsx
@@ -19,7 +19,7 @@ const UnClientPage: React.FC = () => {
       />
 
       <Suspense fallback={<GlobalSpinner />}>
-        <div className="rounded-2xl border border-border/60 bg-card p-6 shadow-sm">
+        <div className="rounded-2xl border border-border/60 bg-card p-6 shadow-card">
           <UnClientList />
         </div>
       </Suspense>

--- a/frontend/src/pages/dashboard/DashboardHome.tsx
+++ b/frontend/src/pages/dashboard/DashboardHome.tsx
@@ -53,8 +53,8 @@ const statIconMap: Record<string, LucideIcon> = {
 };
 
 const priorityStyleMap: Record<string, string> = {
-  high: 'bg-destructive/20 text-destructive',
-  medium: 'bg-warning/20 text-warning',
+  high: 'bg-destructive-soft text-destructive',
+  medium: 'bg-warning-soft text-warning',
 };
 
 const DashboardHome: React.FC = () => {
@@ -92,7 +92,7 @@ const DashboardHome: React.FC = () => {
             key={`${stat.title}-${index}`}
             variant="primary"
             hover="glow"
-            className="animate-fade-in"
+            className="animate-fadeIn"
             style={{ animationDelay: `${index * 0.1}s` }}
           >
             <GlassCardContent className="p-6">
@@ -106,7 +106,7 @@ const DashboardHome: React.FC = () => {
                   </p>
                 </div>
                 <div className={`flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-primary ${stat.colorClass}`}>
-                  <stat.Icon className="h-6 w-6 text-white" />
+                  <stat.Icon className="h-6 w-6 text-text-inverse" />
                 </div>
               </div>
             </GlassCardContent>
@@ -128,7 +128,7 @@ const DashboardHome: React.FC = () => {
               {activities.map((activity, index) => (
                 <div
                   key={`${activity.title}-${index}`}
-                  className="flex items-start gap-3 rounded-lg p-3 transition-colors hover:bg-accent/10"
+                  className="flex items-start gap-3 rounded-lg p-3 transition-colors hover:bg-accent-soft"
                 >
                   <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-accent" />
                   <div className="flex-1">
@@ -154,12 +154,12 @@ const DashboardHome: React.FC = () => {
               {(tasks.items ?? []).map((task, index) => {
                 const priority = task.priority ?? '';
                 const priorityLabel = tasks.priorities?.[priority] ?? priority;
-                const priorityClass = priorityStyleMap[priority] ?? 'bg-warning/20 text-warning';
+                const priorityClass = priorityStyleMap[priority] ?? 'bg-warning-soft text-warning';
 
                 return (
                   <div
                     key={`${task.title}-${index}`}
-                    className="flex items-center justify-between rounded-lg p-3 transition-colors hover:bg-accent/10"
+                    className="flex items-center justify-between rounded-lg p-3 transition-colors hover:bg-accent-soft"
                   >
                     <div className="flex-1">
                       <p className="text-sm font-medium">{task.title}</p>

--- a/frontend/src/pages/dashboard/StatsCards.tsx
+++ b/frontend/src/pages/dashboard/StatsCards.tsx
@@ -69,8 +69,8 @@ export default function StatsCards() {
         const Arrow = stat.change >= 0 ? ArrowUpRight : ArrowDownRight;
         const isPositive = stat.change >= 0;
         const changeBadge = isPositive
-          ? 'bg-[color:hsla(var(--color-success)/0.22)] text-text-inverse'
-          : 'bg-[color:hsla(var(--color-destructive)/0.18)] text-text-inverse';
+          ? 'bg-success-soft text-success'
+          : 'bg-destructive-soft text-destructive';
         const changeText = `${isPositive ? '+' : '−'}${Math.abs(stat.change)}%`;
 
         return (
@@ -79,12 +79,12 @@ export default function StatsCards() {
             variant="primary"
             hover="glow"
             className={cn(
-              'relative overflow-hidden border border-border/70 text-text-inverse shadow-lg transition-transform duration-300',
+              'relative overflow-hidden border border-border/60 text-text-inverse shadow-glow transition-transform duration-300',
               stat.background
             )}
           >
             <div className="absolute inset-0 opacity-70 mix-blend-screen" />
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(255,255,255,0.25),transparent_45%)]" />
+            <div className="absolute inset-0 bg-card-highlight opacity-80" />
             <div className="relative flex flex-col gap-4 p-5">
               <div className="flex items-center justify-between">
                 <p className="text-sm font-medium text-text-inverse/85">{stat.label}</p>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -21,8 +21,15 @@ export default {
         inter: ["Inter", "sans-serif"],
       },
       colors: {
+        transparent: "transparent",
+        current: "currentColor",
         background: "hsl(var(--color-background))",
         foreground: "hsl(var(--color-foreground))",
+        surface: {
+          DEFAULT: "hsl(var(--color-surface))",
+          muted: "hsl(var(--color-surface-muted))",
+          highlight: "hsl(var(--color-surface-highlight))",
+        },
         text: {
           strong: "hsl(var(--color-text-strong))",
           body: "hsl(var(--color-text-body))",
@@ -34,27 +41,57 @@ export default {
           DEFAULT: "hsl(var(--color-primary))",
           hover: "hsl(var(--color-primary-hover))",
           foreground: "hsl(var(--color-primary-foreground))",
+          soft: "hsl(var(--color-primary-soft))",
         },
         accent: {
           DEFAULT: "hsl(var(--color-accent))",
           foreground: "hsl(var(--color-accent-foreground))",
+          soft: "hsl(var(--color-accent-soft))",
           glow: "hsl(var(--color-accent-glow))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--color-secondary))",
+          foreground: "hsl(var(--color-secondary-foreground))",
         },
         success: {
           DEFAULT: "hsl(var(--color-success))",
           foreground: "hsl(var(--color-success-foreground))",
+          soft: "hsl(var(--color-success-soft))",
         },
         warning: {
           DEFAULT: "hsl(var(--color-warning))",
           foreground: "hsl(var(--color-warning-foreground))",
+          soft: "hsl(var(--color-warning-soft))",
         },
         destructive: {
           DEFAULT: "hsl(var(--color-destructive))",
           foreground: "hsl(var(--color-destructive-foreground))",
+          soft: "hsl(var(--color-destructive-soft))",
         },
         card: {
           DEFAULT: "hsl(var(--color-card))",
           foreground: "hsl(var(--color-card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--color-popover))",
+          foreground: "hsl(var(--color-popover-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--color-surface-muted))",
+          foreground: "hsl(var(--color-text-muted))",
+        },
+        border: "hsl(var(--color-border))",
+        input: "hsl(var(--color-input))",
+        ring: "hsl(var(--color-ring))",
+        sidebar: {
+          background: "hsl(var(--color-sidebar-background))",
+          foreground: "hsl(var(--color-sidebar-foreground))",
+          primary: "hsl(var(--color-sidebar-primary))",
+          "primary-foreground": "hsl(var(--color-sidebar-primary-foreground))",
+          accent: "hsl(var(--color-sidebar-accent))",
+          "accent-foreground": "hsl(var(--color-sidebar-accent-foreground))",
+          border: "hsl(var(--color-sidebar-border))",
+          ring: "hsl(var(--color-sidebar-ring))",
         },
       },
       borderRadius: {
@@ -70,10 +107,50 @@ export default {
         "gradient-primary": "var(--gradient-primary)",
         "gradient-hero": "var(--gradient-hero)",
         "gradient-card": "var(--gradient-card)",
+        "gradient-glass": "var(--gradient-glass)",
+        "gradient-success": "var(--gradient-success)",
+        "gradient-accent": "var(--gradient-accent)",
+        "gradient-warning": "var(--gradient-warning)",
+        "hero-overlay-light": "var(--gradient-hero-overlay-light)",
+        "hero-overlay-dark": "var(--gradient-hero-overlay-dark)",
+        "card-highlight": "var(--gradient-card-highlight)",
+      },
+      keyframes: {
+        fadeIn: {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
+        fadeInUp: {
+          from: { opacity: "0", transform: "translate3d(0, 18px, 0)" },
+          to: { opacity: "1", transform: "translate3d(0, 0, 0)" },
+        },
+        fadeInDown: {
+          from: { opacity: "0", transform: "translate3d(0, -16px, 0)" },
+          to: { opacity: "1", transform: "translate3d(0, 0, 0)" },
+        },
+        pulseGlow: {
+          "0%, 100%": { boxShadow: "0 0 0 0 hsl(var(--color-accent-glow))" },
+          "50%": { boxShadow: "0 0 35px 10px hsl(var(--color-accent-glow))" },
+        },
+        float: {
+          "0%, 100%": { transform: "translateY(0)" },
+          "50%": { transform: "translateY(-6px)" },
+        },
       },
       animation: {
-        fadeIn: "fadeIn 0.6s ease-smooth both",
-        fadeInUp: "fadeInUp 0.6s ease-elegant both",
+        fadeIn: "fadeIn 0.6s ease-out both",
+        fadeInUp: "fadeInUp 0.6s cubic-bezier(0.33, 1, 0.68, 1) both",
+        fadeInDown: "fadeInDown 0.6s cubic-bezier(0.33, 1, 0.68, 1) both",
+        pulseGlow: "pulseGlow 2.4s ease-in-out infinite",
+        float: "float 6s ease-in-out infinite",
+      },
+      transitionTimingFunction: {
+        smooth: "cubic-bezier(0.4, 0, 0.2, 1)",
+        elegant: "cubic-bezier(0.33, 1, 0.68, 1)",
+      },
+      scale: {
+        102: "1.02",
+        103: "1.03",
       },
     },
   },


### PR DESCRIPTION
## Summary
- overhaul global design tokens in `index.css` and connect Tailwind theme extensions to the new Cyber-Legal palette
- refresh button variants, glass cards, gradients, and shared UI primitives to rely on tokens and consistent shadow styles
- update landing, dashboard, authentication, and legal detail pages to use the new typography, gradients, and glass morphism treatments

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files such as ui/table utils)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8ecf9510832889e1ad8567a03b5b