### PR TITLE
Enhance dashboard sidebar and header theming

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -31,11 +31,11 @@ export const Header: React.FC<HeaderProps> = ({ title, className }) => {
   return (
     <header
       className={cn(
-        "sticky top-0 z-50 h-16 border-b border-border bg-background/80 backdrop-blur transition-all duration-300",
+        "header-shell sticky top-0 z-50 h-16 transition-all duration-500",
         className
       )}
     >
-      <div className="flex h-full items-center justify-between px-4">
+      <div className="relative z-[1] flex h-full items-center justify-between px-4">
         {/* Left side */}
         <div className={cn("flex items-center gap-3", isRTL ? "flex-row-reverse" : "flex-row")}>
           {/* Mobile menu button */}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -38,17 +38,13 @@ const Sidebar: React.FC = () => {
       animate={{ width: collapsed ? 64 : 256 }}
       transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
       className={cn(
-        "hidden h-screen flex-shrink-0 flex-col border-r border-sidebar-border md:sticky md:top-0 md:flex"
+        "sidebar-shell hidden h-screen flex-shrink-0 flex-col border-r border-sidebar-border md:sticky md:top-0 md:flex"
       )}
-      style={{
-        background: "var(--sidebar-background)",
-        boxShadow: "var(--sidebar-shell-shadow)",
-        backdropFilter: "blur(18px)"
-      }}
       dir={isRTL ? "rtl" : "ltr"}
+      data-collapsed={collapsed}
     >
       {/* Brand Section */}
-      <div className="flex items-center gap-3 border-b border-sidebar-border px-6 py-4">
+      <div className="sidebar-brand flex items-center gap-3 border-b border-transparent px-6 py-4">
         <BrandLogo
           variant={collapsed ? "icon" : "full"}
           className={collapsed ? "h-8 w-8" : "h-8 w-auto"}
@@ -81,7 +77,7 @@ const Sidebar: React.FC = () => {
       </nav>
 
       {/* Logout Section */}
-      <div className="border-t border-sidebar-border px-3 py-4">
+      <div className="sidebar-footer border-t border-transparent px-3 py-4">
         <Button
           onClick={logout}
           variant="ghost"
@@ -127,7 +123,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
   const iconBadge = (
     <span
       className={cn(
-        "flex items-center justify-center rounded-xl transition-all duration-300",
+        "sidebar-icon-badge flex items-center justify-center rounded-xl transition-all duration-300",
         collapsed
           ? "w-[var(--icon-size-collapsed)] h-[var(--icon-size-collapsed)]"
           : "w-[var(--icon-size-expanded)] h-[var(--icon-size-expanded)]",
@@ -155,16 +151,16 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
   };
 
   return (
-    <div>
+    <div className="relative">
       {/* Parent Item */}
       <div
         className={cn(
-          "group relative flex items-center rounded-2xl text-sm transition-all duration-300",
+          "sidebar-nav-item group relative flex items-center rounded-2xl text-sm transition-all duration-300",
           collapsed ? "justify-center py-2" : "px-1 py-1.5",
-          isActive
-            ? "bg-sidebar-active-glow text-sidebar-primary"
-            : "text-sidebar-text-muted hover:bg-sidebar-hover-glow hover:text-sidebar-hover-foreground"
+          isActive ? "text-sidebar-primary" : "text-sidebar-text-muted"
         )}
+        data-active={isActive}
+        data-collapsed={collapsed}
       >
         <NavLink
           to={
@@ -172,7 +168,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
           }
           end={!hasChildren}
           className={cn(
-            "flex w-full items-center gap-3 rounded-2xl px-3 py-2 transition-all duration-300",
+            "sidebar-nav-link flex w-full items-center gap-3 rounded-2xl px-3 py-2",
             collapsed && "justify-center px-0"
           )}
           onClick={(event) => {
@@ -222,15 +218,13 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
                 to={child.path ?? "#"}
                 className={({ isActive }) =>
                   cn(
-                    "flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors",
-                    isActive
-                      ? "bg-sidebar-active-glow text-sidebar-primary"
-                      : "text-sidebar-text-muted hover:bg-sidebar-hover-glow hover:text-sidebar-hover-foreground"
+                    "sidebar-subitem flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm",
+                    isActive ? "is-active" : "text-sidebar-text-muted"
                   )
                 }
               >
                 <span
-                  className="flex h-8 w-8 items-center justify-center rounded-lg"
+                  className="sidebar-icon-badge flex h-8 w-8 items-center justify-center rounded-lg"
                   style={{
                     background: childDesign.badgeGradient,
                     boxShadow: "var(--legal-icon-shadow-soft)"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,6 +141,195 @@
   .carousel-slide.inactive {
     @apply opacity-0 scale-95;
   }
+
+  /* Sidebar Shell */
+  .sidebar-shell {
+    position: relative;
+    overflow: hidden;
+    background: var(--sidebar-surface-gradient);
+    box-shadow: var(--sidebar-shell-shadow);
+    backdrop-filter: blur(var(--sidebar-shell-blur));
+    -webkit-backdrop-filter: blur(var(--sidebar-shell-blur));
+    transition: var(--transition-elegant);
+  }
+
+  .sidebar-shell::before,
+  .sidebar-shell::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .sidebar-shell::before {
+    background: var(--sidebar-ambient-glow);
+    opacity: 0.85;
+  }
+
+  .sidebar-shell::after {
+    inset-inline-start: auto;
+    inset-inline-end: -35%;
+    inset-block: 0;
+    width: 60%;
+    background: var(--sidebar-edge-highlight);
+    opacity: 0.6;
+  }
+
+  .sidebar-shell > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .sidebar-brand {
+    position: relative;
+    background: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.08) 0%,
+      transparent 70%
+    );
+    box-shadow: inset 0 -1px 0 hsl(var(--sidebar-border) / 0.8);
+  }
+
+  .sidebar-brand::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      circle at 30% 30%,
+      hsl(var(--accent) / 0.2) 0%,
+      transparent 70%
+    );
+    opacity: 0.8;
+    pointer-events: none;
+  }
+
+  .sidebar-footer {
+    position: relative;
+    background: linear-gradient(
+      135deg,
+      transparent 0%,
+      hsl(var(--primary) / 0.08) 100%
+    );
+    box-shadow: inset 0 1px 0 hsl(var(--sidebar-border) / 0.7);
+  }
+
+  .sidebar-nav-item {
+    position: relative;
+    border-radius: 1rem;
+    transition: var(--transition-smooth);
+  }
+
+  .sidebar-nav-item[data-active="true"] {
+    background: var(--sidebar-item-active-bg);
+    box-shadow: var(--sidebar-item-active-shadow);
+    color: hsl(var(--sidebar-primary));
+  }
+
+  .sidebar-nav-item[data-active="true"] .sidebar-nav-link {
+    color: inherit;
+  }
+
+  .sidebar-nav-item[data-collapsed="true"] {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .sidebar-nav-item[data-collapsed="true"][data-active="true"] .sidebar-icon-badge {
+    box-shadow: 0 0 0 2px hsl(var(--primary) / 0.35),
+      0 16px 32px -20px hsl(var(--primary) / 0.55);
+  }
+
+  .sidebar-nav-item:not([data-active="true"]):not([data-collapsed="true"]):hover {
+    background: var(--sidebar-item-hover-bg);
+    color: hsl(var(--sidebar-hover-foreground));
+  }
+
+  .sidebar-nav-link {
+    position: relative;
+    transition: var(--transition-smooth);
+  }
+
+  .sidebar-icon-badge {
+    transition: var(--transition-premium);
+  }
+
+  .sidebar-nav-item[data-active="true"] .sidebar-icon-badge {
+    transform: translateY(-1px);
+  }
+
+  .sidebar-nav-item[data-collapsed="true"] .sidebar-nav-link:hover {
+    color: hsl(var(--sidebar-hover-foreground));
+  }
+
+  .sidebar-nav-item[data-collapsed="true"] .sidebar-nav-link:hover .sidebar-icon-badge {
+    box-shadow: 0 0 0 2px hsl(var(--primary) / 0.2);
+  }
+
+  .sidebar-subitem {
+    position: relative;
+    border-radius: 0.75rem;
+    transition: var(--transition-smooth);
+  }
+
+  .sidebar-subitem::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: transparent;
+    transition: inherit;
+    pointer-events: none;
+  }
+
+  .sidebar-subitem:hover {
+    background: var(--sidebar-subitem-hover-bg);
+    color: hsl(var(--sidebar-hover-foreground));
+  }
+
+  .sidebar-subitem.is-active {
+    background: var(--sidebar-subitem-active-bg);
+    box-shadow: var(--sidebar-subitem-shadow);
+    color: hsl(var(--sidebar-primary));
+  }
+
+  .sidebar-subitem.is-active::after {
+    background: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.18) 0%,
+      transparent 100%
+    );
+  }
+
+  .header-shell {
+    position: relative;
+    overflow: hidden;
+    background: var(--header-surface-gradient);
+    box-shadow: var(--header-shell-shadow);
+    backdrop-filter: blur(var(--header-shell-blur));
+    -webkit-backdrop-filter: blur(var(--header-shell-blur));
+    border-bottom: 1px solid var(--header-shell-border);
+    transition: var(--transition-elegant);
+  }
+
+  .header-shell::before,
+  .header-shell::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    pointer-events: none;
+  }
+
+  .header-shell::before {
+    inset-block: 0;
+    background: var(--header-ambient-glow);
+    opacity: 0.8;
+  }
+
+  .header-shell::after {
+    bottom: 0;
+    height: 2px;
+    background: var(--header-bottom-glow);
+  }
 }
 @layer base {
   h1 {

--- a/frontend/src/styles/theme-tokens.css
+++ b/frontend/src/styles/theme-tokens.css
@@ -92,6 +92,64 @@
     --sidebar-hover-glow: 45 85% 42% / 0.05;
     --sidebar-ambient-glow: 215 85% 17% / 0.03;
     --sidebar-shell-shadow: 0 10px 40px -10px hsl(215 85% 17% / 0.08);
+    --sidebar-surface-gradient: linear-gradient(
+      180deg,
+      hsl(215 75% 98% / 0.98) 0%,
+      hsl(215 65% 97% / 0.96) 38%,
+      hsl(215 60% 95% / 0.94) 100%
+    );
+    --sidebar-edge-highlight: linear-gradient(
+      90deg,
+      hsl(215 85% 80% / 0.45) 0%,
+      transparent 65%
+    );
+    --sidebar-ambient-glow: radial-gradient(
+      circle at 18% 12%,
+      hsl(45 85% 60% / 0.22) 0%,
+      transparent 60%
+    );
+    --sidebar-shell-blur: 18px;
+    --sidebar-item-active-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.16) 0%,
+      hsl(var(--primary-glow) / 0.08) 100%
+    );
+    --sidebar-item-hover-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.08) 0%,
+      transparent 65%
+    );
+    --sidebar-item-active-shadow: 0 16px 35px -24px hsl(var(--primary) / 0.4);
+    --sidebar-subitem-hover-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.12) 0%,
+      transparent 70%
+    );
+    --sidebar-subitem-active-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.18) 0%,
+      hsl(var(--primary-glow) / 0.1) 100%
+    );
+    --sidebar-subitem-shadow: 0 12px 28px -24px hsl(var(--primary) / 0.35);
+
+    --header-surface-gradient: linear-gradient(
+      90deg,
+      hsl(215 75% 98% / 0.95) 0%,
+      hsl(215 65% 97% / 0.95) 100%
+    );
+    --header-ambient-glow: radial-gradient(
+      circle at 12% 40%,
+      hsl(var(--primary-glow) / 0.12) 0%,
+      transparent 62%
+    );
+    --header-bottom-glow: linear-gradient(
+      90deg,
+      hsl(var(--primary) / 0.25) 0%,
+      hsl(var(--accent) / 0.18) 100%
+    );
+    --header-shell-shadow: 0 10px 28px -18px hsl(var(--primary) / 0.25);
+    --header-shell-border: hsl(var(--border) / 0.8);
+    --header-shell-blur: 16px;
 
     --color-sidebar-border: 213 20% 88%;
     --color-sidebar-accent: 45 85% 42%;
