### PR TITLE
Improve dashboard sidebar responsiveness

### DIFF
--- a/dashboard-gallery.html
+++ b/dashboard-gallery.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>معرض أفضل لوحات التحكم - TailwindCSS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-900 text-slate-100 min-h-screen">
+  <header class="relative overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-indigo-500/20 via-slate-900 to-slate-900"></div>
+    <div class="relative max-w-6xl mx-auto px-6 py-20">
+      <p class="text-indigo-300 text-sm uppercase tracking-widest">TailwindCSS Premium</p>
+      <h1 class="text-4xl md:text-5xl font-bold mb-4">أفضل 10 تصميمات متجاوبة للوحات التحكم</h1>
+      <p class="text-slate-300 max-w-3xl">
+        مجموعة مختارة بعناية من تصميمات لوحات التحكم المتكاملة المبنية بـ TailwindCSS.
+        كل لوحة جاهزة للاستخدام، مصممة بعناية لتناسب التطبيقات الحديثة، وتدعم جميع القياسات بمرونة كاملة.
+      </p>
+      <div class="mt-8 flex flex-wrap gap-3">
+        <span class="px-4 py-2 bg-indigo-500/20 text-indigo-200 rounded-full text-sm">متجاوبة بالكامل</span>
+        <span class="px-4 py-2 bg-emerald-500/20 text-emerald-200 rounded-full text-sm">إحصائيات ولوحات بيانات</span>
+        <span class="px-4 py-2 bg-amber-500/20 text-amber-200 rounded-full text-sm">تصميم حديث</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-6 pb-20">
+    <section>
+      <h2 class="text-2xl font-semibold mb-6">اختر تصميمك المفضل</h2>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <!-- Cards generated manually -->
+        <!-- We'll create cards referencing dashboards/dashboard-1.html etc -->
+        <a href="dashboards/dashboard-1.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">01</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة تحليلات النمو</h3>
+            <p class="text-slate-300 text-sm">تركيز على مؤشرات الأداء والنمو الأسبوعي لفرق المنتجات.</p>
+            <span class="mt-3 inline-flex items-center text-indigo-300 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-2.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-emerald-500 to-teal-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">02</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة إدارة المشاريع</h3>
+            <p class="text-slate-300 text-sm">عرض حالة المشاريع، التقدم، وأداء الفريق عبر لوحة متكاملة.</p>
+            <span class="mt-3 inline-flex items-center text-emerald-300 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-3.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-amber-500 to-orange-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">03</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة مبيعات التجارة الإلكترونية</h3>
+            <p class="text-slate-300 text-sm">مخططات فورية للطلبات، العائدات، وسلوك العملاء.</p>
+            <span class="mt-3 inline-flex items-center text-amber-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-4.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-sky-500 to-cyan-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">04</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة مراقبة البنية السحابية</h3>
+            <p class="text-slate-300 text-sm">مرئيات لزمن الاستجابة، الاستهلاك، وتنبيهات النظام.</p>
+            <span class="mt-3 inline-flex items-center text-sky-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-5.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-rose-500 to-pink-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">05</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة إدارة المحتوى</h3>
+            <p class="text-slate-300 text-sm">جدولة المحتوى، أداء الحملات، وإدارة القنوات الاجتماعية.</p>
+            <span class="mt-3 inline-flex items-center text-rose-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-6.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-fuchsia-500 to-purple-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">06</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة تجربة العملاء</h3>
+            <p class="text-slate-300 text-sm">نظرة شاملة على رضا العملاء، التذاكر، وسرعة الحل.</p>
+            <span class="mt-3 inline-flex items-center text-fuchsia-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-7.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-lime-500 to-emerald-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">07</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة الموارد البشرية</h3>
+            <p class="text-slate-300 text-sm">مؤشرات الحضور، تقييم الأداء، ومسارات التوظيف.</p>
+            <span class="mt-3 inline-flex items-center text-lime-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-8.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">08</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة إدارة التعليم الإلكتروني</h3>
+            <p class="text-slate-300 text-sm">تتبع الدورات، نشاط الطلاب، وتحليل نتائج التقييمات.</p>
+            <span class="mt-3 inline-flex items-center text-blue-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-9.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-slate-500 to-slate-700 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">09</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة أمن المعلومات</h3>
+            <p class="text-slate-300 text-sm">تنبيهات التهديدات، مستويات الخطورة، وامتثال السياسات.</p>
+            <span class="mt-3 inline-flex items-center text-slate-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+        <a href="dashboards/dashboard-10.html" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+          <div class="h-40 bg-gradient-to-br from-cyan-500 to-emerald-500 flex items-center justify-center">
+            <span class="text-4xl font-bold text-white/80">10</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-xl font-semibold mb-2">لوحة الخدمات المالية</h3>
+            <p class="text-slate-300 text-sm">تحليلات التدفق النقدي، صافي الأرباح، ومؤشرات المخاطر.</p>
+            <span class="mt-3 inline-flex items-center text-cyan-200 text-sm group-hover:translate-x-1 transition">استعراض التصميم →</span>
+          </div>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-800 py-8">
+    <div class="max-w-6xl mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+      <p>© 2024 لوحات تحكم Tailwind. جميع الحقوق محفوظة.</p>
+      <div class="flex gap-4">
+        <a href="#" class="hover:text-slate-200">سياسة الخصوصية</a>
+        <a href="#" class="hover:text-slate-200">شروط الاستخدام</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/dashboards/dashboard-1.html
+++ b/dashboards/dashboard-1.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تحليلات النمو</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen">
+    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
+      <div class="flex items-center gap-3">
+        <div class="h-11 w-11 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center text-lg font-bold">G</div>
+        <div>
+          <p class="font-semibold">Growth Metrics</p>
+          <p class="text-slate-400 text-xs">لوحة تحليلات النمو</p>
+        </div>
+      </div>
+      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <span>فتح القائمة</span>
+      </button>
+    </div>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <div class="lg:flex lg:flex-row">
+      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-slate-900/95 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:static lg:translate-x-0 lg:bg-slate-900 lg:shadow-none">
+        <div class="flex items-start justify-between gap-3">
+          <div class="flex items-center gap-3">
+            <div class="h-12 w-12 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center text-xl font-bold">G</div>
+            <div>
+              <p class="font-semibold text-lg">Growth Metrics</p>
+              <p class="text-slate-400 text-sm">لوحة تحليلات النمو</p>
+            </div>
+          </div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
+            <span>إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <nav class="space-y-1 text-sm">
+          <a class="flex items-center justify-between px-4 py-3 rounded-xl bg-slate-800/60" href="#overview">
+            <span>نظرة عامة</span>
+            <span class="text-indigo-300">•</span>
+          </a>
+          <a class="flex items-center justify-between px-4 py-3 rounded-xl hover:bg-slate-800/40 transition" href="#trends">
+            <span>الاتجاهات</span>
+            <span class="text-slate-600">→</span>
+          </a>
+          <a class="flex items-center justify-between px-4 py-3 rounded-xl hover:bg-slate-800/40 transition" href="#segments">
+            <span>شرائح المستخدمين</span>
+            <span class="text-slate-600">→</span>
+          </a>
+          <a class="flex items-center justify-between px-4 py-3 rounded-xl hover:bg-slate-800/40 transition" href="#retention">
+            <span>الاحتفاظ</span>
+            <span class="text-slate-600">→</span>
+          </a>
+        </nav>
+        <div class="bg-slate-800/50 rounded-2xl p-4">
+          <p class="text-sm text-slate-400">خطة العمل</p>
+          <p class="text-lg font-semibold text-white mt-2">+32% نمو خلال الربع الحالي</p>
+          <p class="text-sm text-slate-400 mt-2">قم بتحسين مسار التحويل مع حملات مستهدفة جديدة.</p>
+        </div>
+      </aside>
+
+      <main class="flex-1 p-6 lg:p-10 space-y-8 lg:pr-10">
+      <header class="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h1 class="text-3xl font-bold">نظرة عامة على النمو</h1>
+          <p class="text-slate-400">متابعة مؤشرات الأداء الرئيسية للشهر الحالي</p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-slate-200">آخر 30 يوم</button>
+          <button class="px-4 py-2 rounded-xl bg-indigo-500 text-white shadow-lg shadow-indigo-500/30">تقرير مخصص</button>
+        </div>
+      </header>
+
+      <section id="overview" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">مستخدمون نشطون</p>
+          <p class="mt-3 text-3xl font-semibold">128,940</p>
+          <p class="mt-2 text-emerald-400 text-sm">+6.4% من الأسبوع الماضي</p>
+          <div class="mt-4 h-16 rounded-xl bg-gradient-to-r from-indigo-500/20 via-indigo-500/10 to-transparent"></div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">نسبة التحويل</p>
+          <p class="mt-3 text-3xl font-semibold">4.87%</p>
+          <p class="mt-2 text-emerald-400 text-sm">+0.42 نقطة مئوية</p>
+          <div class="mt-4 flex items-center gap-2">
+            <div class="flex-1 h-2 bg-slate-800 rounded-full overflow-hidden">
+              <div class="h-full w-4/5 bg-indigo-500"></div>
+            </div>
+            <span class="text-xs text-slate-400">هدف 6%</span>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">قيمة عمر العميل</p>
+          <p class="mt-3 text-3xl font-semibold">$1,240</p>
+          <p class="mt-2 text-amber-400 text-sm">+12% نمو سنوي</p>
+          <div class="mt-4 grid grid-cols-5 gap-2 text-center text-xs text-slate-500">
+            <span class="py-2 bg-slate-800 rounded-lg">Q1</span>
+            <span class="py-2 bg-indigo-500/40 text-indigo-100 rounded-lg">Q2</span>
+            <span class="py-2 bg-indigo-500/60 text-indigo-100 rounded-lg">Q3</span>
+            <span class="py-2 bg-indigo-500/80 text-indigo-100 rounded-lg">Q4</span>
+            <span class="py-2 bg-slate-800 rounded-lg">Q1</span>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">صافي نقاط الترويج</p>
+          <p class="mt-3 text-3xl font-semibold">68</p>
+          <p class="mt-2 text-emerald-400 text-sm">+4 نقاط خلال الشهر</p>
+          <div class="mt-4 flex items-center gap-4">
+            <div class="h-14 w-14 rounded-full bg-emerald-500/20 text-emerald-300 flex items-center justify-center text-lg font-bold">82%</div>
+            <p class="text-xs text-slate-400">العملاء المروجين ارتفعوا بعد إطلاق تجربة الترحيب.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="trends" class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex items-center justify-between mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">منحنى النمو الأسبوعي</h2>
+              <p class="text-slate-400 text-sm">معدل النمو مقابل معدل الزوار الجدد</p>
+            </div>
+            <button class="px-4 py-2 text-sm rounded-xl bg-slate-800">تصدير CSV</button>
+          </div>
+          <div class="h-60 rounded-xl bg-gradient-to-br from-indigo-500/10 via-slate-900 to-slate-900 border border-slate-800 flex items-center justify-center text-slate-500">مخطط خطي</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-6">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">أهم القنوات</h3>
+            <span class="text-xs text-slate-500">آخر تحديث 5 دقائق</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center gap-3">
+              <span class="h-2 w-2 rounded-full bg-indigo-400"></span>
+              <p class="flex-1">إعلانات البحث</p>
+              <span class="text-emerald-400">46%</span>
+            </div>
+            <div class="flex items-center gap-3">
+              <span class="h-2 w-2 rounded-full bg-purple-400"></span>
+              <p class="flex-1">الإحالات</p>
+              <span class="text-emerald-400">32%</span>
+            </div>
+            <div class="flex items-center gap-3">
+              <span class="h-2 w-2 rounded-full bg-amber-400"></span>
+              <p class="flex-1">وسائل التواصل</p>
+              <span class="text-emerald-400">18%</span>
+            </div>
+            <div class="flex items-center gap-3">
+              <span class="h-2 w-2 rounded-full bg-rose-400"></span>
+              <p class="flex-1">البريد الإلكتروني</p>
+              <span class="text-emerald-400">12%</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="segments" class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">شرائح المستخدمين النشطة</h2>
+            <p class="text-sm text-slate-400">أهم الشرائح التي تساهم في الإيرادات</p>
+          </div>
+          <div class="flex gap-3">
+            <button class="px-4 py-2 rounded-xl bg-slate-800 text-slate-200">الشهر</button>
+            <button class="px-4 py-2 rounded-xl bg-indigo-500 text-white">الربع</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[640px] text-sm">
+            <thead>
+              <tr class="text-slate-400">
+                <th class="text-right font-medium pb-3">الشريحة</th>
+                <th class="text-right font-medium pb-3">المستخدمون</th>
+                <th class="text-right font-medium pb-3">القيمة الدورية</th>
+                <th class="text-right font-medium pb-3">نمو 30 يوم</th>
+                <th class="text-right font-medium pb-3">الحالة</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800">
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4">فرق المنتجات الناشئة</td>
+                <td>24,870</td>
+                <td>$420K</td>
+                <td class="text-emerald-400">+14%</td>
+                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-300">متسارع</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4">وكالات التسويق</td>
+                <td>12,430</td>
+                <td>$180K</td>
+                <td class="text-emerald-400">+9%</td>
+                <td><span class="px-3 py-1 rounded-full bg-indigo-500/20 text-indigo-300">مستقر</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4">الشركات التقنية الكبرى</td>
+                <td>7,320</td>
+                <td>$310K</td>
+                <td class="text-amber-400">+3%</td>
+                <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-300">يحتاج تحفيز</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="retention" class="grid gap-6 lg:grid-cols-2">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-6">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">تحليل الاحتفاظ</h3>
+            <span class="text-xs text-slate-500">آخر تحديث 2 دقائق</span>
+          </div>
+          <div class="h-56 rounded-xl bg-gradient-to-br from-indigo-500/10 via-slate-900 to-slate-900 border border-slate-800 flex items-center justify-center text-slate-500">مخطط احتفاظ</div>
+          <div class="grid grid-cols-2 gap-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">اليوم 7</p>
+              <p class="text-xl font-semibold">42%</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">اليوم 30</p>
+              <p class="text-xl font-semibold">28%</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">اليوم 60</p>
+              <p class="text-xl font-semibold">19%</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">التجديدات</p>
+              <p class="text-xl font-semibold text-emerald-400">+8%</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-4">
+          <h3 class="text-lg font-semibold">ملاحظات العملاء الأخيرة</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">"منصة رائعة"</p>
+              <p class="text-slate-400 mt-1">تم تحسين تجربة الإعداد بشكل كبير، مما ساعدنا على إطلاق حملات أسرع.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">"نحتاج تكاملات إضافية"</p>
+              <p class="text-slate-400 mt-1">اقتراح بإضافة تكامل مع Slack لمتابعة التنبيهات.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">"واجهة سهلة"</p>
+              <p class="text-slate-400 mt-1">لوحة التحكم واضحة وتعرض البيانات التي نحتاجها فورًا.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const sidebar = document.getElementById('sidebar');
+      const toggle = document.getElementById('sidebarToggle');
+      const close = document.getElementById('sidebarClose');
+      const backdrop = document.getElementById('sidebarBackdrop');
+      const body = document.body;
+
+      if (!sidebar || !toggle || !close || !backdrop) {
+        return;
+      }
+
+      const openSidebar = () => {
+        sidebar.classList.remove('translate-x-full');
+        backdrop.classList.remove('opacity-0', 'pointer-events-none');
+        backdrop.classList.add('opacity-100');
+        body.classList.add('overflow-hidden');
+      };
+
+      const closeSidebar = () => {
+        sidebar.classList.add('translate-x-full');
+        backdrop.classList.add('opacity-0', 'pointer-events-none');
+        backdrop.classList.remove('opacity-100');
+        body.classList.remove('overflow-hidden');
+      };
+
+      toggle.addEventListener('click', openSidebar);
+      close.addEventListener('click', closeSidebar);
+      backdrop.addEventListener('click', closeSidebar);
+
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeSidebar();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-10.html
+++ b/dashboards/dashboard-10.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الخدمات المالية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col">
+    <header class="border-b border-slate-800 bg-gradient-to-r from-cyan-500/10 via-slate-950 to-slate-950">
+      <div class="max-w-7xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.4em] text-cyan-300">FinSight</p>
+          <h1 class="text-3xl font-bold">لوحة الخدمات المالية والتحليل</h1>
+          <p class="text-slate-300 mt-2">مراقبة التدفق النقدي، الربحية، والمخاطر في الوقت الفعلي.</p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تقرير مخصص</button>
+          <button class="px-4 py-2 rounded-xl bg-cyan-500 text-sm text-slate-950 font-semibold">تحميل البيانات</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 max-w-7xl mx-auto w-full px-6 py-10 space-y-8">
+      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">صافي الربح</p>
+          <p class="mt-3 text-3xl font-semibold">$1.2M</p>
+          <p class="mt-2 text-emerald-300 text-sm">+14% مقارنة بالربع السابق</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">الهامش الإجمالي</p>
+          <p class="mt-3 text-3xl font-semibold">58%</p>
+          <p class="mt-2 text-xs text-slate-500">الهدف 60%</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">التدفق النقدي الحر</p>
+          <p class="mt-3 text-3xl font-semibold">$480K</p>
+          <p class="mt-2 text-emerald-300 text-sm">+9% على أساس شهري</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">نسبة السيولة</p>
+          <p class="mt-3 text-3xl font-semibold">1.9</p>
+          <p class="mt-2 text-emerald-300 text-sm">ضمن النطاق الآمن</p>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">تحليل التدفق النقدي</h2>
+              <p class="text-sm text-slate-400">المصادر والاستخدامات خلال 12 شهر</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">شهر</button>
+              <button class="px-4 py-2 rounded-xl bg-cyan-500 text-slate-950 font-semibold">ربع</button>
+            </div>
+          </div>
+          <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-cyan-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط تدفق</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">مصادر الإيرادات</h3>
+            <span class="text-xs text-slate-500">آخر 30 يوم</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>الاشتراكات</p>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">46%</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>الخدمات الاستشارية</p>
+              <span class="px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-200">32%</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>الشراكات</p>
+              <span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">12%</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">قائمة الحسابات الرئيسية</h2>
+            <p class="text-sm text-slate-400">الرصيد الحالي وأهم الحركات</p>
+          </div>
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تصدير Excel</button>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[720px] text-sm">
+            <thead>
+              <tr class="text-slate-400">
+                <th class="text-right pb-3 font-medium">الحساب</th>
+                <th class="text-right pb-3 font-medium">الرصيد</th>
+                <th class="text-right pb-3 font-medium">التغير الشهري</th>
+                <th class="text-right pb-3 font-medium">الإنفاق</th>
+                <th class="text-right pb-3 font-medium">المخاطر</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800">
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4">النقد وما في حكمه</td>
+                <td>$780K</td>
+                <td class="text-emerald-300">+11%</td>
+                <td>$120K</td>
+                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">منخفض</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4">الذمم المدينة</td>
+                <td>$320K</td>
+                <td class="text-amber-300">+6%</td>
+                <td>$60K</td>
+                <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">متوسط</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4">الاستثمارات قصيرة الأجل</td>
+                <td>$540K</td>
+                <td class="text-emerald-300">+4%</td>
+                <td>$0</td>
+                <td><span class="px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-200">مستقر</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">مؤشرات المخاطر</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>التعرض للعملات</p>
+              <span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">متوسط</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>الديون قصيرة الأجل</p>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">منخفض</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>نقاط الائتمان</p>
+              <span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">مراقبة</span>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">أداء القطاعات</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>التقنية</p>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">+12%</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>الخدمات</p>
+              <span class="px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-200">+9%</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>الأسواق الناشئة</p>
+              <span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">+6%</span>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">أحداث قادمة</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">15 مايو</p>
+              <p class="font-semibold">إعلان أرباح الربع الثاني</p>
+              <p class="text-xs text-emerald-300 mt-1">جلسة مع المستثمرين</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">22 مايو</p>
+              <p class="font-semibold">تحديث خطة الميزانية</p>
+              <p class="text-xs text-emerald-300 mt-1">إدارة المالية</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">29 مايو</p>
+              <p class="font-semibold">مراجعة المخاطر السنوية</p>
+              <p class="text-xs text-emerald-300 mt-1">لجنة المخاطر</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/dashboards/dashboard-2.html
+++ b/dashboards/dashboard-2.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة المشاريع</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col">
+    <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur">
+      <div class="max-w-7xl mx-auto px-6 py-5 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-emerald-300">Project Pulse</p>
+          <h1 class="text-3xl font-bold">لوحة إدارة المشاريع</h1>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">إنشاء مشروع</button>
+          <button class="px-4 py-2 rounded-xl bg-emerald-500 text-sm text-slate-950 font-semibold">تقرير أسبوعي</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 max-w-7xl mx-auto w-full px-6 py-10 space-y-8">
+      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="p-5 rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-900/50">
+          <p class="text-sm text-slate-400">المشاريع الفعالة</p>
+          <div class="mt-3 flex items-baseline gap-2">
+            <span class="text-3xl font-semibold">42</span>
+            <span class="text-xs text-emerald-400">+3 جديدة</span>
+          </div>
+          <div class="mt-4 flex -space-x-2 rtl:space-x-reverse">
+            <div class="h-9 w-9 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-200 text-xs">PM</div>
+            <div class="h-9 w-9 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-200 text-xs">UX</div>
+            <div class="h-9 w-9 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-200 text-xs">DEV</div>
+          </div>
+        </div>
+        <div class="p-5 rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-900/50">
+          <p class="text-sm text-slate-400">نسبة الإنجاز المتوسطة</p>
+          <div class="mt-3 flex items-center gap-3">
+            <div class="flex-1 h-2 rounded-full bg-slate-800 overflow-hidden">
+              <div class="h-full w-3/4 bg-emerald-400"></div>
+            </div>
+            <span class="text-2xl font-semibold">76%</span>
+          </div>
+          <p class="text-xs text-slate-500 mt-2">الهدف: 85% خلال هذا الربع.</p>
+        </div>
+        <div class="p-5 rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-900/50">
+          <p class="text-sm text-slate-400">المهام المتأخرة</p>
+          <p class="mt-3 text-3xl font-semibold text-amber-300">18</p>
+          <p class="text-xs text-amber-400 mt-2">تنبيه: مراجعة sprint team beta</p>
+        </div>
+        <div class="p-5 rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-900/50">
+          <p class="text-sm text-slate-400">الميزانية المستخدمة</p>
+          <p class="mt-3 text-3xl font-semibold">$480K</p>
+          <p class="text-xs text-emerald-400 mt-2">58% من الميزانية السنوية</p>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80">
+          <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 class="text-xl font-semibold">لوح الحالة الفوري</h2>
+              <p class="text-sm text-slate-400">توزيع المشاريع حسب المرحلة</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">هذا الأسبوع</button>
+              <button class="px-4 py-2 rounded-xl bg-emerald-500 text-slate-950 font-semibold">هذا الشهر</button>
+            </div>
+          </div>
+          <div class="p-6 grid gap-6 lg:grid-cols-3">
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4">
+              <p class="text-xs text-slate-500">الاكتشاف</p>
+              <p class="mt-3 text-2xl font-semibold">12</p>
+              <p class="text-xs text-emerald-400 mt-2">+2 منذ الأمس</p>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4">
+              <p class="text-xs text-slate-500">التطوير</p>
+              <p class="mt-3 text-2xl font-semibold">18</p>
+              <p class="text-xs text-emerald-400 mt-2">+1 sprint</p>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4">
+              <p class="text-xs text-slate-500">إطلاق</p>
+              <p class="mt-3 text-2xl font-semibold">9</p>
+              <p class="text-xs text-amber-400 mt-2">-3 بحاجة دعم</p>
+            </div>
+            <div class="lg:col-span-3 rounded-xl border border-dashed border-emerald-500/40 bg-emerald-500/5 p-6 text-sm text-slate-300">
+              <p class="font-semibold text-emerald-200 mb-2">رسالة PM</p>
+              <p>"يرجى التأكد من تحديث حالة المشروع قبل نهاية اليوم لضمان دقة التقرير الأسبوعي".</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-6">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">المواعيد المهمة</h3>
+            <button class="text-xs text-emerald-300">عرض الكل</button>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">12 مايو</p>
+              <p class="font-semibold">تسليم الإصدار 2.1 لتطبيق الهواتف</p>
+              <p class="text-xs text-emerald-400 mt-1">Team Phoenix</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">17 مايو</p>
+              <p class="font-semibold">ورشة تجربة المستخدم</p>
+              <p class="text-xs text-emerald-400 mt-1">مع فريق Growth</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-slate-400">24 مايو</p>
+              <p class="font-semibold">اعتماد ميزانية الربع الثالث</p>
+              <p class="text-xs text-emerald-400 mt-1">مجلس الإدارة</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">جدول الفرق</h2>
+            <p class="text-sm text-slate-400">أعضاء الفرق ونسبة الالتزام</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">كل الفرق</button>
+            <button class="px-4 py-2 rounded-xl bg-emerald-500 text-slate-950 font-semibold">الفرق النشطة</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[720px] text-sm">
+            <thead>
+              <tr class="text-slate-400">
+                <th class="text-right pb-3 font-medium">الفريق</th>
+                <th class="text-right pb-3 font-medium">قائد الفريق</th>
+                <th class="text-right pb-3 font-medium">المشاريع الحالية</th>
+                <th class="text-right pb-3 font-medium">نسبة الالتزام</th>
+                <th class="text-right pb-3 font-medium">مستوى الضغط</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800">
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-emerald-500/20 text-emerald-200 flex items-center justify-center text-xs">UX</span>
+                  <span>فريق تجربة المستخدم</span>
+                </td>
+                <td>داليا الشامي</td>
+                <td>4</td>
+                <td class="text-emerald-400">92%</td>
+                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">مستقر</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-emerald-500/20 text-emerald-200 flex items-center justify-center text-xs">ENG</span>
+                  <span>فريق التطوير</span>
+                </td>
+                <td>سالم الراشد</td>
+                <td>6</td>
+                <td class="text-emerald-400">85%</td>
+                <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">مرتفعة</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-emerald-500/20 text-emerald-200 flex items-center justify-center text-xs">QA</span>
+                  <span>فريق الجودة</span>
+                </td>
+                <td>ميساء فهد</td>
+                <td>3</td>
+                <td class="text-emerald-400">78%</td>
+                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">مستقر</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-emerald-500/20 text-emerald-200 flex items-center justify-center text-xs">OPS</span>
+                  <span>عمليات المشاريع</span>
+                </td>
+                <td>طارق المدني</td>
+                <td>5</td>
+                <td class="text-emerald-400">81%</td>
+                <td><span class="px-3 py-1 rounded-full bg-slate-800 text-slate-300">متوسط</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/dashboards/dashboard-3.html
+++ b/dashboards/dashboard-3.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة مبيعات التجارة الإلكترونية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen">
+    <header class="border-b border-slate-800 bg-gradient-to-br from-amber-500/10 via-slate-950 to-slate-950">
+      <div class="max-w-7xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.4em] text-amber-300">Commerce Insight</p>
+          <h1 class="text-4xl font-bold">لوحة تحليلات المتجر الرقمي</h1>
+          <p class="text-slate-300 mt-3 max-w-2xl">
+            نظرة فورية على الطلبات، العائدات، وولاء العملاء عبر جميع القنوات الرقمية.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-900 text-sm">نطاق مخصص</button>
+          <button class="px-4 py-2 rounded-xl bg-amber-500 text-sm text-slate-950 font-semibold">تحميل التقرير PDF</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-7xl mx-auto px-6 py-10 space-y-10">
+      <section class="grid gap-6 lg:grid-cols-4">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">إجمالي المبيعات</p>
+          <p class="mt-3 text-3xl font-semibold">$284K</p>
+          <p class="mt-2 text-emerald-400 text-sm">+18% مقارنة بالشهر الماضي</p>
+          <div class="mt-4 h-16 bg-gradient-to-r from-amber-500/20 via-amber-500/5 to-transparent rounded-xl"></div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">متوسط قيمة الطلب</p>
+          <p class="mt-3 text-3xl font-semibold">$86.50</p>
+          <p class="mt-2 text-emerald-400 text-sm">+7.2% نمو أسبوعي</p>
+          <div class="mt-4 flex items-center gap-2 text-xs text-slate-500">
+            <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-200">متاجر التطبيق</span>
+            <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-200">الموقع</span>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">نسبة سلة الشراء</p>
+          <div class="mt-3 flex items-center gap-3">
+            <div class="h-14 w-14 rounded-full bg-amber-500/15 flex items-center justify-center">
+              <span class="text-xl font-semibold text-amber-300">42%</span>
+            </div>
+            <div class="space-y-1 text-xs text-slate-400">
+              <p>الهدف الشهري: 40%</p>
+              <p class="text-emerald-300">+3.4% بعد تحسين التجربة</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">العملاء المتكررون</p>
+          <p class="mt-3 text-3xl font-semibold">62%</p>
+          <p class="mt-2 text-emerald-400 text-sm">+5% خلال 90 يوم</p>
+          <div class="mt-4 flex -space-x-3 rtl:space-x-reverse">
+            <div class="h-10 w-10 rounded-full bg-emerald-500/10 border border-emerald-500/20"></div>
+            <div class="h-10 w-10 rounded-full bg-amber-500/10 border border-amber-500/20"></div>
+            <div class="h-10 w-10 rounded-full bg-rose-500/10 border border-rose-500/20"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">منحنى الإيرادات متعدد القنوات</h2>
+              <p class="text-sm text-slate-400">مقارنة بين الموقع، التطبيق، ومتجر السوق</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">7 أيام</button>
+              <button class="px-4 py-2 rounded-xl bg-amber-500 text-slate-950 font-semibold">30 يوم</button>
+            </div>
+          </div>
+          <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-amber-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">منطقة المخطط</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">المنتجات الأعلى أداءً</h3>
+            <span class="text-xs text-slate-500">آخر تحديث قبل 3 دقائق</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center gap-3">
+              <div class="h-12 w-12 rounded-xl bg-emerald-500/10 border border-emerald-500/20"></div>
+              <div class="flex-1">
+                <p class="font-semibold">سماعات Pro X</p>
+                <p class="text-xs text-slate-500">$84K مبيعات</p>
+              </div>
+              <span class="text-emerald-300">+22%</span>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="h-12 w-12 rounded-xl bg-amber-500/10 border border-amber-500/20"></div>
+              <div class="flex-1">
+                <p class="font-semibold">ساعة ذكية</p>
+                <p class="text-xs text-slate-500">$61K مبيعات</p>
+              </div>
+              <span class="text-emerald-300">+18%</span>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="h-12 w-12 rounded-xl bg-rose-500/10 border border-rose-500/20"></div>
+              <div class="flex-1">
+                <p class="font-semibold">حقيبة سفر</p>
+                <p class="text-xs text-slate-500">$47K مبيعات</p>
+              </div>
+              <span class="text-emerald-300">+9%</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">قنوات اكتساب العملاء</h2>
+            <p class="text-sm text-slate-400">تحليل الأداء للمصادر الرئيسية</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">شهر</button>
+            <button class="px-4 py-2 rounded-xl bg-amber-500 text-slate-950 font-semibold">ربع</button>
+          </div>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4 text-sm">
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">إعلانات محركات البحث</p>
+            <p class="text-2xl font-semibold mt-2">$94K</p>
+            <p class="text-emerald-300 text-xs mt-1">+26% معدل العائد</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">وسائل التواصل</p>
+            <p class="text-2xl font-semibold mt-2">$58K</p>
+            <p class="text-emerald-300 text-xs mt-1">+18% معدل التفاعل</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">التسويق بالبريد</p>
+            <p class="text-2xl font-semibold mt-2">$36K</p>
+            <p class="text-emerald-300 text-xs mt-1">+8% معدل الفتح</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">الشراكات</p>
+            <p class="text-2xl font-semibold mt-2">$24K</p>
+            <p class="text-emerald-300 text-xs mt-1">+11% معدل التحويل</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">تقييمات العملاء</h3>
+            <span class="text-xs text-slate-500">آخر 24 ساعة</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">منى القحطاني</p>
+              <p class="text-amber-300 text-xs">★★★★★</p>
+              <p class="text-slate-400 mt-1">خدمة التوصيل سريعة والمنتج مطابق للوصف!</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">أحمد الشمراني</p>
+              <p class="text-amber-300 text-xs">★★★★☆</p>
+              <p class="text-slate-400 mt-1">نحتاج المزيد من خيارات الشحن الدولي.</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">التحويل حسب الجهاز</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>الهاتف</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[72%] bg-amber-400"></div>
+                </div>
+                <span class="text-emerald-300">72%</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>الويب</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[54%] bg-emerald-400"></div>
+                </div>
+                <span class="text-emerald-300">54%</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>التطبيق اللوحي</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[38%] bg-rose-400"></div>
+                </div>
+                <span class="text-emerald-300">38%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">معدل التخلي عن السلة</h3>
+          <div class="h-48 rounded-xl border border-slate-800 bg-gradient-to-br from-amber-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط دائري</div>
+          <p class="text-sm text-slate-400">تحسن بمقدار 6% بعد إضافة خيارات الدفع السريع.</p>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/dashboards/dashboard-4.html
+++ b/dashboards/dashboard-4.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة مراقبة البنية السحابية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen">
+    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
+      <div>
+        <p class="text-xs uppercase tracking-[0.4em] text-sky-300">Cloud Sentinel</p>
+        <h1 class="text-lg font-semibold">المراقبة الفورية</h1>
+      </div>
+      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <span>فتح القائمة</span>
+      </button>
+    </div>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <div class="lg:grid lg:grid-cols-[320px_1fr]">
+      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-slate-900/95 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:relative lg:translate-x-0 lg:w-full lg:max-w-[320px] lg:bg-slate-900/80">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.4em] text-sky-300">Cloud Sentinel</p>
+            <h1 class="text-2xl font-bold">المراقبة الفورية</h1>
+            <p class="text-sm text-slate-400 mt-2">لوحة موحدة للبنية التحتية السحابية.</p>
+          </div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
+            <span>إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div class="space-y-4">
+          <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+            <p class="text-xs text-slate-500">الحالة العامة</p>
+            <p class="text-lg font-semibold text-emerald-300 mt-2">مستقرة</p>
+            <p class="text-xs text-slate-500 mt-2">لا يوجد أعطال حرجة خلال آخر 24 ساعة.</p>
+          </div>
+          <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 space-y-3 text-sm">
+            <p class="text-slate-400">التنبيهات الحية</p>
+            <div class="flex items-center justify-between">
+              <span>CPU</span>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300">طبيعي</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>Memory</span>
+              <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-300">انتباه</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>Network</span>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300">طبيعي</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>Storage</span>
+              <span class="px-3 py-1 rounded-full bg-rose-500/10 text-rose-300">حرج</span>
+            </div>
+          </div>
+        </div>
+        <div class="space-y-3">
+          <p class="text-xs uppercase text-slate-500">البيئات</p>
+          <div class="space-y-2 text-sm">
+            <a class="block px-4 py-3 rounded-xl bg-slate-800/60" href="#">الإنتاج</a>
+            <a class="block px-4 py-3 rounded-xl hover:bg-slate-800/40 transition" href="#">الاختبار</a>
+            <a class="block px-4 py-3 rounded-xl hover:bg-slate-800/40 transition" href="#">التطوير</a>
+          </div>
+        </div>
+      </aside>
+
+      <main class="p-6 lg:p-10 space-y-8 lg:pr-10">
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">المراقبة الزمنية للأحمال</h2>
+              <p class="text-sm text-slate-400">CPU / Memory / Network</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">آخر ساعة</button>
+              <button class="px-4 py-2 rounded-xl bg-sky-500 text-slate-950 font-semibold">آخر 24 ساعة</button>
+            </div>
+          </div>
+          <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-sky-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط متعدد المحاور</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">مؤشر التوفر</h3>
+            <span class="text-xs text-slate-500">آخر تحديث: 12 ثانية</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center gap-4">
+              <span class="w-2 h-12 rounded-full bg-emerald-500"></span>
+              <div class="flex-1">
+                <p class="font-semibold">المنطقة - أوروبا</p>
+                <p class="text-xs text-slate-500">99.98% التوفر</p>
+              </div>
+              <span class="text-emerald-300">↑</span>
+            </div>
+            <div class="flex items-center gap-4">
+              <span class="w-2 h-12 rounded-full bg-emerald-400"></span>
+              <div class="flex-1">
+                <p class="font-semibold">المنطقة - أمريكا</p>
+                <p class="text-xs text-slate-500">99.94% التوفر</p>
+              </div>
+              <span class="text-emerald-300">↑</span>
+            </div>
+            <div class="flex items-center gap-4">
+              <span class="w-2 h-12 rounded-full bg-amber-400"></span>
+              <div class="flex-1">
+                <p class="font-semibold">المنطقة - آسيا</p>
+                <p class="text-xs text-slate-500">99.71% التوفر</p>
+              </div>
+              <span class="text-amber-300">→</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 xl:grid-cols-3">
+        <div class="xl:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80">
+          <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 class="text-xl font-semibold">حالة الخدمات الدقيقة</h2>
+              <p class="text-sm text-slate-400">توزيع السعة والتحميل</p>
+            </div>
+            <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تحديث فوري</button>
+          </div>
+          <div class="p-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-3 text-sm">
+              <div class="flex items-center justify-between">
+                <p class="font-semibold">API Gateway</p>
+                <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300 text-xs">سليم</span>
+              </div>
+              <div>
+                <p class="text-slate-400">زمن الاستجابة</p>
+                <p class="text-lg font-semibold">142ms</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="flex-1 h-2 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[68%] bg-sky-500"></div>
+                </div>
+                <span class="text-xs text-slate-400">68% سعة</span>
+              </div>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-3 text-sm">
+              <div class="flex items-center justify-between">
+                <p class="font-semibold">Auth Service</p>
+                <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-300 text-xs">تحذير</span>
+              </div>
+              <div>
+                <p class="text-slate-400">زمن الاستجابة</p>
+                <p class="text-lg font-semibold">384ms</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="flex-1 h-2 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[84%] bg-amber-400"></div>
+                </div>
+                <span class="text-xs text-slate-400">84% سعة</span>
+              </div>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-3 text-sm">
+              <div class="flex items-center justify-between">
+                <p class="font-semibold">ML Engine</p>
+                <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300 text-xs">سليم</span>
+              </div>
+              <div>
+                <p class="text-slate-400">زمن الاستجابة</p>
+                <p class="text-lg font-semibold">202ms</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="flex-1 h-2 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[58%] bg-emerald-400"></div>
+                </div>
+                <span class="text-xs text-slate-400">58% سعة</span>
+              </div>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-3 text-sm">
+              <div class="flex items-center justify-between">
+                <p class="font-semibold">Streaming Cluster</p>
+                <span class="px-3 py-1 rounded-full bg-rose-500/10 text-rose-300 text-xs">حرج</span>
+              </div>
+              <div>
+                <p class="text-slate-400">زمن الاستجابة</p>
+                <p class="text-lg font-semibold">612ms</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="flex-1 h-2 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[91%] bg-rose-400"></div>
+                </div>
+                <span class="text-xs text-slate-400">91% سعة</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">الإنذارات الأخيرة</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60 border border-slate-800/70">
+              <p class="text-xs text-rose-300">قبل 5 دقائق</p>
+              <p class="font-semibold mt-1">ارتفاع تأخير تخزين المنطقة آسيا</p>
+              <p class="text-xs text-slate-400 mt-2">تم تحويل 32% من الزيارات إلى النسخة الاحتياطية.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60 border border-slate-800/70">
+              <p class="text-xs text-amber-300">قبل 18 دقيقة</p>
+              <p class="font-semibold mt-1">تحذير في Auth Service</p>
+              <p class="text-xs text-slate-400 mt-2">زيادة في عمليات تسجيل الدخول الفاشلة بنسبة 12%.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60 border border-slate-800/70">
+              <p class="text-xs text-sky-300">قبل 42 دقيقة</p>
+              <p class="font-semibold mt-1">استهلاك الذاكرة في cluster analytics</p>
+              <p class="text-xs text-slate-400 mt-2">تم ترحيل المهمة إلى عقدة جديدة بنجاح.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">الامتثال والتدقيق</h2>
+            <p class="text-sm text-slate-400">نظرة على عناصر الامتثال الأساسية</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">30 يوم</button>
+            <button class="px-4 py-2 rounded-xl bg-sky-500 text-slate-950 font-semibold">90 يوم</button>
+          </div>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4 text-sm">
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">ISO 27001</p>
+            <p class="text-2xl font-semibold text-emerald-300 mt-2">متوافق</p>
+            <p class="text-xs text-slate-500 mt-2">آخر مراجعة: قبل 9 أيام</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">GDPR</p>
+            <p class="text-2xl font-semibold text-emerald-300 mt-2">متوافق</p>
+            <p class="text-xs text-slate-500 mt-2">لا توجد مخالفات مفتوحة</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">SOC 2</p>
+            <p class="text-2xl font-semibold text-amber-300 mt-2">معلق</p>
+            <p class="text-xs text-slate-500 mt-2">ينتهي التسليم خلال 12 يوم</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">PCI DSS</p>
+            <p class="text-2xl font-semibold text-emerald-300 mt-2">متوافق</p>
+            <p class="text-xs text-slate-500 mt-2">تدقيق مكتمل بنسبة 94%</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const sidebar = document.getElementById('sidebar');
+      const toggle = document.getElementById('sidebarToggle');
+      const close = document.getElementById('sidebarClose');
+      const backdrop = document.getElementById('sidebarBackdrop');
+      const body = document.body;
+
+      if (!sidebar || !toggle || !close || !backdrop) {
+        return;
+      }
+
+      const openSidebar = () => {
+        sidebar.classList.remove('translate-x-full');
+        backdrop.classList.remove('opacity-0', 'pointer-events-none');
+        backdrop.classList.add('opacity-100');
+        body.classList.add('overflow-hidden');
+      };
+
+      const closeSidebar = () => {
+        sidebar.classList.add('translate-x-full');
+        backdrop.classList.add('opacity-0', 'pointer-events-none');
+        backdrop.classList.remove('opacity-100');
+        body.classList.remove('overflow-hidden');
+      };
+
+      toggle.addEventListener('click', openSidebar);
+      close.addEventListener('click', closeSidebar);
+      backdrop.addEventListener('click', closeSidebar);
+
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeSidebar();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-5.html
+++ b/dashboards/dashboard-5.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة المحتوى</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col">
+    <header class="border-b border-slate-800 bg-gradient-to-r from-rose-500/10 via-slate-950 to-slate-950">
+      <div class="max-w-6xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.4em] text-rose-300">Content Orbit</p>
+          <h1 class="text-3xl font-bold">لوحة إدارة المحتوى المتكاملة</h1>
+          <p class="text-slate-300 mt-2">تخطيط وجدولة المحتوى لكل القنوات في مكان واحد.</p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">إنشاء منشور</button>
+          <button class="px-4 py-2 rounded-xl bg-rose-500 text-sm text-slate-950 font-semibold">استيراد تقويم</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 max-w-6xl mx-auto w-full px-6 py-10 space-y-8">
+      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">مقالات قيد النشر</p>
+          <p class="mt-3 text-3xl font-semibold">28</p>
+          <p class="mt-2 text-emerald-300 text-sm">+6 مقارنة بالأسبوع الماضي</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">منشورات التواصل</p>
+          <p class="mt-3 text-3xl font-semibold">64</p>
+          <p class="mt-2 text-rose-300 text-sm">متوسط تفاعل 5.2%</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">الفيديوهات المجدولة</p>
+          <p class="mt-3 text-3xl font-semibold">12</p>
+          <p class="mt-2 text-emerald-300 text-sm">جاهزة للنشر خلال 48 ساعة</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">رسائل البريد</p>
+          <p class="mt-3 text-3xl font-semibold">4</p>
+          <p class="mt-2 text-amber-300 text-sm">حملة رئيسية يوم الأحد</p>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80">
+        <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-xl font-semibold">تقويم التحرير</h2>
+            <p class="text-sm text-slate-400">عرض أسبوعي للمهام القابلة للتنفيذ</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">أسبوع</button>
+            <button class="px-4 py-2 rounded-xl bg-rose-500 text-slate-950 font-semibold">شهر</button>
+          </div>
+        </div>
+        <div class="p-6 grid gap-6 md:grid-cols-2 xl:grid-cols-3 text-sm">
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-2">
+            <p class="text-slate-400">الأحد</p>
+            <p class="font-semibold text-lg">إطلاق سلسلة المقالات التقنية</p>
+            <p class="text-xs text-slate-500">3 مسودات تنتظر المراجعة النهائية</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-2">
+            <p class="text-slate-400">الإثنين</p>
+            <p class="font-semibold text-lg">حملة البريد للنشرة الأسبوعية</p>
+            <p class="text-xs text-slate-500">معدل فتح مستهدف 38%</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-2">
+            <p class="text-slate-400">الثلاثاء</p>
+            <p class="font-semibold text-lg">بث مباشر على Instagram</p>
+            <p class="text-xs text-slate-500">ضيف: فريق المنتج</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-2">
+            <p class="text-slate-400">الأربعاء</p>
+            <p class="font-semibold text-lg">مدونة الضيوف</p>
+            <p class="text-xs text-slate-500">المحرر: هالة التميمي</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-2">
+            <p class="text-slate-400">الخميس</p>
+            <p class="font-semibold text-lg">مراجعة تقارير الأداء الاجتماعي</p>
+            <p class="text-xs text-slate-500">تفعيل الإعلانات المدفوعة</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 space-y-2">
+            <p class="text-slate-400">الجمعة</p>
+            <p class="font-semibold text-lg">تسجيل بودكاست</p>
+            <p class="text-xs text-slate-500">موضوع: قصص نجاح العملاء</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">لوحة الإلهام</h3>
+            <button class="text-xs text-rose-300">تحديث</button>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">موضوعات ناشئة</p>
+              <p class="text-slate-400 text-xs mt-1">الذكاء الاصطناعي، التحليل التنبؤي، قصص العملاء</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">صور مقترحة</p>
+              <p class="text-slate-400 text-xs mt-1">مرئيات ثلاثية الأبعاد، إضاءة نيون، جداول بيانات أنيقة</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">نغمات الصوت</p>
+              <p class="text-slate-400 text-xs mt-1">مُلهم، استباقي، ودي</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">أداء القنوات</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>المدونة</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[64%] bg-rose-400"></div>
+                </div>
+                <span class="text-emerald-300">64K زيارة</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>LinkedIn</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[52%] bg-emerald-400"></div>
+                </div>
+                <span class="text-emerald-300">52K تفاعل</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>YouTube</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[44%] bg-amber-400"></div>
+                </div>
+                <span class="text-emerald-300">44K مشاهدة</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">مهام الفريق</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-start gap-3">
+              <span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200 text-xs">كتابة</span>
+              <div>
+                <p class="font-semibold">تحديث دليل الأسلوب التحريري</p>
+                <p class="text-xs text-slate-500 mt-1">المسؤول: مريم قاسم - موعد التسليم الثلاثاء</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200 text-xs">تصميم</span>
+              <div>
+                <p class="font-semibold">تجهيز قوالب عروض الشرائح</p>
+                <p class="text-xs text-slate-500 mt-1">المسؤول: فهد الوابل - موعد التسليم الأربعاء</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200 text-xs">توزيع</span>
+              <div>
+                <p class="font-semibold">تنسيق النشر مع المؤثرين</p>
+                <p class="text-xs text-slate-500 mt-1">المسؤول: أنس الشريف - موعد التسليم الخميس</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/dashboards/dashboard-6.html
+++ b/dashboards/dashboard-6.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تجربة العملاء</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen">
+    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
+      <div>
+        <p class="text-xs uppercase tracking-[0.4em] text-fuchsia-300">Customer Pulse</p>
+        <h1 class="text-lg font-semibold">تجربة العملاء الحية</h1>
+      </div>
+      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-fuchsia-500 px-4 py-2 text-sm font-semibold text-slate-950">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <span>فتح القائمة</span>
+      </button>
+    </div>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <div class="lg:flex lg:flex-row">
+      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-gradient-to-b from-fuchsia-500/20 via-slate-950 to-slate-950 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:static lg:w-80 lg:translate-x-0 lg:border-l lg:bg-gradient-to-b lg:from-fuchsia-500/10 lg:via-slate-950 lg:to-slate-950">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.4em] text-fuchsia-300">Customer Pulse</p>
+            <h1 class="text-3xl font-bold">تجربة العملاء الحية</h1>
+            <p class="text-sm text-slate-400 mt-2">لوحة كاملة لرضا العملاء وسرعة الاستجابة.</p>
+          </div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
+            <span>إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div class="space-y-4 text-sm">
+          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+            <p class="text-slate-400">مؤشر رضا العملاء</p>
+            <p class="text-2xl font-semibold text-fuchsia-200 mt-2">87</p>
+            <p class="text-xs text-emerald-300 mt-2">+6 نقاط خلال آخر 30 يوم</p>
+          </div>
+          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+            <p class="text-slate-400">التذاكر المفتوحة</p>
+            <p class="text-2xl font-semibold">124</p>
+            <p class="text-xs text-amber-300 mt-2">انخفاض 14%</p>
+          </div>
+        </div>
+        <div class="space-y-3 text-sm">
+          <p class="text-xs uppercase text-slate-500">التجزئة</p>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/60 text-right">مستوى الخدمة المميز</button>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">المستخدمون الجدد</button>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">الأسواق الدولية</button>
+        </div>
+      </aside>
+
+      <main class="flex-1 p-6 lg:p-10 space-y-8 lg:pr-10">
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">موجز المشاعر</h2>
+              <p class="text-sm text-slate-400">تحليل تلقائي للانطباعات عبر القنوات</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">7 أيام</button>
+              <button class="px-4 py-2 rounded-xl bg-fuchsia-500 text-slate-950 font-semibold">30 يوم</button>
+            </div>
+          </div>
+          <div class="grid gap-4 md:grid-cols-3">
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+              <p class="text-slate-400">إيجابي</p>
+              <p class="text-2xl font-semibold text-emerald-300">64%</p>
+              <p class="text-xs text-slate-500">+8% منذ التحديث السابق</p>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+              <p class="text-slate-400">محايد</p>
+              <p class="text-2xl font-semibold text-amber-300">21%</p>
+              <p class="text-xs text-slate-500">-4% بعد حملة التوعية</p>
+            </div>
+            <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+              <p class="text-slate-400">سلبي</p>
+              <p class="text-2xl font-semibold text-rose-300">15%</p>
+              <p class="text-xs text-slate-500">تم إحالة الحالات إلى فريق الخبراء</p>
+            </div>
+          </div>
+          <div class="mt-6 h-56 rounded-xl border border-slate-800 bg-gradient-to-br from-fuchsia-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط مشاعر</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">مؤشرات الخدمة</h3>
+            <span class="text-xs text-slate-500">تحديث مباشر</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div>
+              <p class="text-slate-400">متوسط زمن الاستجابة</p>
+              <p class="text-xl font-semibold text-fuchsia-200">2:14 دقيقة</p>
+              <p class="text-xs text-emerald-300">-38 ثانية هذا الأسبوع</p>
+            </div>
+            <div>
+              <p class="text-slate-400">معدل الحل من أول اتصال</p>
+              <p class="text-xl font-semibold text-emerald-300">78%</p>
+            </div>
+            <div>
+              <p class="text-slate-400">قنوات الخدمة</p>
+              <div class="mt-2 space-y-2">
+                <div class="flex items-center justify-between">
+                  <span>الدردشة</span>
+                  <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-200">92%</span>
+                </div>
+                <div class="flex items-center justify-between">
+                  <span>المكالمات</span>
+                  <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-200">71%</span>
+                </div>
+                <div class="flex items-center justify-between">
+                  <span>البريد</span>
+                  <span class="px-3 py-1 rounded-full bg-rose-500/10 text-rose-200">64%</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 xl:grid-cols-3">
+        <div class="xl:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80">
+          <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 class="text-xl font-semibold">قائمة التذاكر ذات الأولوية</h2>
+              <p class="text-sm text-slate-400">ترتيب تفاعلي حسب التأثير</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">كل التذاكر</button>
+              <button class="px-4 py-2 rounded-xl bg-fuchsia-500 text-slate-950 font-semibold">الحرجة</button>
+            </div>
+          </div>
+          <div class="p-6 overflow-x-auto">
+            <table class="w-full min-w-[720px] text-sm">
+              <thead>
+                <tr class="text-slate-400">
+                  <th class="text-right pb-3 font-medium">المعرف</th>
+                  <th class="text-right pb-3 font-medium">العميل</th>
+                  <th class="text-right pb-3 font-medium">القناة</th>
+                  <th class="text-right pb-3 font-medium">المدة</th>
+                  <th class="text-right pb-3 font-medium">الحالة</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-800">
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">#CX-1892</td>
+                  <td>ريم علي</td>
+                  <td>الدردشة الفورية</td>
+                  <td>1 ساعة</td>
+                  <td><span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">بانتظار التصعيد</span></td>
+                </tr>
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">#CX-1887</td>
+                  <td>شركة سما</td>
+                  <td>إيميل</td>
+                  <td>3 ساعات</td>
+                  <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">قيد المتابعة</span></td>
+                </tr>
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">#CX-1881</td>
+                  <td>وليد بخيت</td>
+                  <td>مكالمة</td>
+                  <td>12 دقيقة</td>
+                  <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">تم الحل</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">ملاحظات العملاء اللحظية</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">"الدعم الفني سريع"</p>
+              <p class="text-slate-400 text-xs mt-1">تم حل مشكلتي خلال دقائق. شكرًا للفريق.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">"نحتاج بوابة معرفة"</p>
+              <p class="text-slate-400 text-xs mt-1">اقتراح بإضافة دروس مصورة لحلول شائعة.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">"التطبيق رائع"</p>
+              <p class="text-slate-400 text-xs mt-1">أحببت التحديث الأخير، التصميم مميز.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">المعرفة الذاتية</h2>
+            <p class="text-sm text-slate-400">أداء مقالات قاعدة المعرفة</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">7 أيام</button>
+            <button class="px-4 py-2 rounded-xl bg-fuchsia-500 text-slate-950 font-semibold">شهر</button>
+          </div>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4 text-sm">
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">التثبيت الأولي</p>
+            <p class="text-2xl font-semibold">14K مشاهدة</p>
+            <p class="text-xs text-emerald-300 mt-1">92% رضا</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">تكاملات API</p>
+            <p class="text-2xl font-semibold">9K مشاهدة</p>
+            <p class="text-xs text-emerald-300 mt-1">88% رضا</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">إدارة الحسابات</p>
+            <p class="text-2xl font-semibold">6K مشاهدة</p>
+            <p class="text-xs text-emerald-300 mt-1">84% رضا</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">المشكلات الشائعة</p>
+            <p class="text-2xl font-semibold">5K مشاهدة</p>
+            <p class="text-xs text-emerald-300 mt-1">81% رضا</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const sidebar = document.getElementById('sidebar');
+      const toggle = document.getElementById('sidebarToggle');
+      const close = document.getElementById('sidebarClose');
+      const backdrop = document.getElementById('sidebarBackdrop');
+      const body = document.body;
+
+      if (!sidebar || !toggle || !close || !backdrop) {
+        return;
+      }
+
+      const openSidebar = () => {
+        sidebar.classList.remove('translate-x-full');
+        backdrop.classList.remove('opacity-0', 'pointer-events-none');
+        backdrop.classList.add('opacity-100');
+        body.classList.add('overflow-hidden');
+      };
+
+      const closeSidebar = () => {
+        sidebar.classList.add('translate-x-full');
+        backdrop.classList.add('opacity-0', 'pointer-events-none');
+        backdrop.classList.remove('opacity-100');
+        body.classList.remove('overflow-hidden');
+      };
+
+      toggle.addEventListener('click', openSidebar);
+      close.addEventListener('click', closeSidebar);
+      backdrop.addEventListener('click', closeSidebar);
+
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeSidebar();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-7.html
+++ b/dashboards/dashboard-7.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الموارد البشرية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col">
+    <header class="border-b border-slate-800 bg-gradient-to-r from-lime-500/10 via-slate-950 to-slate-950">
+      <div class="max-w-7xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.4em] text-lime-300">People Vision</p>
+          <h1 class="text-3xl font-bold">لوحة الموارد البشرية الشاملة</h1>
+          <p class="text-slate-300 mt-2">مؤشرات الأداء، الحضور، والتوظيف في واجهة واحدة.</p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">إضافة موظف</button>
+          <button class="px-4 py-2 rounded-xl bg-lime-500 text-sm text-slate-950 font-semibold">تحميل التقرير</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 max-w-7xl mx-auto w-full px-6 py-10 space-y-8">
+      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">عدد الموظفين</p>
+          <p class="mt-3 text-3xl font-semibold">268</p>
+          <p class="mt-2 text-emerald-300 text-sm">+12 تعيين جديد</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">معدل الحضور</p>
+          <div class="mt-3 flex items-center gap-3">
+            <div class="h-14 w-14 rounded-full bg-lime-500/15 flex items-center justify-center">
+              <span class="text-xl font-semibold text-lime-200">96%</span>
+            </div>
+            <p class="text-xs text-slate-500">تحسن بنسبة 4% هذا الشهر</p>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">نسبة الدوران</p>
+          <p class="mt-3 text-3xl font-semibold text-amber-300">7.4%</p>
+          <p class="mt-2 text-xs text-slate-500">أقل من متوسط الصناعة</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">برامج التدريب</p>
+          <p class="mt-3 text-3xl font-semibold">18</p>
+          <p class="mt-2 text-emerald-300 text-sm">معدل إكمال 82%</p>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80">
+        <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-xl font-semibold">مخطط القوى العاملة</h2>
+            <p class="text-sm text-slate-400">توزيع الموظفين حسب الإدارات</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">السنة الحالية</button>
+            <button class="px-4 py-2 rounded-xl bg-lime-500 text-slate-950 font-semibold">السنة الماضية</button>
+          </div>
+        </div>
+        <div class="p-6 grid gap-6 lg:grid-cols-3">
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+            <p class="text-slate-400">الهندسة</p>
+            <p class="text-2xl font-semibold">94 موظف</p>
+            <p class="text-xs text-emerald-300">+6 هذا الربع</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+            <p class="text-slate-400">المنتج</p>
+            <p class="text-2xl font-semibold">42 موظف</p>
+            <p class="text-xs text-emerald-300">+3 هذا الربع</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+            <p class="text-slate-400">المبيعات</p>
+            <p class="text-2xl font-semibold">58 موظف</p>
+            <p class="text-xs text-emerald-300">+1 هذا الربع</p>
+          </div>
+          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm space-y-2">
+            <p class="text-slate-400">الدعم</p>
+            <p class="text-2xl font-semibold">36 موظف</p>
+            <p class="text-xs text-emerald-300">-2 بعد الأتمتة</p>
+          </div>
+          <div class="lg:col-span-3 h-56 rounded-xl border border-slate-800 bg-gradient-to-br from-lime-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط تراكمي</div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 xl:grid-cols-3">
+        <div class="xl:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80">
+          <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 class="text-xl font-semibold">قائمة التوظيف المفتوحة</h2>
+              <p class="text-sm text-slate-400">الحالة الراهنة للوظائف</p>
+            </div>
+            <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تصدير</button>
+          </div>
+          <div class="p-6 overflow-x-auto">
+            <table class="w-full min-w-[720px] text-sm">
+              <thead>
+                <tr class="text-slate-400">
+                  <th class="text-right pb-3 font-medium">المسمى الوظيفي</th>
+                  <th class="text-right pb-3 font-medium">الفريق</th>
+                  <th class="text-right pb-3 font-medium">عدد المرشحين</th>
+                  <th class="text-right pb-3 font-medium">المرحلة</th>
+                  <th class="text-right pb-3 font-medium">الأولوية</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-800">
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">قائد فريق الهندسة</td>
+                  <td>الهندسة</td>
+                  <td>12</td>
+                  <td>مقابلات نهائية</td>
+                  <td><span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">عاجلة</span></td>
+                </tr>
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">مصمم تجربة المستخدم</td>
+                  <td>المنتج</td>
+                  <td>18</td>
+                  <td>مراجعة محفظة</td>
+                  <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">متوسطة</span></td>
+                </tr>
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">أخصائي نجاح العملاء</td>
+                  <td>الدعم</td>
+                  <td>9</td>
+                  <td>اختبار عملي</td>
+                  <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">منخفضة</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">نبض الموظفين</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">استبيان الرضا</p>
+              <p class="text-slate-400 text-xs mt-1">معدل استجابة 78% - الموضوع: التوازن الوظيفي</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">مبادرات الرفاهية</p>
+              <p class="text-slate-400 text-xs mt-1">إطلاق برنامج التدريب الذهني الأسبوع المقبل</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">جلسات التطوير</p>
+              <p class="text-slate-400 text-xs mt-1">حجوزات 46 جلسة إرشاد فردي</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">مؤشرات الأداء الرئيسية</h2>
+            <p class="text-sm text-slate-400">تتبع أهداف الموارد البشرية</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">ربع</button>
+            <button class="px-4 py-2 rounded-xl bg-lime-500 text-slate-950 font-semibold">سنة</button>
+          </div>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4 text-sm">
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">زمن التوظيف</p>
+            <p class="text-2xl font-semibold">28 يوم</p>
+            <p class="text-xs text-emerald-300 mt-1">مستهدف 30 يوم</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">التكلفة لكل تعيين</p>
+            <p class="text-2xl font-semibold">$1,840</p>
+            <p class="text-xs text-emerald-300 mt-1">انخفاض 12%</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">المشاركة</p>
+            <p class="text-2xl font-semibold">89%</p>
+            <p class="text-xs text-emerald-300 mt-1">أعلى من الهدف بـ 5%</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">الترقيات الداخلية</p>
+            <p class="text-2xl font-semibold">28</p>
+            <p class="text-xs text-emerald-300 mt-1">45% من إجمالي التعيينات</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/dashboards/dashboard-8.html
+++ b/dashboards/dashboard-8.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة التعليم الإلكتروني</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col">
+    <header class="border-b border-slate-800 bg-gradient-to-r from-blue-500/10 via-slate-950 to-slate-950">
+      <div class="max-w-7xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.4em] text-blue-300">LearnSphere</p>
+          <h1 class="text-3xl font-bold">لوحة التحليلات التعليمية</h1>
+          <p class="text-slate-300 mt-2">متابعة أداء المتعلمين، الدورات، ونسب الإكمال.</p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">إضافة دورة</button>
+          <button class="px-4 py-2 rounded-xl bg-blue-500 text-sm text-slate-950 font-semibold">تحميل التقارير</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 max-w-7xl mx-auto w-full px-6 py-10 space-y-8">
+      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">إجمالي المتعلمين</p>
+          <p class="mt-3 text-3xl font-semibold">18,420</p>
+          <p class="mt-2 text-emerald-300 text-sm">+640 خلال الأسبوع</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">نسبة الإكمال</p>
+          <p class="mt-3 text-3xl font-semibold">72%</p>
+          <p class="mt-2 text-xs text-slate-500">الهدف: 78%</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">الساعات التدريبية</p>
+          <p class="mt-3 text-3xl font-semibold">4,860</p>
+          <p class="mt-2 text-emerald-300 text-sm">+18% مقارنة بالربع السابق</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
+          <p class="text-sm text-slate-400">المهام المرسلة</p>
+          <p class="mt-3 text-3xl font-semibold">2,430</p>
+          <p class="mt-2 text-amber-300 text-sm">94% معدل تقييم</p>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">منحنى مشاركة المتعلمين</h2>
+              <p class="text-sm text-slate-400">نشاط المنصة خلال آخر 30 يوم</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">أسبوع</button>
+              <button class="px-4 py-2 rounded-xl bg-blue-500 text-slate-950 font-semibold">شهر</button>
+            </div>
+          </div>
+          <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-blue-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط نشاط</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">الدورات الأعلى تقييمًا</h3>
+            <span class="text-xs text-slate-500">تحديث 1 ساعة</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">أساسيات علوم البيانات</p>
+              <p class="text-amber-300 text-xs mt-1">تقييم 4.9 / 5</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">تصميم واجهات حديثة</p>
+              <p class="text-amber-300 text-xs mt-1">تقييم 4.8 / 5</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">إدارة المنتجات الرقمية</p>
+              <p class="text-amber-300 text-xs mt-1">تقييم 4.7 / 5</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">قائمة المتعلمين النشطين</h2>
+            <p class="text-sm text-slate-400">أعلى معدل تقدم خلال هذا الأسبوع</p>
+          </div>
+          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تحميل CSV</button>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[720px] text-sm">
+            <thead>
+              <tr class="text-slate-400">
+                <th class="text-right pb-3 font-medium">المتعلم</th>
+                <th class="text-right pb-3 font-medium">الدورة</th>
+                <th class="text-right pb-3 font-medium">نسبة التقدم</th>
+                <th class="text-right pb-3 font-medium">آخر نشاط</th>
+                <th class="text-right pb-3 font-medium">الحالة</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800">
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-blue-500/20 text-blue-200 flex items-center justify-center text-xs">SA</span>
+                  <span>سارة الأنصاري</span>
+                </td>
+                <td>برمجة Python المتقدمة</td>
+                <td class="text-emerald-300">94%</td>
+                <td>قبل 2 ساعة</td>
+                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">مكتمل تقريبًا</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-blue-500/20 text-blue-200 flex items-center justify-center text-xs">HM</span>
+                  <span>حسين مطر</span>
+                </td>
+                <td>التسويق الرقمي الاحترافي</td>
+                <td class="text-emerald-300">88%</td>
+                <td>قبل 5 ساعات</td>
+                <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">في التقدم</span></td>
+              </tr>
+              <tr class="hover:bg-slate-800/40">
+                <td class="py-4 flex items-center gap-3">
+                  <span class="h-10 w-10 rounded-xl bg-blue-500/20 text-blue-200 flex items-center justify-center text-xs">NR</span>
+                  <span>نور الراشد</span>
+                </td>
+                <td>تحليل البيانات باستخدام SQL</td>
+                <td class="text-emerald-300">81%</td>
+                <td>قبل يوم</td>
+                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">في المسار</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">قنوات التعلم</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>مسارات التعلم</p>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-200">52%</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>فصول مباشرة</p>
+              <span class="px-3 py-1 rounded-full bg-blue-500/10 text-blue-200">33%</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>تدريب ذاتي</p>
+              <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-200">15%</span>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">معدلات النجاح حسب المستوى</h3>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <p>مبتدئ</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[78%] bg-emerald-400"></div>
+                </div>
+                <span class="text-emerald-300">78%</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>متوسط</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[68%] bg-blue-400"></div>
+                </div>
+                <span class="text-emerald-300">68%</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <p>متقدم</p>
+              <div class="flex items-center gap-3">
+                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
+                  <div class="h-full w-[58%] bg-rose-400"></div>
+                </div>
+                <span class="text-emerald-300">58%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">خطط المحتوى المقبلة</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">برنامج تحليل البيانات المتقدم</p>
+              <p class="text-slate-400 text-xs mt-1">الإطلاق: يونيو</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">معسكر الأمن السيبراني للمبتدئين</p>
+              <p class="text-slate-400 text-xs mt-1">الإطلاق: يوليو</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="font-semibold">سلسلة إدارة المنتجات</p>
+              <p class="text-slate-400 text-xs mt-1">الإطلاق: أغسطس</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/dashboards/dashboard-9.html
+++ b/dashboards/dashboard-9.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة أمن المعلومات</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen">
+    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
+      <div>
+        <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Cyber Shield</p>
+        <h1 class="text-lg font-semibold">لوحة أمن المعلومات</h1>
+      </div>
+      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-slate-700 px-4 py-2 text-sm font-semibold text-white">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <span>فتح القائمة</span>
+      </button>
+    </div>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <div class="lg:flex lg:flex-row">
+      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-gradient-to-b from-slate-700/40 via-slate-950 to-slate-950 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:static lg:w-80 lg:translate-x-0 lg:bg-gradient-to-b lg:from-slate-700/30 lg:via-slate-950 lg:to-slate-950">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Cyber Shield</p>
+            <h1 class="text-3xl font-bold">لوحة أمن المعلومات</h1>
+            <p class="text-sm text-slate-400 mt-2">مراقبة التهديدات، الامتثال، والاستجابة.</p>
+          </div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
+            <span>إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5 text-sm space-y-3">
+          <div class="flex items-center justify-between">
+            <p class="text-slate-400">مستوى الخطر</p>
+            <span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">متوسط</span>
+          </div>
+          <div class="flex items-center justify-between">
+            <p class="text-slate-400">أحداث اليوم</p>
+            <span class="text-lg font-semibold">42</span>
+          </div>
+          <p class="text-xs text-slate-500">تم إغلاق 36 حدث وتم تصعيد 6.</p>
+        </div>
+        <div class="space-y-2 text-sm">
+          <p class="text-xs uppercase text-slate-500">الفلاتر</p>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/60 text-right">جميع الأنظمة</button>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">النقاط الطرفية</button>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">الخوادم</button>
+          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">الشبكات</button>
+        </div>
+      </aside>
+
+      <main class="flex-1 p-6 lg:p-10 space-y-8 lg:pr-10">
+      <section class="grid gap-6 lg:grid-cols-3">
+        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold">زمن الاستجابة للحوادث</h2>
+              <p class="text-sm text-slate-400">متوسط الزمن لكل مستوى خطورة</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">آخر 24 ساعة</button>
+              <button class="px-4 py-2 rounded-xl bg-slate-600 text-white font-semibold">آخر 7 أيام</button>
+            </div>
+          </div>
+          <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-slate-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط الأعمدة</div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold">مؤشر الامتثال</h3>
+            <span class="text-xs text-slate-500">محدث الآن</span>
+          </div>
+          <div class="space-y-4 text-sm">
+            <div class="flex items-center justify-between">
+              <span>ISO 27001</span>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">متوافق</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>NIST</span>
+              <span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">قيد التحسين</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>CIS</span>
+              <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">متوافق</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-6 xl:grid-cols-3">
+        <div class="xl:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80">
+          <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 class="text-xl font-semibold">الحوادث ذات الأولوية</h2>
+              <p class="text-sm text-slate-400">مراقبة القضايا الحرجة في الوقت الفعلي</p>
+            </div>
+            <div class="flex gap-3 text-sm">
+              <button class="px-4 py-2 rounded-xl bg-slate-800">اليوم</button>
+              <button class="px-4 py-2 rounded-xl bg-slate-600 text-white font-semibold">الأسبوع</button>
+            </div>
+          </div>
+          <div class="p-6 overflow-x-auto">
+            <table class="w-full min-w-[720px] text-sm">
+              <thead>
+                <tr class="text-slate-400">
+                  <th class="text-right pb-3 font-medium">المعرف</th>
+                  <th class="text-right pb-3 font-medium">المصدر</th>
+                  <th class="text-right pb-3 font-medium">النوع</th>
+                  <th class="text-right pb-3 font-medium">زمن الكشف</th>
+                  <th class="text-right pb-3 font-medium">الحالة</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-800">
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">INC-4821</td>
+                  <td>خادم المصادقة</td>
+                  <td>محاولات اختراق</td>
+                  <td>قبل 12 دقيقة</td>
+                  <td><span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">تصعيد</span></td>
+                </tr>
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">INC-4818</td>
+                  <td>جدار الحماية</td>
+                  <td>تضخيم DDoS</td>
+                  <td>قبل 28 دقيقة</td>
+                  <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">قيد المعالجة</span></td>
+                </tr>
+                <tr class="hover:bg-slate-800/40">
+                  <td class="py-4">INC-4812</td>
+                  <td>أجهزة الموظفين</td>
+                  <td>برمجيات خبيثة</td>
+                  <td>قبل 1 ساعة</td>
+                  <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">تم الاحتواء</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
+          <h3 class="text-lg font-semibold">سجل التنبيهات الفورية</h3>
+          <div class="space-y-4 text-sm">
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-xs text-rose-300">قبل 5 دقائق</p>
+              <p class="font-semibold mt-1">تم اكتشاف نشاط غير معتاد في بوابة VPN</p>
+              <p class="text-xs text-slate-400 mt-1">تم فرض مصادقة متعددة العوامل لجميع المستخدمين.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-xs text-amber-300">قبل 22 دقيقة</p>
+              <p class="font-semibold mt-1">زيادة حركة المرور على المنفذ 443</p>
+              <p class="text-xs text-slate-400 mt-1">جارٍ تفعيل طبقة حماية إضافية.</p>
+            </div>
+            <div class="p-4 rounded-xl bg-slate-800/60">
+              <p class="text-xs text-slate-300">قبل ساعة</p>
+              <p class="font-semibold mt-1">تحديث قاعدة التواقيع</p>
+              <p class="text-xs text-slate-400 mt-1">تم تحديث نظام كشف التسلل إلى الإصدار 4.6.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 class="text-xl font-semibold">مصفوفة التهديدات</h2>
+            <p class="text-sm text-slate-400">تحليل احتمالية وتأثير السيناريوهات</p>
+          </div>
+          <div class="flex gap-3 text-sm">
+            <button class="px-4 py-2 rounded-xl bg-slate-800">آخر شهر</button>
+            <button class="px-4 py-2 rounded-xl bg-slate-600 text-white font-semibold">آخر ربع</button>
+          </div>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4 text-sm">
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">التصيّد الاحتيالي</p>
+            <p class="text-2xl font-semibold text-amber-300">احتمالية: عالية</p>
+            <p class="text-xs text-slate-500 mt-1">تأثير متوسط</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">تسرب البيانات</p>
+            <p class="text-2xl font-semibold text-rose-300">احتمالية: متوسطة</p>
+            <p class="text-xs text-slate-500 mt-1">تأثير عالٍ</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">البرمجيات الخبيثة</p>
+            <p class="text-2xl font-semibold text-amber-300">احتمالية: عالية</p>
+            <p class="text-xs text-slate-500 mt-1">تأثير متوسط</p>
+          </div>
+          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
+            <p class="text-slate-400">الهجمات الداخلية</p>
+            <p class="text-2xl font-semibold text-slate-200">احتمالية: منخفضة</p>
+            <p class="text-xs text-slate-500 mt-1">تأثير عالٍ</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const sidebar = document.getElementById('sidebar');
+      const toggle = document.getElementById('sidebarToggle');
+      const close = document.getElementById('sidebarClose');
+      const backdrop = document.getElementById('sidebarBackdrop');
+      const body = document.body;
+
+      if (!sidebar || !toggle || !close || !backdrop) {
+        return;
+      }
+
+      const openSidebar = () => {
+        sidebar.classList.remove('translate-x-full');
+        backdrop.classList.remove('opacity-0', 'pointer-events-none');
+        backdrop.classList.add('opacity-100');
+        body.classList.add('overflow-hidden');
+      };
+
+      const closeSidebar = () => {
+        sidebar.classList.add('translate-x-full');
+        backdrop.classList.add('opacity-0', 'pointer-events-none');
+        backdrop.classList.remove('opacity-100');
+        body.classList.remove('overflow-hidden');
+      };
+
+      toggle.addEventListener('click', openSidebar);
+      close.addEventListener('click', closeSidebar);
+      backdrop.addEventListener('click', closeSidebar);
+
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeSidebar();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mobile toggle headers and overlays to the sidebar dashboards so navigation can open and close on small screens
- introduce a shared JavaScript helper on each page to handle sidebar toggling, backdrop clicks, and escape key support
- tune responsive styles on the affected dashboards to keep layouts readable across viewports

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68d7c08a2d84832fb7f6a80c44a69238