### PR TITLE
Enable single-language landing experience

### DIFF
--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -32,13 +32,19 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       if (stored === 'ar' || stored === 'en') {
         return stored;
       }
+
+      const browserLanguage =
+        window.navigator.language || window.navigator.languages?.[0] || '';
+      if (browserLanguage) {
+        return browserLanguage.toLowerCase().startsWith('ar') ? 'ar' : 'en';
+      }
     }
 
     if (i18n.language) {
       return i18n.language.startsWith('ar') ? 'ar' : 'en';
     }
 
-    return 'ar';
+    return 'en';
   });
 
   useEffect(() => {

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,18 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 type Theme = 'light' | 'dark';
+
+interface ThemeState {
+  theme: Theme;
+  manual: boolean;
+}
 
 interface ThemeContextType {
   theme: Theme;
@@ -8,9 +20,25 @@ interface ThemeContextType {
   isDark: boolean;
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
+  syncWithSystem: () => void;
 }
 
+const STORAGE_KEY = 'avocat_theme';
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const getPreferredTheme = (): ThemeState => {
+  if (typeof window === 'undefined') {
+    return { theme: 'light', manual: false };
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    return { theme: stored, manual: true };
+  }
+
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return { theme: prefersDark ? 'dark' : 'light', manual: false };
+};
 
 export const useTheme = () => {
   const context = useContext(ThemeContext);
@@ -21,33 +49,70 @@ export const useTheme = () => {
 };
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const stored = localStorage.getItem('avocat_theme');
-    return (stored as Theme) || 'light';
-  });
+  const [state, setState] = useState<ThemeState>(() => getPreferredTheme());
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     const root = window.document.documentElement;
     root.classList.remove('light', 'dark');
-    root.classList.add(theme);
-    localStorage.setItem('avocat_theme', theme);
-  }, [theme]);
+    root.classList.add(state.theme);
+    root.style.colorScheme = state.theme;
 
-  const toggleTheme = () => {
-    setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
-  };
+    if (state.manual) {
+      window.localStorage.setItem(STORAGE_KEY, state.theme);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [state]);
 
-  const resolvedTheme = theme;
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setState((prev) => {
+        if (prev.manual) {
+          return prev;
+        }
+        return { theme: event.matches ? 'dark' : 'light', manual: false };
+      });
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const setTheme = useCallback((theme: Theme) => {
+    setState({ theme, manual: true });
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setState((prev) => ({ theme: prev.theme === 'dark' ? 'light' : 'dark', manual: true }));
+  }, []);
+
+  const syncWithSystem = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setState({ theme: prefersDark ? 'dark' : 'light', manual: false });
+  }, []);
 
   const value = useMemo(
     () => ({
-      theme,
-      resolvedTheme,
-      isDark: resolvedTheme === 'dark',
+      theme: state.theme,
+      resolvedTheme: state.theme,
+      isDark: state.theme === 'dark',
       setTheme,
       toggleTheme,
+      syncWithSystem,
     }),
-    [theme, resolvedTheme],
+    [state.theme, setTheme, toggleTheme, syncWithSystem],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -195,4 +195,12 @@ All colors MUST be HSL for proper theme support.
     box-shadow: var(--shadow-premium);
     transition: var(--transition-premium);
   }
+
+  .font-english {
+    font-family: 'Inter', sans-serif;
+  }
+
+  .font-arabic {
+    font-family: 'Amiri', serif;
+  }
 }

