### PR TITLE
Fix mobile sidebar toggle handling

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,20 +1,22 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Header } from '@/components/layout/Header';
 import Sidebar from '@/components/layout/Sidebar';
+import { useSidebar } from '@/contexts/SidebarContext';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 const Dashboard: React.FC = () => {
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { isCollapsed, toggleCollapsed, isMobileOpen, toggleMobile } = useSidebar();
+  const isMobile = useIsMobile();
 
-  const toggleSidebar = () => {
-    setSidebarCollapsed(!sidebarCollapsed);
-  };
+  const sidebarCollapsed = isMobile ? !isMobileOpen : isCollapsed;
+  const handleSidebarToggle = isMobile ? toggleMobile : toggleCollapsed;
 
   return (
     <div className="min-h-screen bg-background">
       <Header />
       <div className="flex h-[calc(100vh-4rem)]">
-        <Sidebar isCollapsed={sidebarCollapsed} onToggle={toggleSidebar} />
+        <Sidebar isCollapsed={sidebarCollapsed} onToggle={handleSidebarToggle} />
         <main className="flex-1 overflow-y-auto">
           <div className="p-6">
             <Outlet />


### PR DESCRIPTION
## Summary
- wire the dashboard layout to the shared sidebar context so it reacts to the mobile toggle
- derive the sidebar collapsed state from the context on mobile and desktop for consistent behaviour

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bff943ec8328a9b7ee2016691b67