@@ -211,6 +269,64 @@
     --sidebar-hover-glow: 38 45% 58% / 0.05;
     --sidebar-ambient-glow: 180 45% 60% / 0.03;
     --sidebar-shell-shadow: 0 10px 40px -10px hsl(0 0% 0% / 0.15);
+    --sidebar-surface-gradient: linear-gradient(
+      180deg,
+      hsl(215 40% 12% / 0.98) 0%,
+      hsl(215 45% 9% / 0.97) 55%,
+      hsl(215 55% 6% / 0.95) 100%
+    );
+    --sidebar-edge-highlight: linear-gradient(
+      90deg,
+      hsl(180 45% 55% / 0.18) 0%,
+      transparent 70%
+    );
+    --sidebar-ambient-glow: radial-gradient(
+      circle at 20% 18%,
+      hsl(38 45% 58% / 0.18) 0%,
+      transparent 60%
+    );
+    --sidebar-shell-blur: 22px;
+    --sidebar-item-active-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.45) 0%,
+      hsl(var(--primary) / 0.22) 100%
+    );
+    --sidebar-item-hover-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.25) 0%,
+      hsl(var(--primary) / 0.12) 100%
+    );
+    --sidebar-item-active-shadow: 0 18px 40px -20px hsl(var(--primary) / 0.55);
+    --sidebar-subitem-hover-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.28) 0%,
+      hsl(var(--accent) / 0.12) 100%
+    );
+    --sidebar-subitem-active-bg: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.42) 0%,
+      hsl(var(--accent) / 0.18) 100%
+    );
+    --sidebar-subitem-shadow: 0 16px 38px -24px hsl(var(--primary) / 0.6);
+
+    --header-surface-gradient: linear-gradient(
+      90deg,
+      hsl(215 55% 7% / 0.9) 0%,
+      hsl(215 60% 5% / 0.92) 100%
+    );
+    --header-ambient-glow: radial-gradient(
+      circle at 18% 45%,
+      hsl(var(--primary) / 0.32) 0%,
+      transparent 65%
+    );
+    --header-bottom-glow: linear-gradient(
+      90deg,
+      hsl(var(--primary) / 0.5) 0%,
+      hsl(var(--accent) / 0.2) 100%
+    );
+    --header-shell-shadow: 0 12px 28px -16px hsl(0 0% 0% / 0.65);
+    --header-shell-border: hsl(var(--border) / 0.6);
+    --header-shell-blur: 22px;
 
     --shadow-premium: 0 25px 50px -12px hsl(0 0% 0% / 0.3);
     --shadow-gold: 0 10px 30px -5px hsl(38 45% 58% / 0.2);


### PR DESCRIPTION
## Summary
- restyle the desktop sidebar shell with gradient surfaces, ambient glows, and refined active/hover states that respect the daytime and nighttime brand palettes
- refresh the dashboard header with a gradient shell and layered content treatment so the logo and controls remain legible in both themes
- add theme tokens and utility classes to drive the new sidebar/header lighting effects across light and dark modes

## Testing
- npm run lint *(fails: pre-existing eslint complaints about legacy any types and fast refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b507a374832fb718d366b2bffaf7