### PR TITLE
Enhance theme toggle with palette-driven styling

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -30,6 +30,8 @@ const buttonVariants = cva(
           "glass text-text-strong shadow-ambient hover:border-accent/40 hover:shadow-glow",
         glow:
           "bg-accent text-accent-foreground shadow-glow hover:scale-102 animate-pulseGlow",
+        chromatic:
+          "relative overflow-hidden rounded-full border border-border/60 bg-transparent px-4 py-2 text-text-strong shadow-ambient transition-all duration-500 hover:border-accent/70 hover:shadow-glow before:pointer-events-none before:absolute before:inset-0 before:-translate-y-full before:bg-[var(--toggle-gradient)] before:opacity-0 before:transition-all before:duration-500 before:content-[''] before:z-0 after:pointer-events-none after:absolute after:inset-[1px] after:rounded-full after:border after:border-white/10 after:opacity-0 after:transition-opacity after:duration-500 after:content-[''] hover:before:translate-y-0 hover:before:opacity-100 hover:text-text-inverse hover:after:opacity-100",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/frontend/src/components/ui/theme-toggle.tsx
+++ b/frontend/src/components/ui/theme-toggle.tsx
@@ -4,21 +4,87 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { useTranslation } from 'react-i18next';
 import { Button } from './button';
 
+type Palette = {
+  primary: string;
+  accent: string;
+  surface: string;
+  foreground: string;
+};
+
 const ThemeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
   const { t } = useTranslation('common');
 
   const isDark = theme === 'dark';
+  const [palette, setPalette] = React.useState<Palette>({
+    primary: '',
+    accent: '',
+    surface: '',
+    foreground: '',
+  });
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const root = document.documentElement;
+      const computed = window.getComputedStyle(root);
+      const readVar = (token: string) => computed.getPropertyValue(token).trim();
+
+      setPalette({
+        primary: readVar('--color-primary'),
+        accent: readVar('--color-accent'),
+        surface: readVar('--color-surface'),
+        foreground: readVar('--color-text-strong'),
+      });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [theme]);
+
+  const buttonStyle = React.useMemo(() => {
+    const style: React.CSSProperties & Record<string, string> = {};
+
+    if (palette.surface) {
+      style.backgroundColor = `hsl(${palette.surface})`;
+    }
+
+    if (palette.foreground) {
+      style.color = `hsl(${palette.foreground})`;
+    }
+
+    if (palette.primary && palette.accent) {
+      style['--toggle-gradient'] = `linear-gradient(135deg, hsl(${palette.primary}), hsl(${palette.accent}))`;
+    }
+
+    return style;
+  }, [palette]);
+
+  const primarySwatch = palette.primary ? { backgroundColor: `hsl(${palette.primary})` } : undefined;
+  const accentSwatch = palette.accent ? { backgroundColor: `hsl(${palette.accent})` } : undefined;
 
   return (
     <Button
-      variant="ghost"
-      size="icon"
+      variant="chromatic"
       onClick={toggleTheme}
       aria-label={isDark ? t('light') : t('dark')}
-      className="h-9 w-9"
+      className="group h-10 rounded-full px-3"
+      style={buttonStyle}
     >
-      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="relative z-10 flex items-center gap-3">
+        <span className="flex items-center gap-1 rounded-full bg-black/5 px-1.5 py-1 text-[0] shadow-inner backdrop-blur-sm dark:bg-white/10">
+          <span className="h-2.5 w-2.5 rounded-full" style={primarySwatch} />
+          <span className="h-2.5 w-2.5 rounded-full" style={accentSwatch} />
+        </span>
+        <span className="flex items-center gap-2 text-sm font-semibold tracking-wide">
+          <span className="uppercase opacity-90 transition-opacity duration-300 group-hover:opacity-100">
+            {isDark ? t('light') : t('dark')}
+          </span>
+          <span className="grid h-7 w-7 place-items-center rounded-full bg-white/70 text-text-strong shadow-inner backdrop-blur-md dark:bg-black/40 dark:text-text-inverse">
+            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </span>
+        </span>
+      </span>
     </Button>
   );
 };


### PR DESCRIPTION
## Summary
- add a chromatic button variant that supports gradient overlays driven by CSS variables
- redesign the theme toggle to read the active palette from CSS variables and showcase the theme’s primary and accent colors

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c9b9f85c8328bd5d9d510c0d79f7