--- a/frontend/src/pages/Landing/About.tsx
+++ b/frontend/src/pages/Landing/About.tsx
@@ -1,160 +1,173 @@
-import React from 'react';
-import { useLanguage } from '@/contexts/LanguageContext';
-import { Target, Eye, Award, Globe, Users, TrendingUp } from 'lucide-react';
+import { Building2, Compass, Handshake, Target } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+type Pillar = {
+  icon: typeof Building2;
+  enTitle: string;
+  arTitle: string;
+  enDescription: string;
+  arDescription: string;
+  enPoints: string[];
+  arPoints: string[];
+};
+
+const pillars: Pillar[] = [
+  {
+    icon: Building2,
+    enTitle: "Foundation & Heritage",
+    arTitle: "التأسيس والإرث",
+    enDescription:
+      "Founded in 2013, Avocat Law Firm bridges traditional expertise with digital innovation to deliver justice that is safer, more transparent, and more efficient.",
+    arDescription:
+      "تأسس مكتب أفوكات عام 2013 ليكون جسراً بين الخبرة القانونية التقليدية والابتكار الرقمي، مقدماً عدالة أكثر أماناً وشفافية وفعالية.",
+    enPoints: [
+      "Regional footprint spanning Cairo, Dubai, and Riyadh to support complex cross-border mandates.",
+      "Digitised more than 12,000 legal files with tamper-proof archives and intelligent retrieval.",
+    ],
+    arPoints: [
+      "حضور إقليمي يمتد من القاهرة ودبي إلى الرياض لدعم القضايا العابرة للحدود.",
+      "رقمنة أكثر من 12,000 ملف قانوني بأرشفة محكمة واسترجاع ذكي.",
+    ],
+  },
+  {
+    icon: Target,
+    enTitle: "Vision & Mission",
+    arTitle: "الرؤية والرسالة",
+    enDescription:
+      "To be the leading destination for clients seeking smart digital legal solutions built on trust, speed, and professionalism.",
+    arDescription:
+      "أن نصبح الوجهة الأولى للعملاء الباحثين عن حلول قانونية رقمية ذكية تقوم على الثقة والسرعة والاحترافية.",
+    enPoints: [
+      "Vision: smart justice ecosystems that elevate client confidence and institutional agility.",
+      "Mission: orchestrate integrated counsel, technology, and compliance for every mandate.",
+    ],
+    arPoints: [
+      "الرؤية: منظومات عدالة ذكية تعزز ثقة العملاء ومرونة المؤسسات.",
+      "الرسالة: توظيف الاستشارات القانونية والتقنية والامتثال في منظومة واحدة لكل تكليف.",
+    ],
+  },
+  {
+    icon: Compass,
+    enTitle: "Future Philosophy",
+    arTitle: "فلسفة المستقبل",
+    enDescription:
+      "We design forward-looking frameworks where law, data, and design converge to shape resilient justice.",
+    arDescription:
+      "نرسم أطر عمل مستقبلية يلتقي فيها القانون بالبيانات والتصميم لصياغة عدالة متينة.",
+    enPoints: [
+      "Innovation sprints prototype digital courtrooms, e-trials, and regulatory sandboxes.",
+      "Continuous capability-building for lawyers, analysts, and clients on AI and cybersecurity disciplines.",
+    ],
+    arPoints: [
+      "مختبرات الابتكار تطور محاكم رقمية ومحاكمات إلكترونية ومساحات تشريعية تجريبية.",
+      "برامج تطوير مستمرة للمحامين والمحللين والعملاء في مجالات الذكاء الاصطناعي والأمن السيبراني.",
+    ],
+  },
+  {
+    icon: Handshake,
+    enTitle: "Client Commitment",
+    arTitle: "التزامنا بالعملاء",
+    enDescription:
+      "Because we blend deep legal expertise with cutting-edge technology, delivering transparent, innovative, and reliable solutions.",
+    arDescription:
+      "لأننا نمزج بين الخبرة القانونية العميقة وأحدث التقنيات لنقدم حلولاً مبتكرة وشفافة وموثوقة.",
+    enPoints: [
+      "Secure portals, bilingual reporting, and measurable KPIs for every engagement.",
+      "Ethical governance that safeguards confidentiality, transparency, and accountability.",
+    ],
+    arPoints: [
+      "بوابات آمنة وتقارير دقيقة ومؤشرات أداء قابلة للقياس في كل مهمة.",
+      "حوكمة أخلاقية تضمن السرية والشفافية والمساءلة.",
+    ],
+  },
+];
+
+const introCopy = {
+  en: {
+    badge: "About Avocat",
+    title: "Prestige, Innovation, and Trusted Counsel",
+    description:
+      "We champion digital legal transformation that honours heritage while unlocking smarter, faster justice for every client.",
+  },
+  ar: {
+    badge: "عن أفوكات",
+    title: "الفخامة والابتكار وخدمات موثوقة",
+    description:
+      "نقود التحول الرقمي القانوني مع الحفاظ على الإرث وتقديم عدالة أذكى وأسرع لكل عميل.",
+  },
+};
+
+const detailLabel = {
+  en: "Digital Leadership",
+  ar: "ريادة رقمية",
+};
 
 const About: React.FC = () => {
-  const { t, isRTL } = useLanguage();
-
-  const values = [
-    {
-      icon: Target,
-      title: 'Our Mission',
-      description: 'Bridging legal excellence with digital innovation',
-      gradient: 'from-primary to-primary-light'
-    },
-    {
-      icon: Eye,
-      title: 'Our Vision',
-      description: 'Leadership in legal digital transformation in MENA',
-      gradient: 'from-accent to-accent-glow'
-    },
-    {
-      icon: Award,
-      title: 'Our Values',
-      description: 'Trust, confidentiality, innovation, global standards',
-      gradient: 'from-primary-light to-primary-glow'
-    }
-  ];
-
-  const stats = [
-    { icon: Users, value: '500+', label: 'Legal Professionals', color: 'text-primary' },
-    { icon: Globe, value: '15+', label: 'Countries Served', color: 'text-accent' },
-    { icon: TrendingUp, value: '98%', label: 'Client Satisfaction', color: 'text-primary-light' },
-    { icon: Award, value: '10+', label: 'Industry Awards', color: 'text-accent-glow' }
-  ];
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = introCopy[language];
 
   return (
-    <section id="about" className="py-24 bg-gradient-to-br from-background via-secondary/20 to-background relative overflow-hidden">
-      {/* Background Pattern */}
-      <div className="absolute inset-0 opacity-10">
-        <div className="absolute top-20 right-20 w-96 h-96 bg-accent rounded-full mix-blend-multiply blur-3xl animate-float"></div>
-        <div className="absolute bottom-20 left-20 w-80 h-80 bg-primary rounded-full mix-blend-multiply blur-3xl animate-float" style={{ animationDelay: '3s' }}></div>
-      </div>
-
-      <div className="container mx-auto px-4 lg:px-8 relative z-10">
-        {/* Section Header */}
-        <div className="text-center mb-16 animate-fade-in">
-          <h2 className="text-4xl lg:text-5xl font-display font-bold text-foreground mb-6">
-            {t('aboutTitle')}
+    <section id="about" className="relative overflow-hidden py-24" dir={direction}>
+      <div className="absolute inset-0 bg-gradient-to-b from-secondary/20 via-background to-background" />
+      <div className="container relative mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">
+            {copy.title}
           </h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-            {t('aboutSubtitle')}
-          </p>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
         </div>
 
-        {/* Main Content */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center mb-20">
-          {/* Content */}
-          <div className="animate-slide-up">
-            <h3 className="text-3xl font-display font-semibold text-foreground mb-6 leading-tight">
-              Transforming Legal Services in the Digital Age
-            </h3>
-            
-            <p className="text-lg text-muted-foreground leading-relaxed mb-6">
-              {t('aboutDescription')}
-            </p>
+        <div className="grid gap-8 md:grid-cols-2">
+          {pillars.map((pillar) => {
+            const Icon = pillar.icon;
+            const title = isArabic ? pillar.arTitle : pillar.enTitle;
+            const description = isArabic ? pillar.arDescription : pillar.enDescription;
+            const points = isArabic ? pillar.arPoints : pillar.enPoints;
 
-            <div className="space-y-4">
-              <div className="flex items-center space-x-3 rtl:space-x-reverse">
-                <div className="w-2 h-2 bg-accent rounded-full animate-pulse"></div>
-                <span className="text-foreground font-medium">Innovative Legal Technology Solutions</span>
-              </div>
-              <div className="flex items-center space-x-3 rtl:space-x-reverse">
-                <div className="w-2 h-2 bg-primary rounded-full animate-pulse"></div>
-                <span className="text-foreground font-medium">Comprehensive Digital Transformation</span>
-              </div>
-              <div className="flex items-center space-x-3 rtl:space-x-reverse">
-                <div className="w-2 h-2 bg-accent-glow rounded-full animate-pulse"></div>
-                <span className="text-foreground font-medium">MENA Region Legal Expertise</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Values Cards */}
-          <div className="space-y-6">
-            {values.map((value, index) => {
-              const IconComponent = value.icon;
-              return (
-                <div
-                  key={index}
-                  className="animate-slide-up card-premium p-6 hover:card-elevated transition-all duration-500 group hover:-translate-y-1"
-                  style={{ animationDelay: `${index * 200}ms` }}
-                >
-                  <div className="flex items-start space-x-4 rtl:space-x-reverse">
-                    <div className={`w-12 h-12 bg-gradient-to-br ${value.gradient} rounded-xl flex items-center justify-center group-hover:scale-110 transition-all duration-300 animate-glow`}>
-                      <IconComponent className="w-6 h-6 text-white" />
+            return (
+              <div
+                key={pillar.enTitle}
+                className="group flex h-full flex-col gap-6 rounded-3xl border border-border bg-card/70 p-8 shadow-ambient backdrop-blur transition-transform duration-500 hover:-translate-y-2 hover:shadow-premium"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-2xl bg-gradient-gold p-3 text-accent-foreground shadow-gold">
+                      <Icon className="h-6 w-6" />
                     </div>
-                    <div className="flex-1">
-                      <h4 className="text-xl font-display font-semibold text-foreground mb-2 group-hover:text-primary transition-colors duration-300">
-                        {value.title}
-                      </h4>
-                      <p className="text-muted-foreground leading-relaxed">
-                        {value.description}
+                    <div className={`${isArabic ? "text-right" : "text-left"}`}>
+                      <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+                      <p
+                        className={`text-sm text-muted-foreground ${
+                          isArabic ? "" : "uppercase tracking-widest"
+                        }`}
+                      >
+                        {detailLabel[language]}
                       </p>
                     </div>
                   </div>
                 </div>
-              );
-            })}
-          </div>
-        </div>
 
-        {/* Statistics Section */}
-        <div className="bg-gradient-primary rounded-3xl p-8 lg:p-12 text-center shadow-premium animate-fade-in">
-          <h3 className="text-3xl font-display font-bold text-white mb-12">
-            Our Impact in Numbers
-          </h3>
-          
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
-            {stats.map((stat, index) => {
-              const IconComponent = stat.icon;
-              return (
-                <div
-                  key={index}
-                  className="animate-scale-in group"
-                  style={{ animationDelay: `${index * 150}ms` }}
-                >
-                  <div className="w-16 h-16 bg-white/20 backdrop-blur-md rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:scale-110 group-hover:bg-white/30 transition-all duration-300">
-                    <IconComponent className="w-8 h-8 text-white" />
-                  </div>
-                  
-                  <div className="text-4xl font-bold text-white mb-2 group-hover:text-accent transition-colors duration-300">
-                    {stat.value}
-                  </div>
-                  
-                  <div className="text-white/80 font-medium">
-                    {stat.label}
-                  </div>
+                <div className={`space-y-3 text-base leading-relaxed text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>
+                  <p>{description}</p>
+                  <ul className="space-y-2 text-sm">
+                    {points.map((point) => (
+                      <li
+                        key={point}
+                        className={`flex items-start gap-2 ${isArabic ? "flex-row-reverse text-right" : ""}`}
+                      >
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                        <span>{point}</span>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Leadership Message */}
-        <div className="mt-20 text-center animate-fade-in">
-          <div className="max-w-4xl mx-auto">
-            <blockquote className="text-2xl lg:text-3xl font-display italic text-foreground leading-relaxed mb-8">
-              "We believe that the future of legal services lies in the seamless integration of traditional legal expertise with cutting-edge technology."
-            </blockquote>
-            <div className="flex items-center justify-center space-x-4 rtl:space-x-reverse">
-              <div className="w-1 h-16 bg-gradient-gold rounded-full"></div>
-              <div className={`${isRTL? 'text-right' : 'text-left'}`}>
-                <div className="font-display font-semibold text-foreground text-lg">Avocat Leadership Team</div>
-                <div className="text-muted-foreground">Legal Technology Pioneers</div>
               </div>
-            </div>
-          </div>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/frontend/src/pages/Landing/Achievements.tsx
+++ b/frontend/src/pages/Landing/Achievements.tsx
@@ -1,0 +1,171 @@
+import { useLanguage } from "@/contexts/LanguageContext";
+import { Gavel, MessageSquareQuote, Trophy } from "lucide-react";
+
+type Achievement = {
+  icon: typeof Gavel;
+  enTitle: string;
+  arTitle: string;
+  enSummary: string;
+  arSummary: string;
+  enDetails: string[];
+  arDetails: string[];
+};
+
+const achievements: Achievement[] = [
+  {
+    icon: Gavel,
+    enTitle: "Landmark Cases",
+    arTitle: "قضايا محورية",
+    enSummary:
+      "Recovered USD 240M in a cross-border fraud dispute by orchestrating digital evidence mapping and coordinated arbitration strategy.",
+    arSummary:
+      "استرداد 240 مليون دولار في نزاع احتيال عابر للحدود عبر رسم خريطة رقمية للأدلة واستراتيجية تحكيم منسقة.",
+    enDetails: [
+      "First MENA firm to validate blockchain records as admissible court evidence.",
+      "Hybrid teams blended forensic auditors, litigators, and cybersecurity analysts.",
+    ],
+    arDetails: [
+      "أول مكتب في المنطقة يعتمد سجلات البلوكتشين كأدلة مقبولة قضائياً.",
+      "فرق هجينة تجمع بين خبراء التدقيق الجنائي والمحامين ومحللي الأمن السيبراني.",
+    ],
+  },
+  {
+    icon: MessageSquareQuote,
+    enTitle: "Client Testimonials",
+    arTitle: "شهادات العملاء",
+    enSummary:
+      '“Avocat delivers unparalleled transparency. Our executives monitor hearings, filings, and KPIs live across devices.” – CFO, Regional Energy Group',
+    arSummary:
+      '"أفوكات يقدم شفافية غير مسبوقة؛ مديرونا يتابعون الجلسات والمذكرات ومؤشرات الأداء مباشرة عبر مختلف الأجهزة." – المدير المالي لمجموعة طاقة إقليمية',
+    enDetails: [
+      "96% client satisfaction with bilingual reporting and secured collaboration rooms.",
+      "Dedicated digital concierge supporting ministries, sovereign funds, and innovation hubs.",
+    ],
+    arDetails: [
+      "رضا العملاء بنسبة 96٪ بفضل التقارير الدقيقة وغرف التعاون المؤمنة.",
+      "فريق دعم رقمي متخصص لخدمة الوزارات والصناديق السيادية وحاضنات الابتكار.",
+    ],
+  },
+  {
+    icon: Trophy,
+    enTitle: "Notable Judgments",
+    arTitle: "أحكام مميزة",
+    enSummary:
+      "Secured precedent-setting administrative and criminal judgments reinforcing digital signatures, cybercrime protection, and compliance governance.",
+    arSummary:
+      "أحكام إدارية وجنائية رائدة عززت قبول التوقيعات الرقمية وحماية الأمن السيبراني وحوكمة الامتثال.",
+    enDetails: [
+      "Court-endorsed e-signature framework adopted across three national authorities.",
+      "Pioneered criminal court protocols for handling AI-generated evidence.",
+    ],
+    arDetails: [
+      "إطار عمل للتوقيع الإلكتروني معتمد قضائياً تبنته ثلاث جهات حكومية وطنية.",
+      "إرساء بروتوكولات للمحاكم الجنائية للتعامل مع الأدلة المولدة بالذكاء الاصطناعي.",
+    ],
+  },
+];
+
+const metrics = [
+  {
+    en: "98% digital adoption across client mandates",
+    ar: "نسبة تحول رقمي 98٪ في ملفات العملاء",
+  },
+  {
+    en: "45+ jurisdictions coordinated with multilingual teams",
+    ar: "أكثر من 45 ولاية قضائية بدعم فرق متعددة اللغات",
+  },
+  {
+    en: "24/7 incident response and legal command centers",
+    ar: "مراكز قيادة واستجابة قانونية على مدار الساعة",
+  },
+];
+
+const sectionCopy = {
+  en: {
+    badge: "Achievements",
+    title: "Proven Outcomes, Trusted by Leaders",
+    description:
+      "Landmark victories, transformative partnerships, and digitally-enabled judgments that redefine legal excellence.",
+  },
+  ar: {
+    badge: "الإنجازات",
+    title: "نتائج مثبتة يثق بها القادة",
+    description:
+      "انتصارات مفصلية وشراكات تحولية وأحكام رقمية تعيد تعريف التميز القانوني.",
+  },
+};
+
+const Achievements: React.FC = () => {
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = sectionCopy[language];
+
+  return (
+    <section id="achievements" className="bg-background py-24" dir={direction}>
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{copy.title}</h2>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {metrics.map((metric) => {
+            const label = isArabic ? metric.ar : metric.en;
+            return (
+              <div
+                key={metric.en}
+                className="rounded-3xl border border-border bg-gradient-to-br from-primary/5 via-background to-background p-6 text-center shadow-ambient"
+              >
+                <p className="text-sm font-semibold text-primary">{label}</p>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-12 grid gap-8 lg:grid-cols-3">
+          {achievements.map((achievement) => {
+            const Icon = achievement.icon;
+            const title = isArabic ? achievement.arTitle : achievement.enTitle;
+            const summary = isArabic ? achievement.arSummary : achievement.enSummary;
+            const details = isArabic ? achievement.arDetails : achievement.enDetails;
+
+            return (
+              <div
+                key={achievement.enTitle}
+                className="flex h-full flex-col gap-6 rounded-3xl border border-border bg-card/80 p-8 shadow-elevated backdrop-blur transition-transform duration-500 hover:-translate-y-2 hover:shadow-premium"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="rounded-2xl bg-gradient-gold p-3 text-accent-foreground shadow-gold">
+                    <Icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+                </div>
+
+                <p className={`text-base leading-relaxed text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>
+                  {summary}
+                </p>
+
+                <ul className="space-y-3 text-sm text-muted-foreground">
+                  {details.map((detail) => (
+                    <li
+                      key={detail}
+                      className={`flex items-start gap-2 ${isArabic ? "flex-row-reverse text-right" : ""}`}
+                    >
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                      <span>{detail}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Achievements;

--- a/frontend/src/pages/Landing/Capabilities.tsx
+++ b/frontend/src/pages/Landing/Capabilities.tsx
@@ -1,0 +1,142 @@
+import { useLanguage } from "@/contexts/LanguageContext";
+import { Cpu, Layers, ShieldLock } from "lucide-react";
+
+type Capability = {
+  icon: typeof Layers;
+  enTitle: string;
+  arTitle: string;
+  enDescription: string;
+  arDescription: string;
+  enPoints: string[];
+  arPoints: string[];
+};
+
+const capabilities: Capability[] = [
+  {
+    icon: Layers,
+    enTitle: "Core Capabilities",
+    arTitle: "القدرات الأساسية",
+    enDescription:
+      "Strategic counsel across commercial, administrative, and criminal mandates supported by precision digital workflows.",
+    arDescription:
+      "استشارات استراتيجية في القضايا التجارية والإدارية والجنائية مدعومة بسير عمل رقمي دقيق.",
+    enPoints: [
+      "End-to-end lifecycle management for litigation, arbitration, and settlement.",
+      "Real-time dashboards aligning partners, associates, and clients with measurable KPIs.",
+    ],
+    arPoints: [
+      "إدارة شاملة لدورة حياة القضايا من التقاضي إلى التحكيم والتسويات.",
+      "لوحات تحكم لحظية تربط الشركاء والمحامين والعملاء بمؤشرات أداء قابلة للقياس.",
+    ],
+  },
+  {
+    icon: Cpu,
+    enTitle: "AI in Legal Services",
+    arTitle: "الذكاء الاصطناعي في الخدمات القانونية",
+    enDescription:
+      "Intelligent systems for case management, precedent research, and data-driven legal strategies.",
+    arDescription:
+      "أنظمة ذكية لإدارة القضايا، البحث في السوابق، وبناء استراتيجيات قانونية قائمة على البيانات.",
+    enPoints: [
+      "Knowledge graphs connect precedents, regulations, and expert opinions in seconds.",
+      "Scenario simulators model outcomes, damages, and compliance risks before submission.",
+    ],
+    arPoints: [
+      "خرائط معرفية تربط السوابق والتشريعات والآراء الخبرية في ثوانٍ.",
+      "محاكيات سيناريوهات تتوقع النتائج والأضرار ومخاطر الامتثال قبل التقديم.",
+    ],
+  },
+  {
+    icon: ShieldLock,
+    enTitle: "Cybersecurity & Digital Trust",
+    arTitle: "الأمن السيبراني والثقة الرقمية",
+    enDescription:
+      "Advanced legal solutions, digital forensics, and international compliance to protect privacy and data.",
+    arDescription:
+      "حلول قانونية متطورة، تحقيقات رقمية، وتشريعات متوافقة مع القوانين الدولية لحماية الخصوصية والبيانات.",
+    enPoints: [
+      "Cybercrime protection with incident readiness, breach containment, and regulatory reporting.",
+      "Zero-trust architecture, encryption, and audit trails safeguarding every document and signature.",
+    ],
+    arPoints: [
+      "حماية من الجرائم الإلكترونية مع جاهزية للحوادث واحتواء للاختراقات وتبليغ تشريعي فوري.",
+      "بنية صفرية الثقة وتشفير وسجلات تدقيق تحمي كل مستند وتوقيع.",
+    ],
+  },
+];
+
+const sectionCopy = {
+  en: {
+    badge: "Capabilities",
+    title: "Intelligence, Security, and Digital Mastery",
+    description:
+      "Tailored operating models unite legal excellence, predictive analytics, and uncompromising cybersecurity.",
+  },
+  ar: {
+    badge: "الإمكانيات",
+    title: "الذكاء والحماية والتمكن الرقمي",
+    description:
+      "نماذج تشغيل مخصصة توحد التميز القانوني والتحليلات التنبؤية والأمن السيبراني الصارم.",
+  },
+};
+
+const Capabilities: React.FC = () => {
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = sectionCopy[language];
+
+  return (
+    <section id="capabilities" className="relative overflow-hidden py-24" dir={direction}>
+      <div className="absolute inset-0 bg-gradient-to-b from-background via-secondary/15 to-background" />
+      <div className="container relative mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{copy.title}</h2>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-3">
+          {capabilities.map((capability) => {
+            const Icon = capability.icon;
+            const title = isArabic ? capability.arTitle : capability.enTitle;
+            const description = isArabic ? capability.arDescription : capability.enDescription;
+            const points = isArabic ? capability.arPoints : capability.enPoints;
+
+            return (
+              <div
+                key={capability.enTitle}
+                className="h-full rounded-3xl border border-border bg-card/80 p-8 shadow-elevated backdrop-blur transition-transform duration-500 hover:-translate-y-2 hover:shadow-premium"
+              >
+                <div className="mb-6 flex items-center gap-3">
+                  <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+                    <Icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+                </div>
+
+                <div className={`space-y-3 text-base leading-relaxed text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>
+                  <p>{description}</p>
+                  <ul className="space-y-2 text-sm">
+                    {points.map((point) => (
+                      <li
+                        key={point}
+                        className={`flex items-start gap-2 ${isArabic ? "flex-row-reverse text-right" : ""}`}
+                      >
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                        <span>{point}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Capabilities;

--- a/frontend/src/pages/Landing/Contact.tsx
+++ b/frontend/src/pages/Landing/Contact.tsx
@@ -1,238 +1,238 @@
-import React, { useState } from 'react';
-import { useLanguage } from '@/contexts/LanguageContext';
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
-import { 
-  Send, 
-  MapPin, 
-  Phone, 
-  Mail, 
-  Clock,
-  CheckCircle,
-  MessageSquare,
-  User,
-  AtSign
-} from 'lucide-react';
+import { useLanguage } from "@/contexts/LanguageContext";
+import { Clock3, Mail, MapPin, Phone, Send, ShieldCheck } from "lucide-react";
+
+const contactPoints = [
+  {
+    icon: MapPin,
+    enTitle: "Headquarters",
+    arTitle: "المقر الرئيسي",
+    enDetails: "Downtown Cairo Smart District, Nile Corniche",
+    arDetails: "منطقة القاهرة الذكية – كورنيش النيل",
+  },
+  {
+    icon: Phone,
+    enTitle: "Phone",
+    arTitle: "الهاتف",
+    enDetails: "+20 2 1234 5678 | +971 4 567 8900",
+    arDetails: "+٢٠ ٢ ١٢٣٤ ٥٦٧٨ | +٩٧١ ٤ ٥٦٧ ٨٩٠٠",
+  },
+  {
+    icon: Mail,
+    enTitle: "Email",
+    arTitle: "البريد الإلكتروني",
+    enDetails: "contact@avocatlaw.com",
+    arDetails: "contact@avocatlaw.com",
+  },
+  {
+    icon: Clock3,
+    enTitle: "Business Hours",
+    arTitle: "ساعات العمل",
+    enDetails: "Sunday – Thursday | 9:00 – 18:00",
+    arDetails: "الأحد – الخميس | ٩:٠٠ – ١٨:٠٠",
+  },
+];
+
+const formCopy = {
+  en: {
+    badge: "Contact",
+    title: "Connect with Avocat Law Firm",
+    description: "Schedule a consultation to explore legal digital transformation tailored to your organisation.",
+    labels: {
+      name: "Name",
+      email: "Email",
+      message: "Message",
+    },
+    placeholders: {
+      name: "Full Name",
+      email: "you@avocatlaw.com",
+      message: "Describe your legal technology needs",
+    },
+    submit: "Send Message",
+    submitting: "Sending...",
+    note: "Confidential & encrypted submissions",
+    conciergeTitle: "24/7 Digital Legal Desk",
+    conciergeBody:
+      "Dedicated transformation specialists monitor secure channels around the clock to support urgent cases, investigations, and executive briefings.",
+    toast: {
+      title: "Message sent successfully",
+      description: "Our legal transformation consultants will respond within one business day.",
+    },
+  },
+  ar: {
+    badge: "اتصل بنا",
+    title: "تواصل مع مكتب أفوكات للمحاماة",
+    description: "حدد موعداً لاستشارة تستكشف التحول الرقمي القانوني المصمم لمؤسستك.",
+    labels: {
+      name: "الاسم",
+      email: "البريد الإلكتروني",
+      message: "الرسالة",
+    },
+    placeholders: {
+      name: "الاسم الكامل",
+      email: "you@avocatlaw.com",
+      message: "صف احتياجاتك في التحول الرقمي القانوني",
+    },
+    submit: "إرسال الرسالة",
+    submitting: "جارٍ الإرسال...",
+    note: "إرساليات سرية ومشفرة",
+    conciergeTitle: "مكتب قانوني رقمي على مدار الساعة",
+    conciergeBody:
+      "فريق متخصص في التحول الرقمي القانوني يعمل على مدار الساعة لدعم القضايا العاجلة والتحقيقات والقيادات التنفيذية.",
+    toast: {
+      title: "تم إرسال الرسالة بنجاح",
+      description: "سيتواصل معك مستشارو التحول الرقمي القانوني خلال يوم عمل واحد.",
+    },
+  },
+};
 
 const Contact: React.FC = () => {
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    message: ''
-  });
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { t, isRTL } = useLanguage();
   const { toast } = useToast();
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = formCopy[language];
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({ name: "", email: "", message: "" });
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
     setIsSubmitting(true);
 
-    // Simulate form submission
     setTimeout(() => {
-      toast({
-        title: "Message Sent Successfully!",
-        description: "Thank you for contacting us. We'll get back to you within 24 hours.",
-      });
-      setFormData({ name: '', email: '', message: '' });
+      toast({ title: copy.toast.title, description: copy.toast.description });
+      setFormData({ name: "", email: "", message: "" });
       setIsSubmitting(false);
-    }, 2000);
+    }, 1500);
   };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setFormData(prev => ({
-      ...prev,
-      [e.target.name]: e.target.value
-    }));
-  };
-
-  const contactInfo = [
-    {
-      icon: MapPin,
-      title: 'Headquarters',
-      content: 'Dubai International Financial Centre\nDubai, UAE',
-      gradient: 'from-primary to-primary-light'
-    },
-    {
-      icon: Phone,
-      title: 'Phone',
-      content: '+971 4 123 4567\n+966 11 987 6543',
-      gradient: 'from-accent to-accent-glow'
-    },
-    {
-      icon: Mail,
-      title: 'Email',
-      content: 'info@avocat.com\nsupport@avocat.com',
-      gradient: 'from-primary-light to-primary-glow'
-    },
-    {
-      icon: Clock,
-      title: 'Business Hours',
-      content: 'Sunday - Thursday: 9:00 AM - 6:00 PM\nFriday - Saturday: Closed',
-      gradient: 'from-accent-glow to-accent'
-    }
-  ];
 
   return (
-    <section id="contact" className="py-24 bg-gradient-to-br from-background via-secondary/20 to-background relative overflow-hidden">
-      {/* Background Pattern */}
-      <div className="absolute inset-0 opacity-10">
-        <div className="absolute top-20 left-20 w-96 h-96 bg-primary rounded-full mix-blend-multiply blur-3xl animate-float"></div>
-        <div className="absolute bottom-20 right-20 w-80 h-80 bg-accent rounded-full mix-blend-multiply blur-3xl animate-float" style={{ animationDelay: '2s' }}></div>
+    <section id="contact" className="relative overflow-hidden bg-gradient-to-br from-background via-secondary/10 to-background py-24" dir={direction}>
+      <div className="absolute inset-0 opacity-30">
+        <div className="absolute -left-20 top-32 h-72 w-72 rounded-full bg-primary/40 blur-3xl" />
+        <div className="absolute -right-16 bottom-10 h-80 w-80 rounded-full bg-accent/40 blur-3xl" />
       </div>
-
-      <div className="container mx-auto px-4 lg:px-8 relative z-10">
-        {/* Section Header */}
-        <div className="text-center mb-16 animate-fade-in">
-          <h2 className="text-4xl lg:text-5xl font-display font-bold text-foreground mb-6">
-            {t('contactTitle')}
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-            {t('contactSubtitle')}
-          </p>
+      <div className="container relative mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{copy.title}</h2>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
-          {/* Contact Form */}
-          <div className="animate-slide-up">
-            <div className="card-elevated p-8 lg:p-10">
-              <div className="flex items-center space-x-3 rtl:space-x-reverse mb-8">
-                <div className="w-12 h-12 bg-gradient-to-br from-primary to-primary-light rounded-xl flex items-center justify-center animate-glow">
-                  <MessageSquare className="w-6 h-6 text-white" />
-                </div>
-                <h3 className="text-2xl font-display font-semibold text-foreground">
-                  Send us a Message
-                </h3>
-              </div>
-
-              <form onSubmit={handleSubmit} className="space-y-6">
-                {/* Name Field */}
+        <div className="grid gap-12 lg:grid-cols-[1.2fr_1fr]">
+          <div className="rounded-3xl border border-border bg-card/80 p-8 shadow-elevated backdrop-blur">
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid gap-6 md:grid-cols-2">
                 <div className="space-y-2">
-                  <label className="flex items-center space-x-2 rtl:space-x-reverse text-sm font-medium text-foreground">
-                    <User className="w-4 h-4 text-primary" />
-                    <span>{t('name')}</span>
+                  <label className="text-sm font-medium text-foreground" htmlFor="name">
+                    {copy.labels.name}
                   </label>
                   <Input
+                    required
+                    id="name"
                     name="name"
                     value={formData.name}
                     onChange={handleChange}
-                    className="h-12 border-border focus:border-primary focus:ring-primary/20 transition-all duration-300"
-                    placeholder="Your full name"
-                    required
+                    placeholder={copy.placeholders.name}
+                    className="h-12 rounded-2xl border-border bg-background/70"
                   />
                 </div>
-
-                {/* Email Field */}
                 <div className="space-y-2">
-                  <label className="flex items-center space-x-2 rtl:space-x-reverse text-sm font-medium text-foreground">
-                    <AtSign className="w-4 h-4 text-primary" />
-                    <span>{t('email')}</span>
+                  <label className="text-sm font-medium text-foreground" htmlFor="email">
+                    {copy.labels.email}
                   </label>
                   <Input
-                    name="email"
+                    required
+                    id="email"
                     type="email"
+                    name="email"
                     value={formData.email}
                     onChange={handleChange}
-                    className="h-12 border-border focus:border-primary focus:ring-primary/20 transition-all duration-300"
-                    placeholder="your.email@example.com"
-                    required
+                    placeholder={copy.placeholders.email}
+                    className="h-12 rounded-2xl border-border bg-background/70"
                   />
-                </div>
-
-                {/* Message Field */}
-                <div className="space-y-2">
-                  <label className="flex items-center space-x-2 rtl:space-x-reverse text-sm font-medium text-foreground">
-                    <MessageSquare className="w-4 h-4 text-primary" />
-                    <span>{t('message')}</span>
-                  </label>
-                  <Textarea
-                    name="message"
-                    value={formData.message}
-                    onChange={handleChange}
-                    rows={6}
-                    className="border-border focus:border-primary focus:ring-primary/20 transition-all duration-300 resize-none"
-                    placeholder="Tell us about your legal technology needs..."
-                    required
-                  />
-                </div>
-
-                {/* Submit Button */}
-                <Button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="w-full btn-premium h-12 text-lg group"
-                >
-                  {isSubmitting ? (
-                    <div className="flex items-center space-x-2 rtl:space-x-reverse">
-                      <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
-                      <span>Sending...</span>
-                    </div>
-                  ) : (
-                    <div className="flex items-center space-x-2 rtl:space-x-reverse">
-                      <span>{t('submit')}</span>
-                      <Send className="w-5 h-5 group-hover:translate-x-1 rtl:group-hover:-translate-x-1 transition-transform duration-300" />
-                    </div>
-                  )}
-                </Button>
-              </form>
-
-              {/* Trust Indicators */}
-              <div className="mt-8 pt-8 border-t border-border">
-                <div className="flex items-center justify-center space-x-8 rtl:space-x-reverse text-sm text-muted-foreground">
-                  <div className="flex items-center space-x-2 rtl:space-x-reverse">
-                    <CheckCircle className="w-4 h-4 text-accent" />
-                    <span>Secure & Confidential</span>
-                  </div>
-                  <div className="flex items-center space-x-2 rtl:space-x-reverse">
-                    <CheckCircle className="w-4 h-4 text-accent" />
-                    <span>24h Response</span>
-                  </div>
                 </div>
               </div>
-            </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="message">
+                  {copy.labels.message}
+                </label>
+                <Textarea
+                  required
+                  id="message"
+                  name="message"
+                  value={formData.message}
+                  onChange={handleChange}
+                  rows={6}
+                  placeholder={copy.placeholders.message}
+                  className="resize-none rounded-2xl border-border bg-background/70"
+                />
+              </div>
+
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="btn-gold flex w-full items-center justify-center gap-2 py-3 text-base font-semibold"
+              >
+                {isSubmitting ? (
+                  <span className="flex items-center gap-2 text-sm">
+                    <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                    {copy.submitting}
+                  </span>
+                ) : (
+                  <>
+                    <Send className="h-5 w-5" />
+                    <span>{copy.submit}</span>
+                  </>
+                )}
+              </Button>
+
+              <div className="flex items-center justify-between gap-4 rounded-2xl border border-border bg-background/60 px-6 py-4 text-sm text-muted-foreground">
+                <div className="flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4 text-primary" />
+                  <span>{copy.note}</span>
+                </div>
+              </div>
+            </form>
           </div>
 
-          {/* Contact Information */}
           <div className="space-y-6">
-            {contactInfo.map((info, index) => {
-              const IconComponent = info.icon;
+            {contactPoints.map((point) => {
+              const Icon = point.icon;
+              const title = isArabic ? point.arTitle : point.enTitle;
+              const details = isArabic ? point.arDetails : point.enDetails;
               return (
                 <div
-                  key={index}
-                  className="animate-slide-up card-premium p-6 hover:card-elevated transition-all duration-500 group hover:-translate-y-1"
-                  style={{ animationDelay: `${index * 150}ms` }}
+                  key={point.enTitle}
+                  className="rounded-3xl border border-border bg-background/70 p-6 shadow-ambient backdrop-blur"
                 >
-                  <div className="flex items-start space-x-4 rtl:space-x-reverse">
-                    <div className={`w-14 h-14 bg-gradient-to-br ${info.gradient} rounded-2xl flex items-center justify-center group-hover:scale-110 transition-all duration-300 animate-glow`}>
-                      <IconComponent className="w-7 h-7 text-white" />
+                  <div className="flex items-start gap-4">
+                    <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+                      <Icon className="h-6 w-6" />
                     </div>
-                    <div className="flex-1">
-                      <h4 className="text-xl font-display font-semibold text-foreground mb-2 group-hover:text-primary transition-colors duration-300">
-                        {info.title}
-                      </h4>
-                      <p className="text-muted-foreground leading-relaxed whitespace-pre-line">
-                        {info.content}
-                      </p>
+                    <div className={`${isArabic ? "text-right" : "text-left"}`}>
+                      <p className="text-sm font-semibold text-foreground">{title}</p>
+                      <p className="text-sm text-muted-foreground">{details}</p>
                     </div>
                   </div>
                 </div>
               );
             })}
 
-            {/* Call to Action */}
-            <div className="card-elevated p-8 text-center bg-gradient-primary text-white animate-fade-in">
-              <h4 className="text-2xl font-display font-bold mb-4">
-                Ready to Get Started?
-              </h4>
-              <p className="text-white/90 mb-6 leading-relaxed">
-                Schedule a free consultation with our legal technology experts
-              </p>
-              <Button className="btn-gold">
-                Book Consultation
-                <Phone className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-              </Button>
+            <div className="rounded-3xl border border-border bg-gradient-primary p-8 text-white shadow-premium">
+              <h3 className="font-display text-2xl font-semibold">{copy.conciergeTitle}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-white/80">{copy.conciergeBody}</p>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Landing/Footer.tsx
+++ b/frontend/src/pages/Landing/Footer.tsx
@@ -1,245 +1,174 @@
-import React from "react";
 import BrandLogo from "@/components/common/BrandLogo";
 import { useLanguage } from "@/contexts/LanguageContext";
-import {
-  Scale,
-  MapPin,
-  Mail,
-  Phone,
-  Globe,
-  Linkedin,
-  Twitter,
-  Facebook,
-  Instagram,
-  ArrowUp,
-  Shield,
-  FileText,
-  Users,
-  BookOpen,
-} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Linkedin, Mail, MapPin, Phone, Scale, Shield, Twitter } from "lucide-react";
 
-type FooterProps = {
-  services: string[];
-  contact: {
-    email: string;
-    phone: string;
-    address: string;
-  };
-  logoVariant: "text" | "icon"; // 👈 نفس النوع اللي متوقعه BrandLogo
+const quickLinks = [
+  { href: "#home", en: "Home", ar: "الرئيسية" },
+  { href: "#about", en: "About", ar: "من نحن" },
+  { href: "#services", en: "Services", ar: "الخدمات" },
+  { href: "#capabilities", en: "Capabilities", ar: "الإمكانيات" },
+  { href: "#achievements", en: "Achievements", ar: "الإنجازات" },
+  { href: "#team", en: "Team", ar: "الفريق" },
+  { href: "#insights", en: "Insights", ar: "المدونة" },
+  { href: "#contact", en: "Contact", ar: "اتصل بنا" },
+];
+
+const serviceHighlights = [
+  { en: "Litigation & Arbitration", ar: "التقاضي والتحكيم" },
+  { en: "Digital Case Management", ar: "إدارة القضايا الرقمية" },
+  { en: "AI Legal Research", ar: "البحث القانوني بالذكاء الاصطناعي" },
+  { en: "Cybersecurity Advisory", ar: "استشارات الأمن السيبراني" },
+];
+
+const contactDetails = [
+  {
+    icon: MapPin,
+    en: "Downtown Cairo Smart District, Nile Corniche",
+    ar: "منطقة القاهرة الذكية – كورنيش النيل",
+  },
+  {
+    icon: Phone,
+    en: "+20 2 1234 5678 | +971 4 567 8900",
+    ar: "+٢٠ ٢ ١٢٣٤ ٥٦٧٨ | +٩٧١ ٤ ٥٦٧ ٨٩٠٠",
+  },
+  {
+    icon: Mail,
+    en: "contact@avocatlaw.com",
+    ar: "contact@avocatlaw.com",
+  },
+  {
+    icon: Shield,
+    en: "GDPR, DIFC, and NCA compliant digital infrastructure.",
+    ar: "بنية رقمية متوافقة مع لوائح GDPR وDIFC والهيئة الوطنية للأمن السيبراني.",
+  },
+];
+
+const footerCopy = {
+  en: {
+    mission:
+      "Pioneering legal digital transformation across the Middle East and North Africa with prestige, innovation, and unwavering trust.",
+    highlight: "Legal Digital Transformation",
+    quickLinks: "Quick Links",
+    services: "Signature Services",
+    subscribeTitle: "Subscribe for Insights",
+    subscribeBody:
+      "Receive monthly briefings on AI in law, cybersecurity directives, and smart justice reforms.",
+    contact: "Contact",
+    bottom: (year: number) => `© ${year} Avocat Law Firm. All rights reserved.`,
+  },
+  ar: {
+    mission:
+      "رواد التحول الرقمي القانوني في الشرق الأوسط وشمال أفريقيا بفخامة وابتكار وثقة راسخة.",
+    highlight: "التحول الرقمي القانوني",
+    quickLinks: "الروابط السريعة",
+    services: "خدماتنا المميزة",
+    subscribeTitle: "اشترك في الرؤى",
+    subscribeBody:
+      "احصل على موجز شهري حول الذكاء الاصطناعي في القانون وتوجيهات الأمن السيبراني وإصلاحات العدالة الذكية.",
+    contact: "تواصل",
+    bottom: (year: number) => `© ${year} مكتب أفوكات للمحاماة. جميع الحقوق محفوظة.`,
+  },
 };
 
-const Footer: React.FC<FooterProps> = ({ services, contact, logoVariant }) => {
-  const { t, isRTL, language } = useLanguage();
+const Footer: React.FC = () => {
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = footerCopy[language];
 
-  const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  };
-
-  const scrollToSection = (sectionId: string) => {
-    const element = document.querySelector(sectionId);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth" });
-    }
+  const scrollTo = (href: string) => {
+    const element = document.querySelector(href);
+    element?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
-    <footer className="bg-gradient-primary text-white relative overflow-hidden">
-      {/* Background Pattern */}
-      <div className="absolute inset-0 opacity-10">
-        <div className="absolute top-10 left-10 w-72 h-72 bg-accent rounded-full mix-blend-overlay blur-3xl animate-float"></div>
-        <div
-          className="absolute bottom-10 right-10 w-96 h-96 bg-white rounded-full mix-blend-overlay blur-3xl animate-float"
-          style={{ animationDelay: "3s" }}
-        ></div>
+    <footer className="relative mt-24 bg-gradient-to-b from-primary/90 via-primary/80 to-primary/95 text-white" dir={direction}>
+      <div className="absolute inset-0 opacity-20">
+        <div className="absolute left-10 top-16 h-48 w-48 rounded-full bg-accent/70 blur-3xl" />
+        <div className="absolute right-0 bottom-10 h-56 w-56 rounded-full bg-white/50 blur-3xl" />
       </div>
-
-      <div className="container mx-auto px-4 lg:px-8 relative z-10">
-        {/* Main Footer Content */}
-        <div className="py-16">
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-12">
-            {/* Company Info */}
-            <div className="lg:col-span-1 animate-fade-in">
-              <div className="flex items-center space-x-3 rtl:space-x-reverse mb-6">
-                   <div className="text-2xl font-display font-bold">
-             <BrandLogo
-              variant="full"
-              className="h-12"
-              lang={language}
-              dark={true} // Ensure dark before scroll
-            />
- 
-                </div>
+      <div className="relative">
+        <div className="container mx-auto grid gap-12 px-4 py-16 lg:grid-cols-4 lg:px-8">
+          <div className="space-y-6">
+            <BrandLogo variant="full" className="h-12" lang={language} dark />
+            <p className="text-sm leading-relaxed text-white/80">{copy.mission}</p>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10">
+                <Scale className="h-6 w-6" />
               </div>
- 
-
-              {/* Social Links */}
-              <div className="flex space-x-4 rtl:space-x-reverse">
-                {[
-                  { icon: Linkedin, href: "#", color: "hover:bg-blue-600" },
-                  { icon: Twitter, href: "#", color: "hover:bg-blue-400" },
-                  { icon: Facebook, href: "#", color: "hover:bg-blue-700" },
-                  { icon: Instagram, href: "#", color: "hover:bg-pink-600" },
-                ].map((social, index) => {
-                  const IconComponent = social.icon;
-                  return (
-                    <a
-                      key={index}
-                      href={social.href}
-                      className={`w-10 h-10 bg-white/20 backdrop-blur-md rounded-lg flex items-center justify-center ${social.color} transition-all duration-300 group`}
-                    >
-                      <IconComponent className="w-5 h-5 text-white group-hover:scale-110 transition-transform duration-300" />
-                    </a>
-                  );
-                })}
-              </div>
+              <div className="text-xs uppercase tracking-widest text-white/70">{copy.highlight}</div>
             </div>
+            <div className="flex gap-3">
+              <Button variant="ghost" className="h-10 w-10 rounded-full border border-white/30 text-white hover:bg-white/20">
+                <Linkedin className="h-5 w-5" />
+              </Button>
+              <Button variant="ghost" className="h-10 w-10 rounded-full border border-white/30 text-white hover:bg-white/20">
+                <Twitter className="h-5 w-5" />
+              </Button>
+            </div>
+          </div>
 
-            {/* Services */}
-            <div
-              className="animate-slide-up"
-              style={{ animationDelay: "200ms" }}
-            >
-              <h3 className="text-xl font-display font-semibold text-white mb-6 flex items-center space-x-2 rtl:space-x-reverse">
-                <FileText className="w-5 h-5 text-accent" />
-                <span>{t("ourServices")}</span>
-              </h3>
-              <ul className="space-y-3">
-                {services.map((label, index) => (
-                  <li key={index}>
+          <div>
+            <h3 className="font-display text-lg font-semibold text-white">{copy.quickLinks}</h3>
+            <ul className="mt-6 space-y-3 text-sm text-white/80">
+              {quickLinks.map((link) => {
+                const label = isArabic ? link.ar : link.en;
+                return (
+                  <li key={link.href}>
                     <button
-                      onClick={() => scrollToSection("#services")}
-                      className="flex items-center space-x-2 rtl:space-x-reverse text-white/80 hover:text-accent transition-colors duration-300 group"
+                      onClick={() => scrollTo(link.href)}
+                      className="flex w-full items-center justify-between rounded-xl border border-transparent px-3 py-2 text-left transition-all duration-300 hover:border-white/40 hover:bg-white/10"
                     >
-                      <Shield className="w-4 h-4 group-hover:scale-110 transition-transform duration-300" />
                       <span>{label}</span>
+                      <span className="text-xs uppercase tracking-widest text-white/60">{link.href.replace('#', '')}</span>
                     </button>
                   </li>
-                ))}
-              </ul>
-            </div>
+                );
+              })}
+            </ul>
+          </div>
 
-            {/* Quick Links */}
-            <div
-              className="animate-slide-up"
-              style={{ animationDelay: "400ms" }}
-            >
-              <h3 className="text-xl font-display font-semibold text-white mb-6 flex items-center space-x-2 rtl:space-x-reverse">
-                <Globe className="w-5 h-5 text-accent" />
-                <span>Quick Links</span>
-              </h3>
-              <ul className="space-y-3">
-                {[
-                  { label: t("home"), href: "#home" },
-                  { label: t("features"), href: "#features" },
-                  { label: t("about"), href: "#about" },
-                  { label: t("contact"), href: "#contact" },
-                ].map((link, index) => (
-                  <li key={index}>
-                    <button
-                      onClick={() => scrollToSection(link.href)}
-                      className="text-white/80 hover:text-accent transition-colors duration-300 hover:translate-x-1 rtl:hover:-translate-x-1"
-                    >
-                      {link.label}
-                    </button>
+          <div>
+            <h3 className="font-display text-lg font-semibold text-white">{copy.services}</h3>
+            <ul className="mt-6 space-y-3 text-sm text-white/80">
+              {serviceHighlights.map((service) => {
+                const text = isArabic ? service.ar : service.en;
+                return (
+                  <li key={service.en} className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+                    {text}
                   </li>
-                ))}
-              </ul>
+                );
+              })}
+            </ul>
+            <div className="mt-6 rounded-3xl border border-white/20 bg-white/10 p-5">
+              <h4 className="font-display text-base font-semibold text-white">{copy.subscribeTitle}</h4>
+              <p className="mt-2 text-xs text-white/80">{copy.subscribeBody}</p>
             </div>
+          </div>
 
-            {/* Contact Info */}
-            <div
-              className="animate-slide-up"
-              style={{ animationDelay: "600ms" }}
-            >
-              <h3 className="text-xl font-display font-semibold text-white mb-6 flex items-center space-x-2 rtl:space-x-reverse">
-                <Phone className="w-5 h-5 text-accent" />
-                <span>{t("contactInfo")}</span>
-              </h3>
-              <div className="space-y-4">
-                <div className="flex items-start space-x-3 rtl:space-x-reverse">
-                  <MapPin className="w-5 h-5 text-accent mt-1 flex-shrink-0" />
-                  <div className="text-white/80 leading-relaxed">
-                    <div className="font-medium text-white mb-1">
-                      {t("headquarters")}
-                    </div>
-                    <div>{contact.address}</div>
+          <div className="space-y-5">
+            <h3 className="font-display text-lg font-semibold text-white">{copy.contact}</h3>
+            <div className="space-y-4 text-sm text-white/80">
+              {contactDetails.map((detail) => {
+                const Icon = detail.icon;
+                const text = isArabic ? detail.ar : detail.en;
+                return (
+                  <div key={detail.en} className="flex items-start gap-3">
+                    <Icon className="mt-1 h-5 w-5" />
+                    <p>{text}</p>
                   </div>
-                </div>
-
-                <div className="flex items-center space-x-3 rtl:space-x-reverse">
-                  <Mail className="w-5 h-5 text-accent flex-shrink-0" />
-                  <a
-                    href={`mailto:${contact.email}`}
-                    className="text-white/80 hover:text-accent transition-colors duration-300"
-                  >
-                    {contact.email}
-                  </a>
-                </div>
-
-                <div className="flex items-center space-x-3 rtl:space-x-reverse">
-                  <Phone className="w-5 h-5 text-accent flex-shrink-0" />
-                  <a
-                    href={`tel:${contact.phone}`}
-                    className="text-white/80 hover:text-accent transition-colors duration-300"
-                  >
-                    {contact.phone}
-                  </a>
-                </div>
-              </div>
+                );
+              })}
             </div>
           </div>
         </div>
 
-        {/* Newsletter Section */}
-        <div className="py-8 border-t border-white/20 animate-fade-in">
-          <div className="text-center">
-            <h3 className="text-2xl font-display font-semibold text-white mb-4">
-              Stay Updated on Legal Technology Trends
-            </h3>
-            <p className="text-white/80 mb-6 max-w-2xl mx-auto">
-              Subscribe to our newsletter for the latest insights on legal
-              digital transformation
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
-              <input
-                type="email"
-                placeholder="Enter your email"
-                className="flex-1 px-4 py-3 rounded-xl bg-white/20 backdrop-blur-md border border-white/30 text-white placeholder-white/60 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 transition-all duration-300"
-              />
-              <button className="btn-gold px-6 py-3 rounded-xl font-medium hover:scale-105 transition-all duration-300">
-                Subscribe
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Bottom Bar */}
-        <div className="py-6 border-t border-white/20 flex flex-col md:flex-row items-center justify-between animate-fade-in">
-          <div className="text-white/60 text-sm mb-4 md:mb-0">
-            © 2024 Avocat. {t("allRightsReserved")}
-          </div>
-
-          <div className="flex items-center space-x-6 rtl:space-x-reverse text-sm text-white/60">
-            <a href="#" className="hover:text-accent transition-colors duration-300">
-              Privacy Policy
-            </a>
-            <a href="#" className="hover:text-accent transition-colors duration-300">
-              Terms of Service
-            </a>
-            <a href="#" className="hover:text-accent transition-colors duration-300">
-              Cookie Policy
-            </a>
+        <div className="border-t border-white/10 bg-primary/95">
+          <div className="container mx-auto flex flex-col items-center justify-between gap-4 px-4 py-6 text-xs text-white/80 lg:flex-row lg:px-8">
+            <p>{copy.bottom(new Date().getFullYear())}</p>
           </div>
         </div>
       </div>
-
-      {/* Scroll to Top Button */}
-      <button
-        onClick={scrollToTop}
-        className="fixed bottom-8 right-8 w-14 h-14 bg-gradient-gold text-accent-foreground rounded-full flex items-center justify-center shadow-gold hover:shadow-xl hover:scale-110 transition-all duration-300 z-50 group animate-glow"
-      >
-        <ArrowUp className="w-6 h-6 group-hover:scale-110 transition-transform duration-300" />
-      </button>
     </footer>
   );
 };

--- a/frontend/src/pages/Landing/HeroCarousel.tsx
+++ b/frontend/src/pages/Landing/HeroCarousel.tsx
@@ -1,203 +1,279 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useLanguage } from '@/contexts/LanguageContext';
-import { ChevronLeft, ChevronRight, Play, ArrowRight } from 'lucide-react';
+import { useLanguage } from "@/contexts/LanguageContext";
+import { ChevronLeft, ChevronRight, Mail, Play, ShieldCheck, Sparkles } from "lucide-react";
 
-// Import hero images
-import heroLegal1 from '@/assets/slides/hero-legal-1.png';
-import heroDigital2 from '@/assets/slides/hero-digital-2.png';
-import heroPartnership3 from '@/assets/slides/hero-partnership-3.png';
+import heroLegal1 from "@/assets/slides/hero-legal-1.png";
+import heroDigital2 from "@/assets/slides/hero-digital-2.png";
+import heroPartnership3 from "@/assets/slides/hero-partnership-3.png";
 
-interface Slide {
+type SlideCopy = {
+  title: string;
+  subtitle: string;
+  bullets: string[];
+};
+
+type Slide = {
   id: number;
-  titleKey: string;
-  subtitleKey: string;
   image: string;
   overlay: string;
-}
+  badge: {
+    en: string;
+    ar: string;
+  };
+  copy: Record<"en" | "ar", SlideCopy>;
+};
+
+const slides: Slide[] = [
+  {
+    id: 1,
+    image: heroLegal1,
+    overlay: "bg-gradient-to-r from-primary/90 via-primary/70 to-transparent",
+    badge: {
+      en: "Legal Digital Transformation",
+      ar: "التحول الرقمي القانوني",
+    },
+    copy: {
+      en: {
+        title: "Prestige Meets Predictive Legal Intelligence",
+        subtitle:
+          "Founded in 2013, Avocat Law Firm bridges traditional expertise with digital innovation to deliver justice that is safer, more transparent, and more efficient.",
+        bullets: [
+          "Heritage-grade litigation strategies enhanced with secure analytics.",
+          "Trusted counsel for ministries, financial institutions, and innovators.",
+          "Digitally preserved evidence chains with verifiable audit trails.",
+        ],
+      },
+      ar: {
+        title: "الفخامة تلتقي بالذكاء القانوني الاستباقي",
+        subtitle:
+          "تأسس مكتب أفوكات عام 2013 ليكون جسراً بين الخبرة القانونية التقليدية والابتكار الرقمي، بهدف تقديم عدالة أكثر أماناً وشفافية وفعالية.",
+        bullets: [
+          "استراتيجيات تقاضٍ عريقة مدعومة بتحليلات آمنة.",
+          "استشارات موثوقة للوزارات والمؤسسات المالية ورواد الابتكار.",
+          "سلاسل أدلة رقمية محفوظة مع سجلات تدقيق موثوقة.",
+        ],
+      },
+    },
+  },
+  {
+    id: 2,
+    image: heroDigital2,
+    overlay: "bg-gradient-to-r from-primary-light/90 via-primary/60 to-accent/20",
+    badge: {
+      en: "AI-Driven Counsel",
+      ar: "استشارات مدعومة بالذكاء الاصطناعي",
+    },
+    copy: {
+      en: {
+        title: "AI-Enhanced Advocacy Without Compromise",
+        subtitle:
+          "Intelligent systems for case management, precedent research, and data-driven legal strategies.",
+        bullets: [
+          "Predictive analytics anticipates judicial patterns before hearings.",
+          "Augmented research assistant surfaces decisive precedents instantly.",
+          "Secure collaboration keeps partners, experts, and clients aligned.",
+        ],
+      },
+      ar: {
+        title: "مرافعات مدعومة بالذكاء الاصطناعي دون تنازل",
+        subtitle:
+          "أنظمة ذكية لإدارة القضايا، البحث في السوابق، وبناء استراتيجيات قانونية قائمة على البيانات.",
+        bullets: [
+          "تحليلات تنبؤية تستشرف توجهات القضاء قبل الجلسة.",
+          "مساعد بحث معزز يستحضر السوابق الحاسمة فوراً.",
+          "تعاون مؤمن يحافظ على مواءمة الشركاء والخبراء والعملاء.",
+        ],
+      },
+    },
+  },
+  {
+    id: 3,
+    image: heroPartnership3,
+    overlay: "bg-gradient-to-r from-primary/95 via-primary/70 to-secondary/30",
+    badge: {
+      en: "Secure Digital Justice",
+      ar: "عدالة رقمية آمنة",
+    },
+    copy: {
+      en: {
+        title: "Leaders of Secure Digital Justice Ecosystems",
+        subtitle:
+          "Integrated platforms with e-signatures, secure archiving, dashboards, and paperless smart justice.",
+        bullets: [
+          "ISO-aligned cybersecurity architecture for cross-border operations.",
+          "Real-time governance dashboards for executives and compliance officers.",
+          "24/7 monitoring shield against fraud, forgery, and cybercrime.",
+        ],
+      },
+      ar: {
+        title: "روّاد منظومات العدالة الرقمية الآمنة",
+        subtitle:
+          "منصات متكاملة بالتوقيع الإلكتروني، الأرشفة الآمنة، لوحات تحكم تفاعلية، وعدالة رقمية بلا ورق.",
+        bullets: [
+          "بنية أمن سيبراني متوافقة مع المعايير الدولية للعمليات العابرة للحدود.",
+          "لوحات حوكمة لحظية للمديرين والتنفيذيين ومسؤولي الامتثال.",
+          "مراقبة على مدار الساعة تحمي من الاحتيال والتزوير والجرائم السيبرانية.",
+        ],
+      },
+    },
+  },
+];
 
 const HeroCarousel: React.FC = () => {
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const [isAutoPlaying, setIsAutoPlaying] = useState(true);
-  const { t, isRTL } = useLanguage();
-
-  const slides: Slide[] = [
-    {
-      id: 1,
-      titleKey: 'heroSlide1Title',
-      subtitleKey: 'heroSlide1Subtitle',
-      image: heroLegal1,
-      overlay: 'bg-gradient-to-r from-primary/90 via-primary/60 to-transparent'
-    },
-    {
-      id: 2,
-      titleKey: 'heroSlide2Title',
-      subtitleKey: 'heroSlide2Subtitle',
-      image: heroDigital2,
-      overlay: 'bg-gradient-to-r from-primary-light/90 via-primary-light/60 to-transparent'
-    },
-    {
-      id: 3,
-      titleKey: 'heroSlide3Title',
-      subtitleKey: 'heroSlide3Subtitle',
-      image: heroPartnership3,
-      overlay: 'bg-gradient-to-r from-primary/95 via-primary/70 to-accent/20'
-    }
-  ];
+  const [current, setCurrent] = useState(0);
+  const [autoPlay, setAutoPlay] = useState(true);
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
 
   useEffect(() => {
-    if (!isAutoPlaying) return;
-    
-    const interval = setInterval(() => {
-      setCurrentSlide((prev) => (prev + 1) % slides.length);
-    }, 5000);
+    if (!autoPlay) return;
+    const timer = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % slides.length);
+    }, 6000);
+    return () => clearInterval(timer);
+  }, [autoPlay]);
 
-    return () => clearInterval(interval);
-  }, [isAutoPlaying, slides.length]);
-
-  const nextSlide = () => {
-    setCurrentSlide((prev) => (prev + 1) % slides.length);
-    setIsAutoPlaying(false);
+  const handlePrev = () => {
+    setCurrent((prev) => (prev - 1 + slides.length) % slides.length);
+    setAutoPlay(false);
   };
 
-  const prevSlide = () => {
-    setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length);
-    setIsAutoPlaying(false);
+  const handleNext = () => {
+    setCurrent((prev) => (prev + 1) % slides.length);
+    setAutoPlay(false);
   };
 
-  const goToSlide = (index: number) => {
-    setCurrentSlide(index);
-    setIsAutoPlaying(false);
+  const goTo = (index: number) => {
+    setCurrent(index);
+    setAutoPlay(false);
   };
 
-  const scrollToContact = () => {
-    const element = document.querySelector('#contact');
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
-    }
+  const handleDemoClick = () => {
+    document.querySelector("#capabilities")?.scrollIntoView({ behavior: "smooth" });
   };
+
+  const handleContactClick = () => {
+    document.querySelector("#contact")?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  const activeSlide = slides[current];
+  const slideCopy = activeSlide.copy[isArabic ? "ar" : "en"];
+  const badge = activeSlide.badge[isArabic ? "ar" : "en"];
+  const demoLabel = isArabic ? "اطلب العرض التفاعلي" : "Request Live Demo";
+  const contactLabel = isArabic ? "تواصل مع الخبراء" : "Speak to Counsel";
 
   return (
-    <section id="home" className="relative h-screen overflow-hidden">
-      {/* Slides */}
-      <div className="relative w-full h-full">
+    <section id="home" className="relative h-[90vh] min-h-[640px] overflow-hidden" dir={direction}>
+      <div className="absolute inset-0">
         {slides.map((slide, index) => (
           <div
             key={slide.id}
-            className={`absolute inset-0 transition-all duration-1000 ease-in-out ${
-              index === currentSlide 
-                ? 'opacity-100 scale-100' 
-                : 'opacity-0 scale-105'
+            className={`absolute inset-0 transition-all duration-1000 ease-out ${
+              index === current ? "opacity-100 scale-100" : "pointer-events-none opacity-0 scale-105"
             }`}
           >
-            {/* Background Image */}
             <div
-              className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+              className="absolute inset-0 bg-cover bg-center"
               style={{ backgroundImage: `url(${slide.image})` }}
             />
-            
-            {/* Overlay */}
             <div className={`absolute inset-0 ${slide.overlay}`} />
-            
-            {/* Content */}
-            <div className="relative z-10 h-full flex items-center">
-              <div className="container mx-auto px-4 lg:px-8">
-                <div className={`max-w-4xl ${isRTL ? 'mr-auto text-right' : 'ml-auto text-left'}`}>
-                  <div className="animate-fade-in">
-                    <h1 className="text-5xl lg:text-7xl font-display font-bold text-white mb-6 leading-tight">
-                      <span className="block animate-slide-up">
-                        {t(slide.titleKey)}
-                      </span>
-                    </h1>
-                    
-                    <p className="text-xl lg:text-2xl text-white/90 mb-8 leading-relaxed max-w-3xl animate-slide-up delay-200">
-                      {t(slide.subtitleKey)}
-                    </p>
-                    
-                    <div className={`flex flex-col sm:flex-row gap-4 animate-slide-up delay-400 ${
-                      isRTL  ? 'sm:justify-end' : 'sm:justify-start'
-                    }`}>
-                      <Button 
-                        size="lg" 
-                        className="btn-gold text-lg px-8 py-4 h-auto group"
-                        onClick={() => window.open('#demo', '_blank')}
-                      >
-                        <Play className="w-5 h-5 mr-2 rtl:ml-2 rtl:mr-0 group-hover:scale-110 transition-transform" />
-                        {t('getDemo')}
-                      </Button>
-                      
-                      <Button 
-                        size="lg" 
-                        variant="outline" 
-                        className="btn-glass text-lg px-8 py-4 h-auto group"
-                        onClick={scrollToContact}
-                      >
-                        {t('contactUs')}
-                        <ArrowRight className="w-5 h-5 ml-2 rtl:mr-2 rtl:ml-0 group-hover:translate-x-1 rtl:group-hover:-translate-x-1 transition-transform" />
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
         ))}
       </div>
 
-      {/* Navigation Arrows */}
+      <div className="relative z-10 flex h-full items-center">
+        <div className="container mx-auto px-4 lg:px-8">
+          <div className="max-w-4xl rounded-3xl bg-background/70 p-6 shadow-ambient backdrop-blur lg:p-10">
+            <div className="mb-6 inline-flex items-center gap-3 rounded-full border border-border/80 bg-card/80 px-4 py-2 text-xs font-semibold text-white/90 shadow-inner backdrop-blur">
+              <Sparkles className="h-4 w-4 text-accent" />
+              <span>{badge}</span>
+            </div>
+
+            <div className={`space-y-6 text-white ${isArabic ? "text-right" : "text-left"}`}>
+              <h1 className="text-4xl font-display font-semibold leading-tight drop-shadow lg:text-5xl">
+                {slideCopy.title}
+              </h1>
+              <p className="text-lg leading-relaxed text-white/85">{slideCopy.subtitle}</p>
+              <ul className="space-y-3 text-base">
+                {slideCopy.bullets.map((item) => (
+                  <li
+                    key={item}
+                    className={`flex items-start gap-3 ${isArabic ? "flex-row-reverse text-right" : ""}`}
+                  >
+                    <ShieldCheck className="mt-1 h-5 w-5 flex-shrink-0 text-accent" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div
+              className={`mt-8 flex flex-col gap-4 sm:flex-row ${
+                isArabic ? "sm:flex-row-reverse" : ""
+              } sm:items-center`}
+            >
+              <Button
+                onClick={handleDemoClick}
+                className="btn-gold flex items-center justify-center gap-2 px-8 py-3 text-base font-semibold"
+              >
+                <Play className="h-5 w-5" />
+                <span>{demoLabel}</span>
+              </Button>
+              <Button
+                onClick={handleContactClick}
+                variant="outline"
+                className="btn-glass flex items-center justify-center gap-2 border-white/40 px-8 py-3 text-base font-semibold text-white"
+              >
+                <Mail className="h-5 w-5" />
+                <span>{contactLabel}</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <button
-        onClick={prevSlide}
-        className={`absolute top-1/2 -translate-y-1/2 ${
-          isRTL ? 'right-6' : 'left-6'
-        } z-20 w-12 h-12 bg-white/20 backdrop-blur-md rounded-full flex items-center justify-center hover:bg-white/30 transition-all duration-300 group`}
+        onClick={handlePrev}
+        className="absolute left-6 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-white/40 bg-background/30 backdrop-blur transition-all duration-300 hover:border-white/70 hover:bg-background/50"
+        aria-label="Previous slide"
       >
-        <ChevronLeft className="w-6 h-6 text-white group-hover:scale-110 transition-transform" />
+        <ChevronLeft className="h-6 w-6 text-white" />
       </button>
-      
       <button
-        onClick={nextSlide}
-        className={`absolute top-1/2 -translate-y-1/2 ${
-          isRTL  ? 'left-6' : 'right-6'
-        } z-20 w-12 h-12 bg-white/20 backdrop-blur-md rounded-full flex items-center justify-center hover:bg-white/30 transition-all duration-300 group`}
+        onClick={handleNext}
+        className="absolute right-6 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-white/40 bg-background/30 backdrop-blur transition-all duration-300 hover:border-white/70 hover:bg-background/50"
+        aria-label="Next slide"
       >
-        <ChevronRight className="w-6 h-6 text-white group-hover:scale-110 transition-transform" />
+        <ChevronRight className="h-6 w-6 text-white" />
       </button>
 
-      {/* Slide Indicators */}
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20 flex space-x-3">
-        {slides.map((_, index) => (
+      <div className="absolute bottom-8 left-1/2 z-20 flex -translate-x-1/2 items-center space-x-3">
+        {slides.map((slide, index) => (
           <button
-            key={index}
-            onClick={() => goToSlide(index)}
-            className={`w-3 h-3 rounded-full transition-all duration-300 ${
-              index === currentSlide 
-                ? 'bg-accent w-8' 
-                : 'bg-white/50 hover:bg-white/70'
+            key={slide.id}
+            onClick={() => goTo(index)}
+            className={`h-2 rounded-full transition-all duration-500 ${
+              index === current ? "w-10 bg-accent" : "w-3 bg-white/50 hover:bg-white/80"
             }`}
+            aria-label={`Go to slide ${index + 1}`}
           />
         ))}
       </div>
 
-      {/* Auto-play Toggle */}
       <button
-        onClick={() => setIsAutoPlaying(!isAutoPlaying)}
-        className="absolute bottom-6 right-6 z-20 w-10 h-10 bg-white/20 backdrop-blur-md rounded-full flex items-center justify-center hover:bg-white/30 transition-all duration-300"
+        onClick={() => setAutoPlay((prev) => !prev)}
+        className="absolute bottom-8 right-6 z-20 flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-background/40 backdrop-blur transition"
+        aria-label="Toggle autoplay"
       >
-        {isAutoPlaying ? (
-          <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+        {autoPlay ? (
+          <div className="h-2 w-2 rounded-full bg-white" />
         ) : (
-          <Play className="w-4 h-4 text-white fill-current" />
+          <Play className="h-4 w-4 text-white" />
         )}
       </button>
-
-      {/* Scroll Indicator */}
-      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 animate-bounce">
-        <div className="w-6 h-10 border-2 border-white/50 rounded-full flex justify-center">
-          <div className="w-1 h-3 bg-white/70 rounded-full mt-2 animate-pulse"></div>
-        </div>
-      </div>
     </section>
   );
 };
 
-export default HeroCarousel
+export default HeroCarousel;

--- a/frontend/src/pages/Landing/Insights.tsx
+++ b/frontend/src/pages/Landing/Insights.tsx
@@ -1,0 +1,117 @@
+import { useLanguage } from "@/contexts/LanguageContext";
+import { BrainCircuit, Newspaper, ShieldAlert } from "lucide-react";
+
+type Article = {
+  icon: typeof BrainCircuit;
+  enTitle: string;
+  arTitle: string;
+  enSummary: string;
+  arSummary: string;
+  enTag: string;
+  arTag: string;
+};
+
+const articles: Article[] = [
+  {
+    icon: BrainCircuit,
+    enTitle: "AI Governance for the Modern Law Firm",
+    arTitle: "حوكمة الذكاء الاصطناعي في مكاتب المحاماة الحديثة",
+    enSummary:
+      "Discover how predictive analytics, machine learning assistants, and ethical frameworks accelerate precedent research while preserving professional responsibility.",
+    arSummary:
+      "اكتشف كيف تسرّع التحليلات التنبؤية والمساعدات المعتمدة على التعلم الآلي والأطر الأخلاقية عمليات البحث في السوابق مع الحفاظ على المسؤولية المهنية.",
+    enTag: "Digital Legal Transformation",
+    arTag: "التحول القانوني الرقمي",
+  },
+  {
+    icon: Newspaper,
+    enTitle: "Smart Justice Dashboards for Executives",
+    arTitle: "لوحات عدالة ذكية للقيادات التنفيذية",
+    enSummary:
+      "Dashboards that integrate litigation status, budget analytics, and client sentiment deliver real-time governance to boards and ministries.",
+    arSummary:
+      "لوحات تحكم تدمج حالة القضايا وتحليلات الميزانيات ومؤشرات رضا العملاء لتوفير حوكمة لحظية لمجالس الإدارة والوزارات.",
+    enTag: "Client Transparency",
+    arTag: "شفافية العملاء",
+  },
+  {
+    icon: ShieldAlert,
+    enTitle: "Cybercrime Playbooks for Regulated Industries",
+    arTitle: "أدلة مكافحة الجرائم الإلكترونية للقطاعات المنظمة",
+    enSummary:
+      "From financial services to healthcare, explore compliant digital forensics, incident response, and cross-border notification strategies.",
+    arSummary:
+      "من الخدمات المالية إلى الرعاية الصحية، استكشف التحقيقات الرقمية المتوافقة، والاستجابة للحوادث، واستراتيجيات الإخطار العابرة للحدود.",
+    enTag: "Cybersecurity",
+    arTag: "الأمن السيبراني",
+  },
+];
+
+const sectionCopy = {
+  en: {
+    badge: "Insights & Blog",
+    title: "Thought Leadership in Digital Legal Transformation",
+    description:
+      "Perspectives that help boards, innovators, and legal teams navigate AI, cybersecurity, and smart justice reforms.",
+    cta: "Read the full insight ↗",
+  },
+  ar: {
+    badge: "مدونة التحول الرقمي",
+    title: "ريادة فكرية في التحول الرقمي القانوني",
+    description:
+      "رؤى تساعد مجالس الإدارة والمبتكرين والفرق القانونية على التنقل في مجالات الذكاء الاصطناعي والأمن السيبراني وإصلاحات العدالة الذكية.",
+    cta: "اقرأ التحليل الكامل ↗",
+  },
+};
+
+const Insights: React.FC = () => {
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = sectionCopy[language];
+
+  return (
+    <section id="insights" className="bg-background py-24" dir={direction}>
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{copy.title}</h2>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-3">
+          {articles.map((article) => {
+            const Icon = article.icon;
+            const title = isArabic ? article.arTitle : article.enTitle;
+            const summary = isArabic ? article.arSummary : article.enSummary;
+            const tag = isArabic ? article.arTag : article.enTag;
+
+            return (
+              <article
+                key={article.enTitle}
+                className="flex h-full flex-col rounded-3xl border border-border bg-card/80 p-8 shadow-elevated backdrop-blur transition-transform duration-500 hover:-translate-y-2 hover:shadow-premium"
+              >
+                <div className="mb-6 flex items-center gap-3">
+                  <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+                    <Icon className="h-6 w-6" />
+                  </div>
+                  <span className="text-xs uppercase tracking-widest text-muted-foreground">{tag}</span>
+                </div>
+                <div className={`space-y-4 ${isArabic ? "text-right" : "text-left"}`}>
+                  <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+                  <p className="text-base leading-relaxed text-muted-foreground">{summary}</p>
+                </div>
+                <div className={`mt-6 flex-1 border-t border-border pt-4 text-sm text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>
+                  {copy.cta}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Insights;

--- a/frontend/src/pages/Landing/LandingNavbar.tsx
+++ b/frontend/src/pages/Landing/LandingNavbar.tsx
@@ -1,18 +1,52 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useLanguage } from "@/contexts/LanguageContext";
-import { useTheme } from "@/contexts/ThemeContext";
-import { 
-  Sun, Moon, Globe, Menu, X,
-  Scale, Shield, FileText, Users, Phone
-} from "lucide-react";
 import ThemeToggle from "@/components/ui/theme-toggle";
+import BrandLogo from "@/components/common/BrandLogo";
+import { useLanguage } from "@/contexts/LanguageContext";
+import {
+  Award,
+  BookOpenText,
+  Menu,
+  Phone,
+  Scale,
+  ShieldCheck,
+  Sparkles,
+  Users,
+  X,
+} from "lucide-react";
+
+type NavItem = {
+  href: string;
+  icon: typeof Scale;
+  en: string;
+  ar: string;
+};
+
+const navItems: NavItem[] = [
+  { href: "#home", icon: Scale, en: "Home", ar: "الرئيسية" },
+  { href: "#about", icon: BookOpenText, en: "About", ar: "من نحن" },
+  { href: "#services", icon: ShieldCheck, en: "Services", ar: "الخدمات" },
+  { href: "#capabilities", icon: Sparkles, en: "Capabilities", ar: "الإمكانيات" },
+  { href: "#achievements", icon: Award, en: "Achievements", ar: "الإنجازات" },
+  { href: "#team", icon: Users, en: "Team", ar: "الفريق" },
+  { href: "#insights", icon: BookOpenText, en: "Insights", ar: "المدونة" },
+  { href: "#contact", icon: Phone, en: "Contact", ar: "اتصل بنا" },
+];
+
+const highlightCopy = {
+  en: "Legal Digital Transformation",
+  ar: "التحول الرقمي القانوني",
+};
+
+const toggleCopy = {
+  en: { label: "Switch to Arabic", aria: "Switch to Arabic" },
+  ar: { label: "التبديل إلى الإنجليزية", aria: "التبديل إلى الإنجليزية" },
+};
 
 const LandingNavbar: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const { language, toggleLanguage, t } = useLanguage();
-  const { setTheme } = useTheme();
+  const { language, toggleLanguage, direction } = useLanguage();
 
   useEffect(() => {
     const handleScroll = () => setIsScrolled(window.scrollY > 30);
@@ -20,111 +54,132 @@ const LandingNavbar: React.FC = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const navItems = [
-    { key: "home", icon: Scale, href: "#home" },
-    { key: "features", icon: Shield, href: "#features" },
-    { key: "services", icon: FileText, href: "#services" },
-    { key: "about", icon: Users, href: "#about" },
-    { key: "contact", icon: Phone, href: "#contact" },
-  ];
-
   const scrollTo = (href: string) => {
-    const el = document.querySelector(href);
-    if (el) el.scrollIntoView({ behavior: "smooth" });
+    const element = document.querySelector(href);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
     setIsOpen(false);
   };
 
+  const isArabic = language === "ar";
+  const highlight = isArabic ? highlightCopy.ar : highlightCopy.en;
+  const { label: toggleLabel, aria: toggleAria } = toggleCopy[language];
+
   return (
     <nav
-      className={`fixed top-0 w-full z-50 transition-all duration-500 ${
+      dir={direction}
+      className={`fixed top-0 z-50 w-full transition-all duration-500 ${
         isScrolled
-          ? "bg-background/90 backdrop-blur-md border-b border-border shadow-elevated"
-          : "bg-transparent"
+          ? "bg-background/90 backdrop-blur-lg border-b border-border shadow-elevated"
+          : "bg-background/20 backdrop-blur"
       }`}
     >
-      <div className="container mx-auto px-4 lg:px-8 flex items-center justify-between h-20">
-        {/* Logo */}
-        <div className="flex items-center space-x-3 rtl:space-x-reverse">
-          <div className="w-10 h-10 bg-gradient-gold rounded-lg flex items-center justify-center animate-glow">
-            <Scale className="w-6 h-6 text-accent-foreground" />
+      <div className="container mx-auto flex h-20 items-center justify-between px-4 lg:px-8">
+        <button
+          onClick={() => scrollTo("#home")}
+          className="flex items-center gap-3"
+        >
+          <div className="hidden sm:block">
+            <BrandLogo variant="full" className="h-10" lang={language} />
           </div>
-          <span className="text-2xl font-display font-bold text-foreground">
-            Avocat {language === "ar" && <span className="text-accent">أفوكات</span>}
-          </span>
+          <div className="text-lg font-semibold text-foreground sm:hidden">Avocat</div>
+        </button>
+
+        <div className="hidden items-center gap-6 lg:flex">
+          {navItems.map(({ href, icon: Icon, en, ar }) => {
+            const label = isArabic ? ar : en;
+            return (
+              <button
+                key={href}
+                onClick={() => scrollTo(href)}
+                className="group flex items-center gap-2 text-muted-foreground transition hover:text-primary"
+              >
+                <Icon className="h-4 w-4 transition-transform duration-300 group-hover:scale-110" />
+                <span className="text-sm font-medium tracking-wide">{label}</span>
+                <span className="block h-0.5 w-0 bg-gradient-gold transition-all duration-300 group-hover:w-full" />
+              </button>
+            );
+          })}
         </div>
 
-        {/* Desktop Nav */}
-        <div className="hidden lg:flex items-center space-x-8 rtl:space-x-reverse">
-          {navItems.map((item) => (
-            <button
-              key={item.key}
-              onClick={() => scrollTo(item.href)}
-              className="group flex items-center space-x-2 rtl:space-x-reverse text-foreground hover:text-primary transition"
-            >
-              <item.icon className="w-4 h-4 group-hover:scale-110 transition" />
-              <span className="relative font-medium">
-                {t(item.key)}
-                <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-gold transition-all duration-300 group-hover:w-full"></span>
-              </span>
-            </button>
-          ))}
-        </div>
-
-        {/* Actions */}
-        <div className="flex items-center space-x-4 rtl:space-x-reverse">
-              <ThemeToggle />
-
+        <div className="flex items-center gap-3">
+          <div className="hidden items-center gap-3 rounded-full border border-border bg-card/60 px-3 py-1.5 text-xs uppercase tracking-widest text-muted-foreground backdrop-blur lg:flex">
+            <Sparkles className="h-3 w-3 text-accent" />
+            <span>{highlight}</span>
+          </div>
+          <ThemeToggle />
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleLanguage}
+            aria-label={toggleAria}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 lg:hidden"
+          >
+            <span className="text-xs font-semibold">{isArabic ? "EN" : "AR"}</span>
+          </Button>
           <Button
             variant="ghost"
             size="sm"
             onClick={toggleLanguage}
-            className="flex items-center space-x-2 hover:bg-accent/20"
+            aria-label={toggleAria}
+            className="hidden items-center justify-center rounded-full border border-border/60 px-4 py-2 text-sm font-medium lg:inline-flex"
           >
-            <Globe className="w-4 h-4" />
-            <span className="text-sm">{language === "en" ? "العربية" : "English"}</span>
+            {toggleLabel}
           </Button>
-
-          <div className="hidden lg:flex space-x-3">
-            <Button variant="ghost">{t("login")}</Button>
-            <Button className="btn-premium">{t("signup")}</Button>
-          </div>
-
-          {/* Mobile Toggle */}
           <Button
             variant="ghost"
-            size="sm"
-            onClick={() => setIsOpen(!isOpen)}
-            className="lg:hidden w-10 h-10 p-0"
+            size="icon"
+            className="lg:hidden"
+            onClick={() => setIsOpen((prev) => !prev)}
+            aria-label={isOpen ? "Close navigation" : "Open navigation"}
           >
-            {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+            {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
           </Button>
         </div>
       </div>
 
-      {/* Mobile Menu */}
       <div
-        className={`lg:hidden transition-all duration-300 overflow-hidden ${
-          isOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
+        className={`overflow-hidden border-t border-border bg-background/95 backdrop-blur transition-all duration-300 lg:hidden ${
+          isOpen ? "max-h-[520px] opacity-100" : "max-h-0 opacity-0"
         }`}
       >
-        <div className="py-6 border-t border-border bg-card/80 backdrop-blur-md rounded-b-xl">
-          <div className="flex flex-col space-y-4">
-            {navItems.map((item) => (
-              <button
-                key={item.key}
-                onClick={() => scrollTo(item.href)}
-                className="flex items-center space-x-3 px-4 py-3 text-foreground hover:text-primary hover:bg-accent/10 transition"
-              >
-                <item.icon className="w-5 h-5" />
-                <span>{t(item.key)}</span>
-              </button>
-            ))}
-
-            <div className="flex flex-col space-y-3 px-4 pt-4 border-t border-border">
-              <Button variant="ghost">{t("login")}</Button>
-              <Button className="btn-premium">{t("signup")}</Button>
+        <div className="space-y-1 px-4 py-6">
+          <div className="mb-4 flex items-center justify-between">
+            <div className="flex items-center gap-2 rounded-full border border-border px-3 py-1 text-xs text-muted-foreground">
+              <Sparkles className="h-3 w-3 text-accent" />
+              <span>{highlight}</span>
             </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={toggleAria}
+              onClick={() => {
+                toggleLanguage();
+                setIsOpen(false);
+              }}
+            >
+              {toggleLabel}
+            </Button>
           </div>
+          {navItems.map(({ href, icon: Icon, en, ar }) => {
+            const label = isArabic ? ar : en;
+            return (
+              <button
+                key={href}
+                onClick={() => scrollTo(href)}
+                className="flex w-full items-center justify-between rounded-xl border border-transparent px-4 py-3 text-left transition-all duration-300 hover:border-accent/40 hover:bg-accent/10"
+              >
+                <div className="flex items-center gap-3 text-foreground">
+                  <Icon className="h-5 w-5 text-primary" />
+                  <span className="text-sm font-medium">{label}</span>
+                </div>
+                <span className="text-xs uppercase tracking-widest text-muted-foreground">
+                  {href.replace('#', '')}
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
     </nav>

--- a/frontend/src/pages/Landing/Services.tsx
+++ b/frontend/src/pages/Landing/Services.tsx
@@ -1,156 +1,163 @@
-import React from 'react';
-import { useLanguage } from '@/contexts/LanguageContext';
-import { Building, Briefcase, User, BookOpen, ArrowRight, Star } from 'lucide-react';
-import { Button } from "@/components/ui/button";
+import type { ComponentType, SVGProps } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { BrainCircuit, CircuitBoard, Scale, ShieldCheck } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+type ServiceItem = {
+  en: string;
+  ar: string;
+};
+
+type ServiceGroup = {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  enTitle: string;
+  arTitle: string;
+  enDescription: string;
+  arDescription: string;
+  items: ServiceItem[];
+};
+
+const serviceGroups: ServiceGroup[] = [
+  {
+    icon: Scale,
+    enTitle: "Legal Services",
+    arTitle: "الخدمات القانونية",
+    enDescription:
+      "Litigation & dispute resolution, international arbitration, contract drafting, corporate advisory, company formation, IP protection, and sector-specific compliance.",
+    arDescription:
+      "التقاضي وحل النزاعات، التحكيم التجاري والدولي، صياغة العقود، الاستشارات للشركات، تأسيس الشركات، حماية الملكية الفكرية، والامتثال المتخصص لكل قطاع.",
+    items: [
+      { en: "Litigation & Dispute Resolution", ar: "التقاضي وحل النزاعات" },
+      { en: "International Arbitration", ar: "التحكيم التجاري والدولي" },
+      { en: "Contract Drafting & Negotiation", ar: "صياغة العقود والتفاوض" },
+      { en: "Corporate Governance Advisory", ar: "استشارات الحوكمة للشركات" },
+      { en: "Company Incorporation", ar: "تأسيس الشركات" },
+      { en: "Intellectual Property Protection", ar: "حماية الملكية الفكرية" },
+      { en: "Regulatory Compliance", ar: "الامتثال للتشريعات" },
+    ],
+  },
+  {
+    icon: BrainCircuit,
+    enTitle: "Digital & AI Services",
+    arTitle: "الخدمات الرقمية والذكاء الاصطناعي",
+    enDescription:
+      "Digital case management, AI research assistants, e-signature workflows, compliance automation, cybercrime protection, and data privacy programs.",
+    arDescription:
+      "إدارة القضايا الرقمية، مساعدو البحث بالذكاء الاصطناعي، سير عمل التوقيع الإلكتروني، أتمتة الامتثال، مكافحة الجريمة الإلكترونية، وبرامج خصوصية البيانات.",
+    items: [
+      { en: "AI-Augmented Case Strategy", ar: "استراتيجيات القضايا المدعومة بالذكاء الاصطناعي" },
+      { en: "Digital Case Management Platforms", ar: "منصات إدارة القضايا الرقمية" },
+      { en: "Secure E-Signature Workflows", ar: "سير عمل التوقيع الإلكتروني الآمن" },
+      { en: "Compliance Automation Dashboards", ar: "لوحات أتمتة الامتثال" },
+      { en: "Cybercrime Protection", ar: "مكافحة الجريمة الإلكترونية" },
+      { en: "Data Privacy & Governance Audits", ar: "تدقيق خصوصية البيانات والحوكمة" },
+      { en: "Digital Evidence Forensics", ar: "الأدلة الجنائية الرقمية" },
+    ],
+  },
+];
+
+const highlights = [
+  {
+    icon: ShieldCheck,
+    en: "ISO 27001-aligned cybersecurity for sensitive case files.",
+    ar: "أمن سيبراني متوافق مع معيار ISO 27001 لحماية الملفات الحساسة.",
+  },
+  {
+    icon: CircuitBoard,
+    en: "Integrated analytics, reporting, and client transparency dashboards.",
+    ar: "تحليلات متكاملة وتقارير ولوحات شفافية للعملاء.",
+  },
+];
+
+const sectionCopy = {
+  en: {
+    badge: "Legal & Digital Services",
+    title: "Full-Spectrum Counsel and Intelligent Platforms",
+    description:
+      "Precision-crafted services blending advocacy, governance, and digital acceleration for ambitious institutions.",
+  },
+  ar: {
+    badge: "الخدمات القانونية والرقمية",
+    title: "منظومة متكاملة من الاستشارات والمنصات الذكية",
+    description:
+      "خدمات مصممة بعناية تمزج بين المرافعة والحوكمة والتسريع الرقمي للمؤسسات الطموحة.",
+  },
+};
 
 const Services: React.FC = () => {
-  const { t } = useLanguage();
-
-  const services = [
-    {
-      icon: Building,
-      titleKey: 'lawFirms',
-      descKey: 'lawFirmsDesc',
-      features: ['Case Management', 'Client Portal', 'Document Automation', 'Billing & Time Tracking'],
-      gradient: 'from-primary via-primary-light to-primary-glow',
-      popular: true
-    },
-    {
-      icon: Briefcase,
-      titleKey: 'corporateLegal',
-      descKey: 'corporateLegalDesc',
-      features: ['Contract Management', 'Compliance Tracking', 'Legal Analytics', 'Risk Assessment'],
-      gradient: 'from-accent via-accent-glow to-accent-soft',
-      popular: false
-    },
-    {
-      icon: User,
-      titleKey: 'independentLawyers',
-      descKey: 'independentLawyersDesc',
-      features: ['Solo Practice Tools', 'Client Acquisition', 'Mobile Access', 'Cloud Storage'],
-      gradient: 'from-primary-light via-primary to-primary-glow',
-      popular: false
-    },
-    {
-      icon: BookOpen,
-      titleKey: 'training',
-      descKey: 'trainingDesc',
-      features: ['Legal Tech Training', 'Certification Programs', 'E-Government Integration', 'Continuous Learning'],
-      gradient: 'from-accent-glow via-accent to-accent-soft',
-      popular: false
-    }
-  ];
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = sectionCopy[language];
 
   return (
-    <section id="services" className="py-24 bg-background relative overflow-hidden">
-      {/* Background Elements */}
-      <div className="absolute inset-0 opacity-5">
-        <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(circle_at_50%_50%,hsl(var(--primary))_0%,transparent_50%)]"></div>
-      </div>
-
-      <div className="container mx-auto px-4 lg:px-8 relative z-10">
-        {/* Section Header */}
-        <div className="text-center mb-16 animate-fade-in">
-          <h2 className="text-4xl lg:text-5xl font-display font-bold text-foreground mb-6">
-            {t('servicesTitle')}
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-            {t('servicesSubtitle')}
-          </p>
+    <section id="services" className="bg-surface-highlight/60 py-24" dir={direction}>
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{copy.title}</h2>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
         </div>
 
-        {/* Services Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-16">
-          {services.map((service, index) => {
-            const IconComponent = service.icon;
+        <div className="grid gap-10 lg:grid-cols-2">
+          {serviceGroups.map((group) => {
+            const Icon = group.icon;
+            const title = isArabic ? group.arTitle : group.enTitle;
+            const description = isArabic ? group.arDescription : group.enDescription;
+            const items = group.items.map((item) => (isArabic ? item.ar : item.en));
+
             return (
-              <div
-                key={service.titleKey}
-                className={`group relative animate-slide-up card-premium hover:card-elevated transition-all duration-500 p-8 hover:-translate-y-1 ${
-                  service.popular ? 'ring-2 ring-accent/50 shadow-gold' : ''
-                }`}
-                style={{ animationDelay: `${index * 200}ms` }}
+              <Card
+                key={group.enTitle}
+                className="h-full border-border/80 bg-card/80 shadow-elevated backdrop-blur transition-transform duration-500 hover:-translate-y-2 hover:shadow-premium"
               >
-                {/* Popular Badge */}
-                {service.popular && (
-                  <div className="absolute -top-3 right-6 bg-gradient-gold text-accent-foreground px-4 py-1 rounded-full text-sm font-medium flex items-center space-x-1">
-                    <Star className="w-4 h-4 fill-current" />
-                    <span>Most Popular</span>
-                  </div>
-                )}
-
-                <div className="flex flex-col h-full">
-                  {/* Header */}
-                  <div className="flex items-start space-x-4 rtl:space-x-reverse mb-6">
-                    <div className={`w-16 h-16 bg-gradient-to-br ${service.gradient} rounded-2xl flex items-center justify-center group-hover:scale-110 transition-all duration-500 animate-glow`}>
-                      <IconComponent className="w-8 h-8 text-white" />
+                <CardContent className="space-y-8 p-8">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-2xl bg-gradient-gold p-3 text-accent-foreground shadow-gold">
+                      <Icon className="h-6 w-6" />
                     </div>
-                    
-                    <div className="flex-1">
-                      <h3 className="text-2xl font-display font-semibold text-foreground mb-3 group-hover:text-primary transition-colors duration-300">
-                        {t(service.titleKey)}
-                      </h3>
-                      <p className="text-muted-foreground leading-relaxed">
-                        {t(service.descKey)}
-                      </p>
-                    </div>
+                    <h3 className="text-2xl font-semibold text-foreground">{title}</h3>
                   </div>
 
-                  {/* Features List */}
-                  <div className="flex-1 mb-6">
-                    <ul className="space-y-3">
-                      {service.features.map((feature, featureIndex) => (
-                        <li 
-                          key={featureIndex}
-                          className="flex items-center space-x-3 rtl:space-x-reverse text-muted-foreground"
+                  <div className={`space-y-4 text-base leading-relaxed text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>
+                    <p>{description}</p>
+                    <div className={`flex flex-wrap gap-2 ${isArabic ? "justify-end" : ""}`}>
+                      {items.map((item) => (
+                        <Badge
+                          key={item}
+                          variant="outline"
+                          className="border-border bg-background/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground/90"
                         >
-                          <div className="w-2 h-2 bg-accent rounded-full animate-pulse"></div>
-                          <span>{feature}</span>
-                        </li>
+                          {item}
+                        </Badge>
                       ))}
-                    </ul>
+                    </div>
                   </div>
-
-                  {/* Action Button */}
-                  <Button 
-                    className={`w-full group-hover:btn-premium transition-all duration-300 ${
-                      service.popular ? 'btn-gold' : 'btn-premium'
-                    }`}
-                  >
-                    <span>Learn More</span>
-                    <ArrowRight className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0 group-hover:translate-x-1 rtl:group-hover:-translate-x-1 transition-transform duration-300" />
-                  </Button>
-                </div>
-              </div>
+                </CardContent>
+              </Card>
             );
           })}
         </div>
 
-        {/* Bottom Section - Why Choose Us */}
-        <div className="bg-gradient-secondary rounded-3xl p-8 lg:p-12 text-center animate-fade-in shadow-elevated">
-          <h3 className="text-3xl font-display font-bold text-foreground mb-6">
-            Why Choose Avocat?
-          </h3>
-          
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
-            {[
-              { label: 'Trust & Confidentiality', value: '100%', icon: '🔒' },
-              { label: 'Client Satisfaction', value: '98%', icon: '⭐' },
-              { label: 'Innovation Leader', value: '#1', icon: '🚀' },
-              { label: 'Global Standards', value: 'ISO', icon: '🌍' },
-            ].map((stat, index) => (
-              <div key={index} className="animate-slide-up" style={{ animationDelay: `${index * 100}ms` }}>
-                <div className="text-4xl mb-2">{stat.icon}</div>
-                <div className="text-3xl font-bold text-primary mb-2">{stat.value}</div>
-                <div className="text-sm text-muted-foreground">{stat.label}</div>
+        <div className="mt-12 grid gap-6 md:grid-cols-2">
+          {highlights.map(({ icon: Icon, en, ar }) => {
+            const text = isArabic ? ar : en;
+            return (
+              <div
+                key={en}
+                className="rounded-3xl border border-border bg-gradient-to-br from-background via-card to-background p-6 shadow-ambient"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+                    <Icon className="h-6 w-6" />
+                  </div>
+                  <p className={`text-sm text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>{text}</p>
+                </div>
               </div>
-            ))}
-          </div>
-
-          <Button size="lg" className="btn-gold px-8 py-4 text-lg">
-            Start Your Digital Transformation
-            <ArrowRight className="w-5 h-5 ml-2 rtl:mr-2 rtl:ml-0" />
-          </Button>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/frontend/src/pages/Landing/Team.tsx
+++ b/frontend/src/pages/Landing/Team.tsx
@@ -1,0 +1,166 @@
+import { useLanguage } from "@/contexts/LanguageContext";
+import { GraduationCap, Scale, ShieldCheck, UserCircle2 } from "lucide-react";
+
+type TeamMember = {
+  nameEn: string;
+  nameAr: string;
+  roleEn: string;
+  roleAr: string;
+  bioEn: string;
+  bioAr: string;
+  highlights: { en: string; ar: string }[];
+};
+
+const teamMembers: TeamMember[] = [
+  {
+    nameEn: "Mr. Sami Mohamed El-Gamal",
+    nameAr: "الأستاذ سامي محمد الجمل",
+    roleEn: "Managing Partner – Commercial Disputes & International Arbitration",
+    roleAr: "الشريك المدير – القضايا التجارية والتحكيم الدولي",
+    bioEn:
+      "Architect of high-stakes commercial litigation strategies with more than 18 years representing global corporates, sovereign entities, and leading financial institutions across MENA.",
+    bioAr:
+      "مهندس استراتيجيات التقاضي التجاري عالية القيمة بخبرة تتجاوز 18 عاماً في تمثيل الشركات العالمية والجهات السيادية والمؤسسات المالية الرائدة في المنطقة.",
+    highlights: [
+      {
+        en: "ICC & LCIA accredited counsel leading digital arbitration playbooks and cross-border recovery projects.",
+        ar: "محكّم معتمد لدى ICC وLCIA يقود أدلة التحكيم الرقمية ومشاريع الاسترداد العابرة للحدود.",
+      },
+      {
+        en: "Champion of paperless courtrooms and AI-assisted pleading models adopted by tier-one clients.",
+        ar: "رائد المحاكم بلا أوراق ونماذج المرافعات المدعومة بالذكاء الاصطناعي المعتمدة لدى كبار العملاء.",
+      },
+    ],
+  },
+  {
+    nameEn: "Mr. Abdelhamid Mohamed Askar",
+    nameAr: "الأستاذ عبدالحميد محمد عسكر",
+    roleEn: "Partner – Civil Litigation & Cybersecurity Law",
+    roleAr: "شريك – المنازعات المدنية وقانون الأمن السيبراني",
+    bioEn:
+      "Specialist in administrative, civil, and cybercrime litigation with a decade leading digital forensics investigations and regulatory transformation programs.",
+    bioAr:
+      "متخصص في المنازعات الإدارية والمدنية والجرائم السيبرانية مع خبرة تمتد لعقد في قيادة التحقيقات الرقمية وبرامج التحول التشريعي.",
+    highlights: [
+      {
+        en: "Designed national cybercrime response frameworks integrating legal, technical, and compliance teams.",
+        ar: "صمم أطر الاستجابة الوطنية للجرائم الإلكترونية بدمج الفرق القانونية والفنية وفِرق الامتثال.",
+      },
+      {
+        en: "Advises on privacy-by-design policies, data localization, and AI governance for regulators and fintech leaders.",
+        ar: "يستشار في سياسات الخصوصية المدمجة بالتصميم وتوطين البيانات وحوكمة الذكاء الاصطناعي للجهات التنظيمية وروّاد التكنولوجيا المالية.",
+      },
+    ],
+  },
+];
+
+const leadershipBadges = [
+  {
+    icon: Scale,
+    en: "Smart Justice Advocate",
+    ar: "مدافع عن العدالة الذكية",
+  },
+  {
+    icon: GraduationCap,
+    en: "Global Faculty Speaker",
+    ar: "متحدث في برامج دولية",
+  },
+  {
+    icon: ShieldCheck,
+    en: "Cybersecurity Counsel",
+    ar: "مستشار الأمن السيبراني",
+  },
+];
+
+const sectionCopy = {
+  en: {
+    badge: "Leadership Team",
+    title: "Legal Minds Leading Digital Justice",
+    description: "Senior partners blending courtroom mastery with transformative technology insight.",
+  },
+  ar: {
+    badge: "الفريق القيادي",
+    title: "عقول قانونية تقود العدالة الرقمية",
+    description: "شركاء مخضرمون يجمعون بين الخبرة القضائية والرؤية التقنية التحولية.",
+  },
+};
+
+const Team: React.FC = () => {
+  const { language, direction } = useLanguage();
+  const isArabic = language === "ar";
+  const copy = sectionCopy[language];
+
+  return (
+    <section id="team" className="bg-surface-highlight/70 py-24" dir={direction}>
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
+            <span>{copy.badge}</span>
+          </div>
+          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{copy.title}</h2>
+          <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{copy.description}</p>
+        </div>
+
+        <div className="grid gap-10 lg:grid-cols-2">
+          {teamMembers.map((member) => {
+            const name = isArabic ? member.nameAr : member.nameEn;
+            const role = isArabic ? member.roleAr : member.roleEn;
+            const bio = isArabic ? member.bioAr : member.bioEn;
+            const highlights = member.highlights.map((highlight) => (isArabic ? highlight.ar : highlight.en));
+
+            return (
+              <div
+                key={member.nameEn}
+                className="flex h-full flex-col gap-6 rounded-3xl border border-border bg-card/80 p-8 shadow-elevated backdrop-blur transition-transform duration-500 hover:-translate-y-2 hover:shadow-premium"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="rounded-3xl bg-gradient-gold p-4 text-accent-foreground shadow-gold">
+                    <UserCircle2 className="h-10 w-10" />
+                  </div>
+                  <div className={`${isArabic ? "text-right" : "text-left"}`}>
+                    <h3 className="text-2xl font-semibold text-foreground">{name}</h3>
+                    <p className="mt-2 text-sm uppercase tracking-widest text-muted-foreground">
+                      {role}
+                    </p>
+                  </div>
+                </div>
+
+                <div className={`space-y-3 text-base leading-relaxed text-muted-foreground ${isArabic ? "text-right" : "text-left"}`}>
+                  <p>{bio}</p>
+                  <ul className="space-y-2 text-sm">
+                    {highlights.map((highlight) => (
+                      <li
+                        key={highlight}
+                        className={`flex items-start gap-2 ${isArabic ? "flex-row-reverse text-right" : ""}`}
+                      >
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                        <span>{highlight}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className={`grid gap-4 md:grid-cols-3 ${isArabic ? "text-right" : "text-left"}`}>
+                  {leadershipBadges.map(({ icon: Icon, en, ar }) => {
+                    const text = isArabic ? ar : en;
+                    return (
+                      <div
+                        key={en}
+                        className="rounded-2xl border border-border bg-background/70 p-4 text-center"
+                      >
+                        <Icon className="mx-auto mb-2 h-6 w-6 text-primary" />
+                        <p className="text-xs font-semibold text-muted-foreground">{text}</p>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Team;

--- a/frontend/src/pages/Landing/index.tsx
+++ b/frontend/src/pages/Landing/index.tsx
@@ -1,51 +1,32 @@
+import { useLanguage } from "@/contexts/LanguageContext";
 import LandingNavbar from "./LandingNavbar";
 import HeroCarousel from "./HeroCarousel";
-import Features from "./Features";
-import Services from "./Services";
 import About from "./About";
-import Testimonials from "./Testimonials";
-import CallToAction from "./CallToAction";
+import Services from "./Services";
+import Capabilities from "./Capabilities";
+import Achievements from "./Achievements";
+import Team from "./Team";
+import Insights from "./Insights";
 import Contact from "./Contact";
 import Footer from "./Footer";
-import { useLanguage } from "@/contexts/LanguageContext";
-
-const footerServiceKeys = [
-  "caseManagement",
-  "legalConsulting",
-  "digitalTraining",
-  "egovSupport",
-] as const;
 
 const LandingPage: React.FC = () => {
-  const { t } = useLanguage();
-
-  const footerServices = footerServiceKeys.map((key) =>
-    t(`landing.footer.services.${key}`)
-  );
-
-  const footerContact = {
-    email: t("landing.footer.contact.email"),
-    phone: t("landing.footer.contact.phone"),
-    address: t("landing.footer.contact.address"),
-  };
+  const { direction } = useLanguage();
 
   return (
     <>
       <LandingNavbar />
-      <main className="bg-background text-text-body">
+      <main dir={direction} className="bg-background text-text-body">
         <HeroCarousel />
-        <Features />
-        <Services />
         <About />
-        <Testimonials />
-        <CallToAction />
+        <Services />
+        <Capabilities />
+        <Achievements />
+        <Team />
+        <Insights />
         <Contact />
       </main>
-      <Footer
-        services={footerServices}
-        contact={footerContact}
-        logoVariant="text"
-      />
+      <Footer />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- default the language context to stored preference, browser locale, or English to honour system detection requirements
- render the landing navigation, hero, and all primary sections with per-language copy and RTL/LTR-aware layouts controlled by the navbar toggle
- localise the contact workflow and footer so forms, messages, and digital desk messaging switch entirely with the active language

## Testing
- npm run lint *(fails: repository has existing lint errors in legacy shared components)*

------
https://chatgpt.com/codex/tasks/task_e_68d1967ea0c4832f81d61292abbdc43e