### PR TITLE
feat: finalize dashboards with collapsible sidebar

### DIFF
--- a/dashboard-gallery.html
+++ b/dashboard-gallery.html
@@ -118,16 +118,542 @@
         ]
       };
 
-      // ... (dashboard cards config + rendering functions remain same from your new code)
+      const copyTargets = {
+        'hero-tag': translations.heroTag,
+        'hero-title': translations.heroTitle,
+        'hero-description': translations.heroDescription,
+        'section-title': translations.sectionTitle,
+        'footer-text': translations.footerText,
+        'footer-privacy': translations.footerPrivacy,
+        'footer-terms': translations.footerTerms
+      };
+
+      const dashboards = [
+        {
+          id: 1,
+          slug: 'dashboard-1',
+          accent: 'from-indigo-500/30 via-purple-500/20 to-slate-900/60',
+          badge: { ar: 'النمو', en: 'Growth' },
+          category: { ar: 'منتجات SaaS', en: 'SaaS products' },
+          title: { ar: 'لوحة تحليلات النمو', en: 'Growth analytics dashboard' },
+          description: {
+            ar: 'مراقبة مؤشرات النمو والاكتساب والاحتفاظ لمنتج SaaS ناشئ.',
+            en: 'Track growth, acquisition, and retention signals for a scaling SaaS product.'
+          },
+          features: [
+            { ar: 'مخططات نمو أسبوعية', en: 'Weekly growth curves' },
+            { ar: 'تحليلات قنوات الاكتساب', en: 'Acquisition channel analytics' },
+            { ar: 'جدول أحداث الانطلاق', en: 'Launch milestone timeline' }
+          ],
+          metrics: {
+            label: { ar: 'محتويات جاهزة', en: 'Production-ready sections' },
+            value: { ar: '5 وحدات', en: '5 sections' }
+          }
+        },
+        {
+          id: 2,
+          slug: 'dashboard-2',
+          accent: 'from-cyan-500/30 via-sky-500/20 to-slate-900/60',
+          badge: { ar: 'المشاريع', en: 'Projects' },
+          category: { ar: 'إدارة المحافظ', en: 'Portfolio management' },
+          title: { ar: 'لوحة إدارة المشاريع', en: 'Project portfolio dashboard' },
+          description: {
+            ar: 'تنسيق خارطة الطريق، المخاطر، وسعة الفرق عبر مبادرات متعددة.',
+            en: 'Coordinate roadmaps, risks, and team capacity across strategic initiatives.'
+          },
+          features: [
+            { ar: 'منحنى السرعة التراكمية', en: 'Cumulative velocity chart' },
+            { ar: 'لوحة متابعة المخاطر', en: 'Risk tracking board' },
+            { ar: 'قوائم المشاريع ذات الأولوية', en: 'Prioritised project lists' }
+          ],
+          metrics: {
+            label: { ar: 'قوالب جاهزة', en: 'Reusable layouts' },
+            value: { ar: '6 لوحات', en: '6 layouts' }
+          }
+        },
+        {
+          id: 3,
+          slug: 'dashboard-3',
+          accent: 'from-amber-500/35 via-orange-500/20 to-slate-900/60',
+          badge: { ar: 'تجارة', en: 'Commerce' },
+          category: { ar: 'متاجر رقمية', en: 'Digital retail' },
+          title: { ar: 'لوحة تجارة إلكترونية', en: 'E-commerce intelligence dashboard' },
+          description: {
+            ar: 'لوحة مبيعات متكاملة تجمع الإيرادات، القنوات، وتجربة العملاء.',
+            en: 'A commerce control centre blending revenue, channels, and customer experience.'
+          },
+          features: [
+            { ar: 'إيرادات يومية مباشرة', en: 'Live daily revenue' },
+            { ar: 'ترتيب القنوات الأعلى أداءً', en: 'Top-performing channel ranking' },
+            { ar: 'متابعة حالة الشحنات', en: 'Fulfilment status tracking' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر الواجهة', en: 'Interface components' },
+            value: { ar: '6 عناصر', en: '6 components' }
+          }
+        },
+        {
+          id: 4,
+          slug: 'dashboard-4',
+          accent: 'from-sky-500/30 via-cyan-500/20 to-slate-900/70',
+          badge: { ar: 'البنية السحابية', en: 'Cloud ops' },
+          category: { ar: 'مركز العمليات', en: 'Operations centre' },
+          title: { ar: 'لوحة مراقبة البنية السحابية', en: 'Cloud infrastructure monitor' },
+          description: {
+            ar: 'رصد موحد لحمل الموارد، التنبيهات الحية، وتوافر المناطق.',
+            en: 'Unified monitoring for resource load, live alerts, and regional availability.'
+          },
+          features: [
+            { ar: 'تنبيهات الخدمات الحرجة', en: 'Critical service alerts' },
+            { ar: 'مخططات الأداء الزمني', en: 'Time-series performance panels' },
+            { ar: 'بطاقات توافر المناطق', en: 'Regional availability cards' }
+          ],
+          metrics: {
+            label: { ar: 'شرائح جاهزة', en: 'Drop-in widgets' },
+            value: { ar: '4 أقسام', en: '4 sections' }
+          }
+        },
+        {
+          id: 5,
+          slug: 'dashboard-5',
+          accent: 'from-sky-400/25 via-emerald-400/20 to-slate-900/70',
+          badge: { ar: 'الاستمرارية', en: 'Resilience' },
+          category: { ar: 'الاستجابة للحوادث', en: 'Incident response' },
+          title: { ar: 'لوحة مراقبة البنية السحابية', en: 'Cloud reliability war-room' },
+          description: {
+            ar: 'إدارة الأعطال والسعة مع جداول الحوادث وخطط التوسع.',
+            en: 'Manage outages and capacity with incident logs and scaling readiness.'
+          },
+          features: [
+            { ar: 'قائمة الحوادث المباشرة', en: 'Live incident roster' },
+            { ar: 'مؤشرات حالة الموارد', en: 'Resource health badges' },
+            { ar: 'خيارات توسيع فورية', en: 'On-demand scaling actions' }
+          ],
+          metrics: {
+            label: { ar: 'حزم مدمجة', en: 'Embedded blocks' },
+            value: { ar: '3 لوحات', en: '3 blocks' }
+          }
+        },
+        {
+          id: 6,
+          slug: 'dashboard-6',
+          accent: 'from-fuchsia-500/30 via-pink-500/20 to-slate-900/70',
+          badge: { ar: 'العملاء', en: 'CX' },
+          category: { ar: 'نجاح العملاء', en: 'Customer success' },
+          title: { ar: 'لوحة تجربة العملاء', en: 'Customer experience cockpit' },
+          description: {
+            ar: 'قياس المشاعر، مؤشرات SLA، وتجربة الدعم في الوقت الفعلي.',
+            en: 'Measure sentiment, SLA performance, and support workload in real time.'
+          },
+          features: [
+            { ar: 'تحليل المشاعر الآلي', en: 'Automated sentiment analysis' },
+            { ar: 'مؤشرات زمن الاستجابة', en: 'Response-time indicators' },
+            { ar: 'لوحات التذاكر المفتوحة', en: 'Open ticket panels' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع محسّنة', en: 'Optimised modules' },
+            value: { ar: '6 عناصر', en: '6 modules' }
+          }
+        },
+        {
+          id: 7,
+          slug: 'dashboard-7',
+          accent: 'from-lime-500/25 via-emerald-500/20 to-slate-900/70',
+          badge: { ar: 'الموظفون', en: 'People' },
+          category: { ar: 'إدارة المواهب', en: 'Talent management' },
+          title: { ar: 'لوحة الموارد البشرية', en: 'People operations dashboard' },
+          description: {
+            ar: 'تحليلات القوى العاملة، التوظيف، وبرامج التطوير في لوحة واحدة.',
+            en: 'Workforce analytics, hiring pipelines, and development programs in one view.'
+          },
+          features: [
+            { ar: 'مؤشرات القوى العاملة', en: 'Workforce KPIs' },
+            { ar: 'جداول الوظائف المفتوحة', en: 'Open role matrices' },
+            { ar: 'لوحة نبض الموظفين', en: 'Employee pulse board' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر تحليلات', en: 'Analytic cards' },
+            value: { ar: '7 بطاقات', en: '7 cards' }
+          }
+        },
+        {
+          id: 8,
+          slug: 'dashboard-8',
+          accent: 'from-blue-500/30 via-sky-400/20 to-slate-900/70',
+          badge: { ar: 'التعليم', en: 'Learning' },
+          category: { ar: 'منصات تعليمية', en: 'Learning platforms' },
+          title: { ar: 'لوحة إدارة التعليم الإلكتروني', en: 'E-learning analytics dashboard' },
+          description: {
+            ar: 'متابعة المتعلمين، نسب الإكمال، وتفاعل المحتوى للمنصات التعليمية.',
+            en: 'Monitor learners, completion rates, and content engagement for academies.'
+          },
+          features: [
+            { ar: 'مخطط نشاط المتعلمين', en: 'Learner activity curve' },
+            { ar: 'قائمة الدورات المتميزة', en: 'Top-rated courses list' },
+            { ar: 'جدول تقدم المتعلمين', en: 'Learner progress table' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع تعليمية', en: 'Learning widgets' },
+            value: { ar: '6 وحدات', en: '6 widgets' }
+          }
+        },
+        {
+          id: 9,
+          slug: 'dashboard-9',
+          accent: 'from-slate-600/40 via-emerald-500/10 to-slate-900/80',
+          badge: { ar: 'الأمن', en: 'Security' },
+          category: { ar: 'مركز الدفاع', en: 'Security centre' },
+          title: { ar: 'لوحة أمن المعلومات', en: 'Cyber security dashboard' },
+          description: {
+            ar: 'مراقبة التهديدات، الامتثال، ووقت الاستجابة للهجمات الرقمية.',
+            en: 'Monitor threats, compliance posture, and cyber incident response times.'
+          },
+          features: [
+            { ar: 'مستويات الخطر المباشرة', en: 'Live threat levels' },
+            { ar: 'توزيع الحوادث حسب النظام', en: 'Incidents by surface' },
+            { ar: 'مخطط الاستجابة للحوادث', en: 'Incident response chart' }
+          ],
+          metrics: {
+            label: { ar: 'لوحات أمنية', en: 'Security panels' },
+            value: { ar: '5 عروض', en: '5 panels' }
+          }
+        },
+        {
+          id: 10,
+          slug: 'dashboard-10',
+          accent: 'from-violet-500/30 via-indigo-500/20 to-slate-900/70',
+          badge: { ar: 'المالية', en: 'Finance' },
+          category: { ar: 'الخدمات المالية', en: 'Financial services' },
+          title: { ar: 'لوحة الخدمات المالية', en: 'Financial services performance' },
+          description: {
+            ar: 'عرض المحافظ، المخاطر، والأحداث التنظيمية لفرق الاستثمار.',
+            en: 'Visualise portfolios, risk posture, and regulatory events for investment teams.'
+          },
+          features: [
+            { ar: 'مخطط أداء المحافظ', en: 'Portfolio performance graph' },
+            { ar: 'لوحة المخاطر والامتثال', en: 'Risk & compliance board' },
+            { ar: 'خط زمني للأحداث المالية', en: 'Financial events timeline' }
+          ],
+          metrics: {
+            label: { ar: 'مكونات جاهزة', en: 'Ready components' },
+            value: { ar: '6 أقسام', en: '6 sections' }
+          }
+        },
+        {
+          id: 11,
+          slug: 'dashboard-11',
+          accent: 'from-emerald-500/30 via-teal-500/20 to-slate-900/70',
+          badge: { ar: 'الصحة', en: 'Health' },
+          category: { ar: 'العمليات السريرية', en: 'Clinical ops' },
+          title: { ar: 'لوحة عمليات الرعاية الصحية', en: 'Healthcare operations dashboard' },
+          description: {
+            ar: 'تنسيق تدفق المرضى، تنبيهات سريرية، واستعداد الخدمات للمستشفيات.',
+            en: 'Coordinate patient flow, clinical alerts, and service readiness for hospitals.'
+          },
+          features: [
+            { ar: 'مخطط تدفق المرضى', en: 'Patient flow chart' },
+            { ar: 'تنبيهات طبية حرجة', en: 'Critical clinical alerts' },
+            { ar: 'قوائم جاهزية الأقسام', en: 'Service readiness lists' }
+          ],
+          metrics: {
+            label: { ar: 'مقاييس متخصصة', en: 'Specialised metrics' },
+            value: { ar: '5 عناصر', en: '5 items' }
+          }
+        },
+        {
+          id: 12,
+          slug: 'dashboard-12',
+          accent: 'from-rose-500/30 via-fuchsia-500/20 to-slate-900/70',
+          badge: { ar: 'التسويق', en: 'Marketing' },
+          category: { ar: 'قنوات متعددة', en: 'Omnichannel' },
+          title: { ar: 'لوحة حملات التسويق', en: 'Marketing campaigns dashboard' },
+          description: {
+            ar: 'مراقبة الإنفاق، الأداء متعدد القنوات، وأتمتة الحملات.',
+            en: 'Monitor spend, multi-channel performance, and campaign automation.'
+          },
+          features: [
+            { ar: 'مخطط الأداء متعدد القنوات', en: 'Omnichannel performance chart' },
+            { ar: 'قائمة الحملات البارزة', en: 'Highlighted campaign list' },
+            { ar: 'جدول رحلات الأتمتة', en: 'Automation journey table' }
+          ],
+          metrics: {
+            label: { ar: 'شرائح حملات', en: 'Campaign blocks' },
+            value: { ar: '6 مقاطع', en: '6 blocks' }
+          }
+        },
+        {
+          id: 13,
+          slug: 'dashboard-13',
+          accent: 'from-amber-500/25 via-emerald-500/20 to-slate-900/70',
+          badge: { ar: 'اللوجستيات', en: 'Logistics' },
+          category: { ar: 'سلسلة الإمداد', en: 'Supply chain' },
+          title: { ar: 'لوحة سلسلة الإمداد', en: 'Supply chain command' },
+          description: {
+            ar: 'رؤية الشحنات، مخزون المستودعات، وتنبيهات الموردين عالميًا.',
+            en: 'Global view of shipments, warehouse inventory, and supplier alerts.'
+          },
+          features: [
+            { ar: 'خريطة التقدم اليومي', en: 'Daily shipment tracker' },
+            { ar: 'بطاقات مستويات المخزون', en: 'Inventory health cards' },
+            { ar: 'خط زمني للأحداث اللوجستية', en: 'Logistics updates timeline' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر لوجستية', en: 'Logistics widgets' },
+            value: { ar: '6 عناصر', en: '6 widgets' }
+          }
+        },
+        {
+          id: 14,
+          slug: 'dashboard-14',
+          accent: 'from-emerald-500/25 via-lime-500/20 to-slate-900/70',
+          badge: { ar: 'العقارات', en: 'Property' },
+          category: { ar: 'استثمار عقاري', en: 'Real estate investing' },
+          title: { ar: 'لوحة إدارة العقارات', en: 'Real estate portfolio dashboard' },
+          description: {
+            ar: 'مراقبة الإشغال، الإيرادات، وأعمال الصيانة عبر المحافظ.',
+            en: 'Monitor occupancy, cashflow, and maintenance across property portfolios.'
+          },
+          features: [
+            { ar: 'مخطط العوائد الشهرية', en: 'Monthly returns chart' },
+            { ar: 'قائمة العقارات البارزة', en: 'Property spotlight list' },
+            { ar: 'لوحة الصيانة والعمليات', en: 'Operations and upkeep board' }
+          ],
+          metrics: {
+            label: { ar: 'قوالب استثمار', en: 'Investment tiles' },
+            value: { ar: '6 بطاقات', en: '6 tiles' }
+          }
+        },
+        {
+          id: 15,
+          slug: 'dashboard-15',
+          accent: 'from-orange-500/30 via-rose-500/20 to-slate-900/70',
+          badge: { ar: 'التصنيع', en: 'Manufacturing' },
+          category: { ar: 'عمليات المصانع', en: 'Factory operations' },
+          title: { ar: 'لوحة العمليات التصنيعية', en: 'Manufacturing operations dashboard' },
+          description: {
+            ar: 'تحليل الأداء، الجودة، والصيانة على خطوط الإنتاج.',
+            en: 'Analyse performance, quality, and maintenance across production lines.'
+          },
+          features: [
+            { ar: 'مخطط الإنتاج الفعلي', en: 'Actual vs plan production chart' },
+            { ar: 'تنبيهات أعطال حرجة', en: 'Critical downtime alerts' },
+            { ar: 'تقدم مبادرات التحسين', en: 'Improvement program tracker' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع تشغيلية', en: 'Operational blocks' },
+            value: { ar: '6 وحدات', en: '6 units' }
+          }
+        },
+        {
+          id: 16,
+          slug: 'dashboard-16',
+          accent: 'from-purple-500/30 via-indigo-500/20 to-slate-900/70',
+          badge: { ar: 'البث', en: 'Streaming' },
+          category: { ar: 'منصات المحتوى', en: 'Content platforms' },
+          title: { ar: 'لوحة منصة البث', en: 'Streaming service dashboard' },
+          description: {
+            ar: 'قياس المشتركين، أداء المحتوى، وصحة الشبكة لخدمة البث.',
+            en: 'Measure subscribers, content performance, and network health for OTT.'
+          },
+          features: [
+            { ar: 'نمو المشتركين', en: 'Subscriber growth cards' },
+            { ar: 'لوحة أداء العناوين', en: 'Title performance board' },
+            { ar: 'جودة التجربة التقنية', en: 'Experience quality metrics' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع وسائط', en: 'Media widgets' },
+            value: { ar: '6 عناصر', en: '6 widgets' }
+          }
+        },
+        {
+          id: 17,
+          slug: 'dashboard-17',
+          accent: 'from-emerald-500/25 via-cyan-500/20 to-slate-900/70',
+          badge: { ar: 'المدن الذكية', en: 'Smart city' },
+          category: { ar: 'البنية الحضرية', en: 'Urban infrastructure' },
+          title: { ar: 'لوحة المدينة الذكية', en: 'Smart city operations' },
+          description: {
+            ar: 'إدارة التنقل، الطاقة، والاستدامة داخل المدينة الرقمية.',
+            en: 'Manage mobility, energy, and sustainability across a digital city.'
+          },
+          features: [
+            { ar: 'مؤشرات التنقل اليومي', en: 'Daily mobility indicators' },
+            { ar: 'بطاقات الاستدامة', en: 'Sustainability scorecards' },
+            { ar: 'خط زمني لمشاريع المدينة', en: 'City initiatives timeline' }
+          ],
+          metrics: {
+            label: { ar: 'محاور حضرية', en: 'Urban modules' },
+            value: { ar: '6 محاور', en: '6 modules' }
+          }
+        },
+        {
+          id: 18,
+          slug: 'dashboard-18',
+          accent: 'from-amber-500/25 via-rose-500/20 to-slate-900/70',
+          badge: { ar: 'الضيافة', en: 'Hospitality' },
+          category: { ar: 'إدارة الفنادق', en: 'Hotel management' },
+          title: { ar: 'لوحة تجربة الضيافة', en: 'Hospitality experience dashboard' },
+          description: {
+            ar: 'مؤشرات الإشغال، رضا الضيوف، وجدولة الخدمات عبر ممتلكات الضيافة.',
+            en: 'Occupancy, guest sentiment, and service schedules across hospitality assets.'
+          },
+          features: [
+            { ar: 'مخطط الأداء اليومي', en: 'Daily performance chart' },
+            { ar: 'قائمة الفنادق الأعلى', en: 'Top property spotlight' },
+            { ar: 'جدول مبادرات التجربة', en: 'Guest experience roadmap' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع ضيافة', en: 'Hospitality blocks' },
+            value: { ar: '6 شرائح', en: '6 blocks' }
+          }
+        },
+        {
+          id: 19,
+          slug: 'dashboard-19',
+          accent: 'from-emerald-500/30 via-lime-500/20 to-slate-900/70',
+          badge: { ar: 'الطاقة', en: 'Energy' },
+          category: { ar: 'الطاقة المتجددة', en: 'Renewables' },
+          title: { ar: 'لوحة الطاقة المتجددة', en: 'Renewable energy operations' },
+          description: {
+            ar: 'تشغيل محطات الطاقة النظيفة، موازنة الشبكة، ومشاريع الاستدامة.',
+            en: 'Operate clean generation sites, balance the grid, and track sustainability.'
+          },
+          features: [
+            { ar: 'مؤشرات توليد الطاقة', en: 'Generation KPI tiles' },
+            { ar: 'مراقبة توازن الشبكة', en: 'Grid balance monitoring' },
+            { ar: 'لوحة المبادرات الخضراء', en: 'Green initiatives board' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر الطاقة', en: 'Energy widgets' },
+            value: { ar: '6 عناصر', en: '6 widgets' }
+          }
+        },
+        {
+          id: 20,
+          slug: 'dashboard-20',
+          accent: 'from-orange-500/25 via-rose-500/20 to-slate-900/70',
+          badge: { ar: 'الرياضة', en: 'Sports' },
+          category: { ar: 'أندية محترفة', en: 'Pro clubs' },
+          title: { ar: 'لوحة إدارة الرياضة', en: 'Sports management analytics' },
+          description: {
+            ar: 'نتائج المباريات، جاهزية اللاعبين، وتفاعل الجماهير طوال الموسم.',
+            en: 'Match outcomes, player readiness, and fan engagement across the season.'
+          },
+          features: [
+            { ar: 'تحليلات المباريات', en: 'Match analytics' },
+            { ar: 'لوحة صحة اللاعبين', en: 'Player wellness board' },
+            { ar: 'مؤشرات جماهيرية مباشرة', en: 'Live fan engagement KPIs' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع رياضية', en: 'Sports modules' },
+            value: { ar: '6 شرائح', en: '6 modules' }
+          }
+        }
+      ];
+
+      const languageSwitchers = document.querySelectorAll('[data-role="language-switcher"]');
+      const heroBadgesContainer = document.querySelector('[data-role="hero-badges"]');
+      const cardGrid = document.querySelector('[data-role="card-grid"]');
+      const langButtons = [];
+
+      function renderHeroBadges(lang) {
+        if (!heroBadgesContainer) return;
+        heroBadgesContainer.innerHTML = translations.badges
+          .map(badge => `<span class="${badge.classes}">${badge.text[lang]}</span>`)
+          .join('');
+      }
+
+      function renderCards(lang) {
+        if (!cardGrid) return;
+        cardGrid.innerHTML = '';
+        dashboards.forEach(dashboard => {
+          const article = document.createElement('article');
+          article.className = 'group overflow-hidden rounded-2xl border border-white/5 bg-slate-900/60 backdrop-blur-xl flex flex-col transition hover:border-white/15 hover:bg-slate-900/70';
+          article.innerHTML = `
+            <div class="relative h-32 overflow-hidden">
+              <div class="absolute inset-0 bg-gradient-to-br ${dashboard.accent} opacity-80"></div>
+              <div class="relative h-full w-full flex items-start justify-between p-4 text-xs text-white/80">
+                <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 font-semibold">
+                  ${dashboard.badge[lang]}
+                </span>
+                <span class="font-semibold tracking-[0.3em] text-white/70">${String(dashboard.id).padStart(2, '0')}</span>
+              </div>
+            </div>
+            <div class="flex-1 p-5 space-y-5">
+              <div class="space-y-2">
+                <p class="text-xs uppercase tracking-wide text-slate-400">${dashboard.category[lang]}</p>
+                <h3 class="text-lg font-semibold text-white">${dashboard.title[lang]}</h3>
+                <p class="text-sm text-slate-300">${dashboard.description[lang]}</p>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                ${dashboard.features.map(feature => `<span class="inline-flex items-center rounded-full bg-white/5 px-3 py-1 text-xs text-slate-200">${feature[lang]}</span>`).join('')}
+              </div>
+              <div class="flex items-center justify-between rounded-xl border border-white/5 bg-white/5 px-3 py-2 text-xs text-slate-300">
+                <span>${dashboard.metrics.label[lang]}</span>
+                <span class="font-semibold text-white">${dashboard.metrics.value[lang]}</span>
+              </div>
+              <a href="dashboards/${dashboard.slug}.html" class="inline-flex items-center gap-2 text-sm font-semibold text-indigo-300 transition hover:text-indigo-200">
+                ${translations.linkLabel[lang]}
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4">
+                  <path d="M5.25 4.5a.75.75 0 0 1 .75-.75h12a.75.75 0 0 1 .75.75v12a.75.75 0 0 1-1.5 0V6.31l-9.72 9.72a.75.75 0 0 1-1.06-1.06l9.72-9.72H6a.75.75 0 0 1-.75-.75z" />
+                </svg>
+              </a>
+            </div>
+          `;
+          cardGrid.appendChild(article);
+        });
+      }
+
+      function renderCopy(lang) {
+        Object.entries(copyTargets).forEach(([key, value]) => {
+          document.querySelectorAll(`[data-i18n="${key}"]`).forEach(node => {
+            node.textContent = value[lang];
+          });
+        });
+      }
+
+      function renderLanguageSwitchers(lang) {
+        langButtons.length = 0;
+        languageSwitchers.forEach(container => {
+          container.innerHTML = '';
+          ['ar', 'en'].forEach(code => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.dataset.langButton = code;
+            button.textContent = code === 'ar' ? 'ع' : 'En';
+            button.className = 'px-3 py-1 text-xs font-semibold rounded-lg border border-white/10 text-slate-200 bg-transparent hover:bg-white/10 transition';
+            button.addEventListener('click', () => setLanguage(code));
+            container.appendChild(button);
+            langButtons.push(button);
+          });
+        });
+        updateLanguageButtons(lang);
+      }
+
+      function updateLanguageButtons(lang) {
+        langButtons.forEach(button => {
+          const active = button.dataset.langButton === lang;
+          button.classList.toggle('bg-white/10', active);
+          button.classList.toggle('text-white', active);
+          button.classList.toggle('opacity-60', !active);
+        });
+      }
 
       let currentLang = 'ar';
+
       function setLanguage(lang) {
         currentLang = lang;
         html.setAttribute('lang', lang);
         html.setAttribute('dir', lang === 'ar' ? 'rtl' : 'ltr');
         body.classList.toggle('font-english', lang === 'en');
         document.title = translations.pageTitle[lang];
+        renderCopy(lang);
+        renderHeroBadges(lang);
+        renderCards(lang);
+        updateLanguageButtons(lang);
       }
+
+      renderLanguageSwitchers(currentLang);
       setLanguage(currentLang);
     })();
   </script>

--- a/dashboards/dashboard-1.html
+++ b/dashboards/dashboard-1.html
@@ -46,7 +46,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-10.html
+++ b/dashboards/dashboard-10.html
@@ -46,7 +46,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-11.html
+++ b/dashboards/dashboard-11.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-12.html
+++ b/dashboards/dashboard-12.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-13.html
+++ b/dashboards/dashboard-13.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-14.html
+++ b/dashboards/dashboard-14.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-15.html
+++ b/dashboards/dashboard-15.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-16.html
+++ b/dashboards/dashboard-16.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-17.html
+++ b/dashboards/dashboard-17.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-18.html
+++ b/dashboards/dashboard-18.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-19.html
+++ b/dashboards/dashboard-19.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-2.html
+++ b/dashboards/dashboard-2.html
@@ -46,7 +46,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-20.html
+++ b/dashboards/dashboard-20.html
@@ -43,7 +43,7 @@
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
           <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
           <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
             <span data-role="close-label">إغلاق</span>

--- a/dashboards/dashboard-3.html
+++ b/dashboards/dashboard-3.html
@@ -13,43 +13,56 @@
 </head>
 <body class="bg-slate-950 text-slate-100">
   <div class="min-h-screen flex flex-col lg:flex-row">
-    <!-- Header -->
+    <!-- Mobile Header -->
     <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
       <div class="flex items-center gap-3">
-        <div class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">E</div>
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">E</div>
         <div>
           <p data-role="mobile-brand-name" class="font-semibold"></p>
           <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
         </div>
       </div>
-      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <span>فتح القائمة</span>
-      </button>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
     </header>
 
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
     <!-- Sidebar -->
-    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 transition-transform duration-300 lg:static lg:translate-x-0">
-      <div class="flex items-center justify-between">
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
         <div class="flex items-center gap-3">
-          <div class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">E</div>
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">E</div>
           <div>
             <p data-role="brand-name" class="text-lg font-semibold"></p>
             <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
-          إغلاق
-        </button>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
       </div>
-      <nav data-role="sidebar-nav" class="mt-6 space-y-2"></nav>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
     </aside>
 
     <!-- Main -->
     <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
-      <div data-role="main-header"></div>
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
       <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
       <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
     </main>
@@ -59,11 +72,22 @@
   <script>
     initDashboard({
       defaultLang: 'ar',
-      meta: { title: { ar: 'لوحة تجارة إلكترونية', en: 'E-commerce Intelligence Dashboard' } },
+      meta: {
+        title: {
+          ar: 'لوحة تجارة إلكترونية',
+          en: 'E-commerce Intelligence Dashboard'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
       brand: {
         badge: 'E',
         name: { ar: 'نبض التجارة', en: 'Commerce Pulse' },
-        tagline: { ar: 'تحليلات المبيعات وتجربة العملاء', en: 'Sales and experience analytics' }
+        tagline: { ar: 'تحليلات المبيعات وتجربة العملاء', en: 'Sales & CX analytics cockpit' }
       },
       theme: {
         accentGradient: 'from-amber-500 via-orange-500 to-rose-500',
@@ -73,21 +97,93 @@
         badgeText: 'text-white'
       },
       nav: [
-        { id: 'overview', icon: 'shopping-bag', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'موسمي', en: 'Seasonal' } },
+        { id: 'overview', icon: 'shopping-bag', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'مباشر', en: 'Live' } },
         { id: 'sales', icon: 'chart-bar', label: { ar: 'المبيعات', en: 'Sales' } },
         { id: 'marketing', icon: 'megaphone', label: { ar: 'التسويق', en: 'Marketing' } },
-        { id: 'fulfilment', icon: 'truck', label: { ar: 'التنفيذ والشحن', en: 'Fulfilment & shipping' } }
+        { id: 'fulfilment', icon: 'truck', label: { ar: 'التنفيذ والشحن', en: 'Fulfilment' } }
       ],
       highlight: {
         label: { ar: 'إيرادات اليوم', en: 'Today’s revenue' },
         value: '$482K',
-        description: { ar: 'حملة الصيف رفعت متوسط قيمة السلة 18%.', en: 'Summer campaign lifted order value 18%.' }
+        description: {
+          ar: 'حملة الصيف رفعت متوسط قيمة السلة 18% عبر أهم القنوات.',
+          en: 'Summer incentives lifted average order value by 18% across top channels.'
+        }
+      },
+      header: {
+        title: { ar: 'مركز تحليلات التجارة', en: 'Commerce analytics hub' },
+        subtitle: {
+          ar: 'راقب الإيرادات، سلاسل التوريد، وتجربة العملاء في الوقت الفعلي.',
+          en: 'Monitor revenue, fulfilment, and customer sentiment in real time.'
+        },
+        primary: { ar: 'إطلاق حملة جديدة', en: 'Launch new campaign' },
+        secondary: { ar: 'آخر 7 أيام', en: 'Last 7 days' }
       },
       stats: [
         { icon: 'shopping-bag', label: { ar: 'قيمة المبيعات اليومية', en: 'Daily sales value' }, value: '$482K', delta: { ar: '+14% مقارنة بالأسبوع الماضي', en: '+14% vs previous week' }, trend: 'positive' },
-        { icon: 'cursor-arrow', label: { ar: 'نسبة التحويل', en: 'Conversion rate' }, value: '3.9%', delta: { ar: '+0.6 نقطة عن المتوسط', en: '+0.6 pts above average' }, trend: 'positive' },
+        { icon: 'cursor-arrow', label: { ar: 'نسبة التحويل', en: 'Conversion rate' }, value: '3.9%', delta: { ar: '+0.6 نقطة عن المتوسط', en: '+0.6 pts above avg' }, trend: 'positive' },
         { icon: 'heart', label: { ar: 'متوسط قيمة السلة', en: 'Average order value' }, value: '$126', delta: { ar: '+18% بعد الحملات', en: '+18% after campaigns' }, trend: 'positive' },
-        { icon: 'truck', label: { ar: 'طلبات جاهزة للشحن', en: 'Orders ready to ship' }, value: '1,280', delta: { ar: 'تم تسليم 92% خلال 24 ساعة', en: '92% delivered within 24h' }, trend: 'positive' }
+        { icon: 'truck', label: { ar: 'طلبات جاهزة للشحن', en: 'Orders ready to ship' }, value: '1,280', delta: { ar: '92% خلال 24 ساعة', en: '92% within 24h' }, trend: 'positive' }
+      ],
+      panels: [
+        {
+          id: 'revenue',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى الإيرادات اليومية', en: 'Daily revenue curve' },
+          subtitle: { ar: 'مقارنة القنوات الأساسية بالعام الماضي.', en: 'Comparing primary channels to last year.' },
+          action: { ar: 'تصدير CSV', en: 'Export CSV' },
+          placeholder: { ar: 'مخطط الإيرادات', en: 'Revenue chart' }
+        },
+        {
+          id: 'channels',
+          type: 'list',
+          title: { ar: 'القنوات الأعلى أداءً', en: 'Top performing channels' },
+          action: { ar: 'تحديث منذ 4 دقائق', en: 'Updated 4 minutes ago' },
+          items: [
+            { icon: 'megaphone', title: { ar: 'إعلانات البحث', en: 'Search ads' }, subtitle: { ar: 'تكلفة اكتساب 11.4$', en: 'Acquisition cost $11.4' }, value: '42%', delta: { ar: '+6% نمو', en: '+6% growth' } },
+            { icon: 'tv', title: { ar: 'وسائل التواصل', en: 'Social media' }, subtitle: { ar: 'حملات مؤثرين جديدة', en: 'Fresh influencer pushes' }, value: '31%', delta: { ar: '+9% تفاعل', en: '+9% engagement' } },
+            { icon: 'sparkles', title: { ar: 'البريد التلقائي', en: 'Automated email' }, subtitle: { ar: 'مسارات الترحيب المحسنة', en: 'Optimised welcome journeys' }, value: '18%', delta: { ar: '+3% تحويل', en: '+3% conversion' } }
+          ]
+        },
+        {
+          id: 'funnel',
+          type: 'progress',
+          title: { ar: 'مراحل التحويل', en: 'Conversion stages' },
+          items: [
+            { title: { ar: 'زيارة المنتج', en: 'Product view' }, subtitle: { ar: 'جلسات مخصصة حسب الاهتمامات', en: 'Interest-based merchandising' }, value: '78%', percent: '78%' },
+            { title: { ar: 'إضافة إلى السلة', en: 'Add to cart' }, subtitle: { ar: 'تنبيهات التخفيضات النشطة', en: 'Active discount nudges' }, value: '51%', percent: '51%' },
+            { title: { ar: 'إتمام الدفع', en: 'Checkout completion' }, subtitle: { ar: 'دعم فوري متعدد القنوات', en: 'Multichannel checkout support' }, value: '26%', percent: '26%' }
+          ]
+        },
+        {
+          id: 'orders',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'حالة الشحنات', en: 'Shipment status' },
+          action: { ar: 'عرض جميع الطلبات', en: 'View all orders' },
+          headers: [
+            { ar: 'الطلب', en: 'Order' },
+            { ar: 'الحالة', en: 'Status' },
+            { ar: 'التغيير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: '#5821 - متجر الخليج', en: '#5821 - Gulf Store' }, metric: 'قيد التجهيز', delta: { ar: 'إلى الشحن خلال ساعتين', en: 'Shipping within 2h' }, trend: 'positive' },
+            { name: { ar: '#5710 - باريس', en: '#5710 - Paris' }, metric: 'تم الشحن', delta: { ar: '+1 يوم في العبور', en: '+1 day in transit' }, trend: 'neutral' },
+            { name: { ar: '#5698 - دبي مول', en: '#5698 - Dubai Mall' }, metric: 'بانتظار الدفع', delta: { ar: '-12% تأخير', en: '-12% delay' }, trend: 'negative' }
+          ]
+        },
+        {
+          id: 'campaigns',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'آخر الأنشطة التسويقية', en: 'Latest marketing activities' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'إطلاق حملة العودة للمدارس', en: 'Back-to-school launch' }, subtitle: { ar: 'زيادة 22% في العائد الإعلاني', en: '22% uplift in ROAS' }, time: { ar: 'منذ ساعتين', en: '2 hours ago' } },
+            { icon: 'users', title: { ar: 'بث مباشر مع المؤسس', en: 'Founder live stream' }, subtitle: { ar: 'أكثر من 6 آلاف مشاهدة', en: '6k+ live viewers' }, time: { ar: 'اليوم', en: 'Today' } },
+            { icon: 'chart-bar', title: { ar: 'تقرير تسعير فلاش', en: 'Flash pricing report' }, subtitle: { ar: 'تم تحديث أسعار 38 منتجاً', en: '38 products repriced' }, time: { ar: 'أمس', en: 'Yesterday' } }
+          ]
+        }
       ]
     });
   </script>

--- a/dashboards/dashboard-4.html
+++ b/dashboards/dashboard-4.html
@@ -5,159 +5,190 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>لوحة مراقبة البنية السحابية</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
   </style>
 </head>
-<body class="bg-slate-950 text-slate-100"> 
-  <div class="min-h-screen">
-    <!-- الهيدر للموبايل -->
-    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
-      <div>
-        <p class="text-xs uppercase tracking-[0.4em] text-sky-300">Cloud Sentinel</p>
-        <h1 class="text-lg font-semibold">المراقبة الفورية</h1>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <!-- Mobile Header -->
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">C</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
       </div>
-      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <span>فتح القائمة</span>
-      </button>
-    </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
 
-    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
 
-    <div class="lg:grid lg:grid-cols-[320px_1fr]">
-      <!-- الشريط الجانبي -->
-      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-slate-900/95 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:relative lg:translate-x-0 lg:w-full lg:max-w-[320px] lg:bg-slate-900/80">
-        <div class="flex items-start justify-between gap-3">
+    <!-- Sidebar -->
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">C</div>
           <div>
-            <p class="text-xs uppercase tracking-[0.4em] text-sky-300">Cloud Sentinel</p>
-            <h1 class="text-2xl font-bold">المراقبة الفورية</h1>
-            <p class="text-sm text-slate-400 mt-2">لوحة موحدة للبنية التحتية السحابية.</p>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
-          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
-            <span>إغلاق</span>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
 
-        <!-- محتوى جانبي بسيط -->
-        <div class="space-y-4">
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
-            <p class="text-xs text-slate-500">الحالة العامة</p>
-            <p class="text-lg font-semibold text-emerald-300 mt-2">مستقرة</p>
-            <p class="text-xs text-slate-500 mt-2">لا يوجد أعطال حرجة خلال آخر 24 ساعة.</p>
-          </div>
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 space-y-3 text-sm">
-            <p class="text-slate-400">التنبيهات الحية</p>
-            <div class="flex items-center justify-between">
-              <span>CPU</span>
-              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300">طبيعي</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>Memory</span>
-              <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-300">انتباه</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>Network</span>
-              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300">طبيعي</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>Storage</span>
-              <span class="px-3 py-1 rounded-full bg-rose-500/10 text-rose-300">حرج</span>
-            </div>
-          </div>
-        </div>
-      </aside>
-
-      <!-- المحتوى الرئيسي -->
-      <main class="p-6 lg:p-10 space-y-8 lg:pr-10"> 
-        <section class="grid gap-6 lg:grid-cols-3">
-          <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-              <div>
-                <h2 class="text-xl font-semibold">المراقبة الزمنية للأحمال</h2>
-                <p class="text-sm text-slate-400">CPU / Memory / Network</p>
-              </div>
-              <div class="flex gap-3 text-sm">
-                <button class="px-4 py-2 rounded-xl bg-slate-800">آخر ساعة</button>
-                <button class="px-4 py-2 rounded-xl bg-sky-500 text-slate-950 font-semibold">آخر 24 ساعة</button>
-              </div>
-            </div>
-            <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-sky-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط متعدد المحاور</div>
-          </div>
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-            <div class="flex items-center justify-between">
-              <h3 class="text-lg font-semibold">مؤشر التوفر</h3>
-              <span class="text-xs text-slate-500">آخر تحديث: 12 ثانية</span>
-            </div>
-            <div class="space-y-4 text-sm">
-              <div class="flex items-center gap-4">
-                <span class="w-2 h-12 rounded-full bg-emerald-500"></span>
-                <div class="flex-1">
-                  <p class="font-semibold">المنطقة - أوروبا</p>
-                  <p class="text-xs text-slate-500">99.98% التوفر</p>
-                </div>
-                <span class="text-emerald-300">↑</span>
-              </div>
-              <div class="flex items-center gap-4">
-                <span class="w-2 h-12 rounded-full bg-emerald-400"></span>
-                <div class="flex-1">
-                  <p class="font-semibold">المنطقة - أمريكا</p>
-                  <p class="text-xs text-slate-500">99.94% التوفر</p>
-                </div>
-                <span class="text-emerald-300">↑</span>
-              </div>
-              <div class="flex items-center gap-4">
-                <span class="w-2 h-12 rounded-full bg-amber-400"></span>
-                <div class="flex-1">
-                  <p class="font-semibold">المنطقة - آسيا</p>
-                  <p class="text-xs text-slate-500">99.71% التوفر</p>
-                </div>
-                <span class="text-amber-300">→</span>
-              </div>
-            </div>
-          </div>
-        </section>
-      </main>
-    </div>
+    <!-- Main -->
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
   </div>
- 
+
+  <script src="dashboard-common.js"></script>
   <script>
-    (function () {
-      const sidebar = document.getElementById('sidebar');
-      const toggle = document.getElementById('sidebarToggle');
-      const close = document.getElementById('sidebarClose');
-      const backdrop = document.getElementById('sidebarBackdrop');
-      const body = document.body;
-
-      if (!sidebar || !toggle || !close || !backdrop) return;
-
-      const openSidebar = () => {
-        sidebar.classList.remove('translate-x-full');
-        backdrop.classList.remove('opacity-0', 'pointer-events-none');
-        backdrop.classList.add('opacity-100');
-        body.classList.add('overflow-hidden');
-      };
-
-      const closeSidebar = () => {
-        sidebar.classList.add('translate-x-full');
-        backdrop.classList.add('opacity-0', 'pointer-events-none');
-        backdrop.classList.remove('opacity-100');
-        body.classList.remove('overflow-hidden');
-      };
-
-      toggle.addEventListener('click', openSidebar);
-      close.addEventListener('click', closeSidebar);
-      backdrop.addEventListener('click', closeSidebar);
-      window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') closeSidebar();
-      });
-    })();
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة مراقبة البنية السحابية',
+          en: 'Cloud Infrastructure Monitor'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
+      brand: {
+        badge: 'C',
+        name: { ar: 'Cloud Sentinel', en: 'Cloud Sentinel' },
+        tagline: { ar: 'قيادة عمليات البنية السحابية', en: 'Cloud operations command' }
+      },
+      theme: {
+        accentGradient: 'from-sky-500 via-cyan-500 to-blue-500',
+        accentText: 'text-sky-200',
+        highlightBg: 'bg-sky-500/10 border-sky-400/30',
+        badgeBg: 'bg-sky-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        { id: 'overview', icon: 'chart-bar', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'مباشر', en: 'Live' } },
+        { id: 'services', icon: 'cloud', label: { ar: 'الخدمات', en: 'Services' } },
+        { id: 'incidents', icon: 'shield', label: { ar: 'الحوادث', en: 'Incidents' } },
+        { id: 'regions', icon: 'map', label: { ar: 'المناطق', en: 'Regions' } }
+      ],
+      highlight: {
+        label: { ar: 'الحالة العامة', en: 'Overall status' },
+        value: { ar: 'مستقر', en: 'Stable' },
+        description: {
+          ar: 'حمل منخفض على الخدمات الحرجة واستجابة تلقائية فعالة.',
+          en: 'Low load across critical services with healthy auto-healing.'
+        }
+      },
+      header: {
+        title: { ar: 'مركز مراقبة البنية', en: 'Infrastructure monitoring centre' },
+        subtitle: {
+          ar: 'راقب الحمل، التنبيهات، وتوافر المناطق من لوحة تحكم واحدة.',
+          en: 'Track load, alerts, and regional availability from a single control plane.'
+        },
+        primary: { ar: 'إطلاق خطة تعافي', en: 'Launch recovery plan' },
+        secondary: { ar: 'آخر 24 ساعة', en: 'Last 24 hours' }
+      },
+      stats: [
+        { icon: 'cpu-chip', label: { ar: 'متوسط استخدام المعالج', en: 'Avg CPU utilisation' }, value: '62%', delta: { ar: 'مستقر خلال الساعة', en: 'Stable past hour' }, trend: 'positive' },
+        { icon: 'alert', label: { ar: 'تنبيهات حرجة', en: 'Critical alerts' }, value: '3', delta: { ar: 'تم حل حالتين اليوم', en: '2 resolved today' }, trend: 'positive' },
+        { icon: 'clock', label: { ar: 'زمن الاستجابة', en: 'Edge latency' }, value: '184ms', delta: { ar: '−12% مقارنة بالأمس', en: '−12% vs yesterday' }, trend: 'positive' },
+        { icon: 'sun', label: { ar: 'توافر المنصة', en: 'Platform availability' }, value: '99.96%', delta: { ar: 'هدف الشهر 99.9%', en: 'Monthly target 99.9%' }, trend: 'positive' }
+      ].map(stat => ({
+        ...stat,
+        icon: stat.icon === 'cpu-chip' ? 'cog' : stat.icon === 'alert' ? 'sparkles' : stat.icon === 'clock' ? 'calendar' : stat.icon
+      })),
+      panels: [
+        {
+          id: 'load',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى الحمل الزمني', en: 'Service load timeline' },
+          subtitle: { ar: 'CPU / Memory / I/O لكل طبقة خلال 24 ساعة.', en: 'CPU, memory, and I/O by tier across 24 hours.' },
+          action: { ar: 'تحميل المخطط', en: 'Download chart' },
+          placeholder: { ar: 'مخطط الحمل', en: 'Load chart' }
+        },
+        {
+          id: 'alerts',
+          type: 'list',
+          title: { ar: 'أهم التنبيهات', en: 'Top alerts' },
+          action: { ar: 'آخر تحديث منذ 3 دقائق', en: 'Updated 3 minutes ago' },
+          items: [
+            { icon: 'shield', title: { ar: 'API Gateway', en: 'API gateway' }, subtitle: { ar: 'زيادة زمن الاستجابة', en: 'Latency increase detected' }, value: 'مرتفع', delta: { ar: 'تم التوجيه للفريق الأزرق', en: 'Escalated to blue team' } },
+            { icon: 'database', title: { ar: 'Managed DB', en: 'Managed DB' }, subtitle: { ar: 'استهلاك اتصال 82%', en: 'Connection usage 82%' }, value: 'متوسط', delta: { ar: 'ضبط التجميع الليلي', en: 'Nightly compaction tuned' } },
+            { icon: 'cloud', title: { ar: 'Compute Cluster', en: 'Compute cluster' }, subtitle: { ar: 'عقدة واحدة غير مستقرة', en: 'One node unstable' }, value: 'مراقبة', delta: { ar: 'تحت المراقبة', en: 'Under observation' } }
+          ].map(item => ({ ...item, icon: item.icon === 'database' ? 'cube' : item.icon }))
+        },
+        {
+          id: 'playbooks',
+          type: 'progress',
+          title: { ar: 'خطة الاستجابة للحوادث', en: 'Incident response playbook' },
+          items: [
+            { title: { ar: 'التقييم والتصنيف', en: 'Assess & classify' }, subtitle: { ar: 'مراجعة تلقائية للحساسية', en: 'Automated severity scoring' }, value: '90%', percent: '90%' },
+            { title: { ar: 'التخفيف', en: 'Mitigation' }, subtitle: { ar: 'تنفيذ سياسات التدرج التلقائي', en: 'Auto-scaling policies executed' }, value: '64%', percent: '64%' },
+            { title: { ar: 'التحقق والتوثيق', en: 'Verification & logs' }, subtitle: { ar: 'تقارير ما بعد الحادث قيد الإعداد', en: 'Postmortem drafts pending' }, value: '38%', percent: '38%' }
+          ]
+        },
+        {
+          id: 'regions',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'توافر المناطق', en: 'Regional availability' },
+          action: { ar: 'مزامنة مع مركز NOC', en: 'Sync with NOC' },
+          headers: [
+            { ar: 'المنطقة', en: 'Region' },
+            { ar: 'التوفر', en: 'Availability' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: 'أوروبا - غرب', en: 'EU West' }, metric: '99.98%', delta: { ar: '+0.02% اليوم', en: '+0.02% today' }, trend: 'positive' },
+            { name: { ar: 'أمريكا - شرق', en: 'US East' }, metric: '99.92%', delta: { ar: 'بدون تغيير', en: 'Unchanged' }, trend: 'neutral' },
+            { name: { ar: 'آسيا - جنوب شرق', en: 'APAC Southeast' }, metric: '99.71%', delta: { ar: '−0.08% بسبب الصيانة', en: '−0.08% maintenance' }, trend: 'negative' }
+          ]
+        },
+        {
+          id: 'incidents',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'سجل الحوادث الأخير', en: 'Recent incident log' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'إعادة موازنة حركة المرور', en: 'Traffic rebalancing' }, subtitle: { ar: 'توجيه 18% من الحمل إلى أوروبا', en: 'Shifted 18% load to EU' }, time: { ar: 'قبل 30 دقيقة', en: '30 minutes ago' } },
+            { icon: 'cog', title: { ar: 'تصحيح تلقائي لحاوية', en: 'Automated container patch' }, subtitle: { ar: 'تم توقيف الحاوية المتأثرة وإعادة تشغيلها', en: 'Impacted pod drained & restarted' }, time: { ar: 'قبل ساعة', en: '1 hour ago' } },
+            { icon: 'map', title: { ar: 'اختبار خطة التعافي', en: 'Disaster recovery drill' }, subtitle: { ar: 'نجاح التمرين دون تأثير على العملاء', en: 'Successful drill without customer impact' }, time: { ar: 'أمس', en: 'Yesterday' } }
+          ]
+        }
+      ]
+    });
   </script>
 </body>
 </html>

--- a/dashboards/dashboard-5.html
+++ b/dashboards/dashboard-5.html
@@ -3,161 +3,189 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>لوحة مراقبة البنية السحابية</title>
+  <title>لوحة مراقبة الاستمرارية</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
   </style>
 </head>
-<body class="bg-slate-950 text-slate-100"> 
-  <div class="min-h-screen">
-    <!-- الهيدر للموبايل -->
-    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
-      <div>
-        <p class="text-xs uppercase tracking-[0.4em] text-sky-300">Cloud Sentinel</p>
-        <h1 class="text-lg font-semibold">المراقبة الفورية</h1>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <!-- Mobile Header -->
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">R</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
       </div>
-      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <span>فتح القائمة</span>
-      </button>
-    </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
 
-    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
 
-    <div class="lg:grid lg:grid-cols-[320px_1fr]">
-      <!-- الشريط الجانبي -->
-      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-slate-900/95 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:relative lg:translate-x-0 lg:w-full lg:max-w-[320px] lg:bg-slate-900/80">
-        <div class="flex items-start justify-between gap-3">
+    <!-- Sidebar -->
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">R</div>
           <div>
-            <p class="text-xs uppercase tracking-[0.4em] text-sky-300">Cloud Sentinel</p>
-            <h1 class="text-2xl font-bold">المراقبة الفورية</h1>
-            <p class="text-sm text-slate-400 mt-2">لوحة موحدة للبنية التحتية السحابية.</p>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
-          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
-            <span>إغلاق</span>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
 
-        <!-- محتوى جانبي بسيط -->
-        <div class="space-y-4">
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
-            <p class="text-xs text-slate-500">الحالة العامة</p>
-            <p class="text-lg font-semibold text-emerald-300 mt-2">مستقرة</p>
-            <p class="text-xs text-slate-500 mt-2">لا يوجد أعطال حرجة خلال آخر 24 ساعة.</p>
-          </div>
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 space-y-3 text-sm">
-            <p class="text-slate-400">التنبيهات الحية</p>
-            <div class="flex items-center justify-between">
-              <span>CPU</span>
-              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300">طبيعي</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>Memory</span>
-              <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-300">انتباه</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>Network</span>
-              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300">طبيعي</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>Storage</span>
-              <span class="px-3 py-1 rounded-full bg-rose-500/10 text-rose-300">حرج</span>
-            </div>
-          </div>
-        </div>
-      </aside>
-
-      <!-- المحتوى الرئيسي -->
-      <main class="p-6 lg:p-10 space-y-8 lg:pr-10"> 
-        <section class="grid gap-6 lg:grid-cols-3">
-          <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-              <div>
-                <h2 class="text-xl font-semibold">المراقبة الزمنية للأحمال</h2>
-                <p class="text-sm text-slate-400">CPU / Memory / Network</p>
-              </div>
-              <div class="flex gap-3 text-sm">
-                <button class="px-4 py-2 rounded-xl bg-slate-800">آخر ساعة</button>
-                <button class="px-4 py-2 rounded-xl bg-sky-500 text-slate-950 font-semibold">آخر 24 ساعة</button>
-              </div>
-            </div>
-            <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-sky-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط متعدد المحاور</div>
-          </div>
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-            <div class="flex items-center justify-between">
-              <h3 class="text-lg font-semibold">مؤشر التوفر</h3>
-              <span class="text-xs text-slate-500">آخر تحديث: 12 ثانية</span>
-            </div>
-            <div class="space-y-4 text-sm">
-              <div class="flex items-center gap-4">
-                <span class="w-2 h-12 rounded-full bg-emerald-500"></span>
-                <div class="flex-1">
-                  <p class="font-semibold">المنطقة - أوروبا</p>
-                  <p class="text-xs text-slate-500">99.98% التوفر</p>
-                </div>
-                <span class="text-emerald-300">↑</span>
-              </div>
-              <div class="flex items-center gap-4">
-                <span class="w-2 h-12 rounded-full bg-emerald-400"></span>
-                <div class="flex-1">
-                  <p class="font-semibold">المنطقة - أمريكا</p>
-                  <p class="text-xs text-slate-500">99.94% التوفر</p>
-                </div>
-                <span class="text-emerald-300">↑</span>
-              </div>
-              <div class="flex items-center gap-4">
-                <span class="w-2 h-12 rounded-full bg-amber-400"></span>
-                <div class="flex-1">
-                  <p class="font-semibold">المنطقة - آسيا</p>
-                  <p class="text-xs text-slate-500">99.71% التوفر</p>
-                </div>
-                <span class="text-amber-300">→</span>
-              </div>
-            </div>
-          </div>
-        </section>
-      </main>
-    </div>
+    <!-- Main -->
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
   </div>
- 
+
+  <script src="dashboard-common.js"></script>
   <script>
-    (function () {
-      const sidebar = document.getElementById('sidebar');
-      const toggle = document.getElementById('sidebarToggle');
-      const close = document.getElementById('sidebarClose');
-      const backdrop = document.getElementById('sidebarBackdrop');
-      const body = document.body;
-
-      if (!sidebar || !toggle || !close || !backdrop) return;
-
-      const openSidebar = () => {
-        sidebar.classList.remove('translate-x-full');
-        backdrop.classList.remove('opacity-0', 'pointer-events-none');
-        backdrop.classList.add('opacity-100');
-        body.classList.add('overflow-hidden');
-      };
-
-      const closeSidebar = () => {
-        sidebar.classList.add('translate-x-full');
-        backdrop.classList.add('opacity-0', 'pointer-events-none');
-        backdrop.classList.remove('opacity-100');
-        body.classList.remove('overflow-hidden');
-      };
-
-      toggle.addEventListener('click', openSidebar);
-      close.addEventListener('click', closeSidebar);
-      backdrop.addEventListener('click', closeSidebar);
-      window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') closeSidebar();
-      });
-    })();
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة مراقبة الاستمرارية',
+          en: 'Cloud Reliability War-room'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
+      brand: {
+        badge: 'R',
+        name: { ar: 'Resilience Core', en: 'Resilience Core' },
+        tagline: { ar: 'قيادة الاستجابة للحوادث', en: 'Incident response command' }
+      },
+      theme: {
+        accentGradient: 'from-emerald-500 via-sky-400 to-indigo-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        { id: 'overview', icon: 'shield', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'P1 نشط', en: 'P1 active' } },
+        { id: 'incidents', icon: 'alert', label: { ar: 'الحوادث', en: 'Incidents' } },
+        { id: 'capacity', icon: 'cloud', label: { ar: 'السعة', en: 'Capacity' } },
+        { id: 'playbooks', icon: 'book-open', label: { ar: 'أدلة العمل', en: 'Runbooks' } }
+      ].map(item => ({ ...item, icon: item.icon === 'alert' ? 'sparkles' : item.icon })),
+      highlight: {
+        label: { ar: 'أولوية الحادث', en: 'Incident priority' },
+        value: { ar: 'P1 - تأخر تدفق البيانات', en: 'P1 – Data stream lag' },
+        description: {
+          ar: 'تأثير على التقارير الزمنية، زمن الاستجابة الحالي 7 دقائق.',
+          en: 'Impacting realtime analytics, current response time 7 minutes.'
+        }
+      },
+      header: {
+        title: { ar: 'غرفة التحكم بالاستمرارية', en: 'Reliability command room' },
+        subtitle: {
+          ar: 'إدارة الحوادث، التوسع، وخطط التعافي في لوحة واحدة.',
+          en: 'Coordinate incidents, scaling, and recovery strategies from one view.'
+        },
+        primary: { ar: 'دعوة قادة الطوارئ', en: 'Page incident leads' },
+        secondary: { ar: 'نافذة 6 ساعات', en: 'Last 6 hours' }
+      },
+      stats: [
+        { icon: 'shield', label: { ar: 'الحوادث المفتوحة', en: 'Open incidents' }, value: '5', delta: { ar: '−3 خلال 12 ساعة', en: '−3 in 12 hours' }, trend: 'positive' },
+        { icon: 'clock', label: { ar: 'متوسط زمن الحل', en: 'Mean time to resolve' }, value: '42 دقيقة', delta: { ar: 'الهدف 45 دقيقة', en: 'Target 45 minutes' }, trend: 'positive' },
+        { icon: 'users', label: { ar: 'فرق الاستجابة النشطة', en: 'Active response squads' }, value: '4 فرق', delta: { ar: 'انضم فريق النمو', en: 'Growth team joined' }, trend: 'positive' },
+        { icon: 'cloud', label: { ar: 'جاهزية التوسع', en: 'Scaling readiness' }, value: '88%', delta: { ar: 'أضيفت 12 عقدة جديدة', en: '12 nodes added' }, trend: 'positive' }
+      ].map(stat => ({ ...stat, icon: stat.icon === 'clock' ? 'calendar' : stat.icon })),
+      panels: [
+        {
+          id: 'impact',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'نافذة تأثير SLA', en: 'SLA impact window' },
+          subtitle: { ar: 'حجم التوقف مقابل خط الأساس خلال آخر 6 ساعات.', en: 'Downtime magnitude vs baseline across the last 6 hours.' },
+          action: { ar: 'تحميل تقرير التأثير', en: 'Download impact report' },
+          placeholder: { ar: 'منحنى التأثير', en: 'Impact curve' }
+        },
+        {
+          id: 'live-incidents',
+          type: 'list',
+          title: { ar: 'الحوادث المباشرة', en: 'Live incidents' },
+          action: { ar: 'تم التحديث قبل دقيقتين', en: 'Updated 2 minutes ago' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'SYN-212 - فقدان رسائل', en: 'SYN-212 – Message loss' }, subtitle: { ar: 'خدمة البث اللحظي', en: 'Realtime stream service' }, value: 'مرحلة التخفيف', delta: { ar: 'ETA الحل 18 دقيقة', en: 'ETA resolution 18m' } },
+            { icon: 'cloud', title: { ar: 'CAP-104 - ضغط السعة', en: 'CAP-104 – Capacity pressure' }, subtitle: { ar: 'عنقود المعالجة في سنغافورة', en: 'Singapore processing cluster' }, value: 'يتطلب التوسع', delta: { ar: 'زيادة 20% في الحمل', en: 'Load up 20%' } },
+            { icon: 'shield', title: { ar: 'SEC-078 - رمز تنبيه', en: 'SEC-078 – Token alert' }, subtitle: { ar: 'بوابة الهوية', en: 'Identity gateway' }, value: 'تحقيق', delta: { ar: 'لا تأثير على العملاء', en: 'No customer impact' } }
+          ]
+        },
+        {
+          id: 'runbooks',
+          type: 'progress',
+          title: { ar: 'تنفيذ خطة الاستجابة', en: 'Response plan execution' },
+          items: [
+            { title: { ar: 'تنسيق الاتصالات', en: 'Communications' }, subtitle: { ar: 'إرسال تحديثات العملاء كل 15 دقيقة', en: 'Customer updates every 15 minutes' }, value: '95%', percent: '95%' },
+            { title: { ar: 'الاستعادة المرحلية', en: 'Phased recovery' }, subtitle: { ar: 'تفعيل المسار البديل للبيانات', en: 'Fallback data path enabled' }, value: '68%', percent: '68%' },
+            { title: { ar: 'مراجعة ما بعد الحادث', en: 'Post-incident review' }, subtitle: { ar: 'جمع المقاييس والجداول', en: 'Collecting metrics & timelines' }, value: '22%', percent: '22%' }
+          ]
+        },
+        {
+          id: 'capacity',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'خطة التوسع الفوري', en: 'Immediate scaling plan' },
+          action: { ar: 'مزامنة مع الفريق الهندسي', en: 'Sync with engineering' },
+          headers: [
+            { ar: 'العنقود', en: 'Cluster' },
+            { ar: 'الحالة', en: 'Status' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: 'معالجة الأحداث', en: 'Event processing' }, metric: 'قيد التوسعة', delta: { ar: '+12 عقدة خلال 5 دقائق', en: '+12 nodes in 5m' }, trend: 'positive' },
+            { name: { ar: 'مخزن البيانات', en: 'Data lake' }, metric: 'جاهز', delta: { ar: 'سعة احتياطية 34%', en: '34% buffer capacity' }, trend: 'positive' },
+            { name: { ar: 'منصة الهوية', en: 'Identity platform' }, metric: 'تحذير طفيف', delta: { ar: '+4% تأخير جلسات', en: '+4% session latency' }, trend: 'neutral' }
+          ]
+        },
+        {
+          id: 'updates',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'خط زمني للتحديثات', en: 'Update timeline' },
+          items: [
+            { icon: 'megaphone', title: { ar: 'بيان العملاء الأول', en: 'Initial customer note' }, subtitle: { ar: 'إرسال إلى قائمة الحالة العامة', en: 'Shared via public status page' }, time: { ar: 'قبل 10 دقائق', en: '10 minutes ago' } },
+            { icon: 'cog', title: { ar: 'تنشيط الحاويات الاحتياطية', en: 'Backup containers activated' }, subtitle: { ar: 'تحويل 35% من الحمل إلى المسار البديل', en: 'Rerouted 35% of load to fallback path' }, time: { ar: 'قبل 25 دقيقة', en: '25 minutes ago' } },
+            { icon: 'book-open', title: { ar: 'بدء مراجعة ما بعد الحادث', en: 'Post-incident review kickoff' }, subtitle: { ar: 'جمع الملاحظات من جميع الفرق', en: 'Collecting notes from all squads' }, time: { ar: 'أمس', en: 'Yesterday' } }
+          ]
+        }
+      ]
+    });
   </script>
 </body>
 </html>

--- a/dashboards/dashboard-6.html
+++ b/dashboards/dashboard-6.html
@@ -5,133 +5,187 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>لوحة تجربة العملاء</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
   </style>
 </head>
-<body class="bg-slate-950 text-slate-100"> 
-  <div class="min-h-screen">
-    <!-- هيدر الموبايل -->
-    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
-      <div>
-        <p class="text-xs uppercase tracking-[0.4em] text-fuchsia-300">Customer Pulse</p>
-        <h1 class="text-lg font-semibold">تجربة العملاء الحية</h1>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <!-- Mobile Header -->
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">C</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
       </div>
-      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-fuchsia-500 px-4 py-2 text-sm font-semibold text-slate-950">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <span>فتح القائمة</span>
-      </button>
-    </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
 
-    <!-- خلفية جانبية -->
-    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
 
-    <div class="lg:flex lg:flex-row">
-      <!-- الشريط الجانبي -->
-      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-gradient-to-b from-fuchsia-500/20 via-slate-950 to-slate-950 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:static lg:w-80 lg:translate-x-0 lg:border-l lg:bg-gradient-to-b lg:from-fuchsia-500/10 lg:via-slate-950 lg:to-slate-950">
-        <div class="flex items-start justify-between gap-3">
+    <!-- Sidebar -->
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">C</div>
           <div>
-            <p class="text-xs uppercase tracking-[0.4em] text-fuchsia-300">Customer Pulse</p>
-            <h1 class="text-3xl font-bold">تجربة العملاء الحية</h1>
-            <p class="text-sm text-slate-400 mt-2">لوحة كاملة لرضا العملاء وسرعة الاستجابة.</p>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
-          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
-            <span>إغلاق</span>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
 
-        <!-- مقاييس جانبية -->
-        <div class="space-y-4 text-sm">
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
-            <p class="text-slate-400">مؤشر رضا العملاء</p>
-            <p class="text-2xl font-semibold text-fuchsia-200 mt-2">87</p>
-            <p class="text-xs text-emerald-300 mt-2">+6 نقاط خلال آخر 30 يوم</p>
-          </div>
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
-            <p class="text-slate-400">التذاكر المفتوحة</p>
-            <p class="text-2xl font-semibold">124</p>
-            <p class="text-xs text-amber-300 mt-2">انخفاض 14%</p>
-          </div>
-        </div>
-      </aside>
+    <!-- Main -->
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
 
-      <!-- المحتوى الرئيسي -->
-      <main class="flex-1 p-6 lg:p-10 space-y-8 lg:pr-10"> 
-        <section class="grid gap-6 lg:grid-cols-3">
-          <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-              <div>
-                <h2 class="text-xl font-semibold">موجز المشاعر</h2>
-                <p class="text-sm text-slate-400">تحليل تلقائي للانطباعات عبر القنوات</p>
-              </div>
-              <div class="flex gap-3 text-sm">
-                <button class="px-4 py-2 rounded-xl bg-slate-800">7 أيام</button>
-                <button class="px-4 py-2 rounded-xl bg-fuchsia-500 text-slate-950 font-semibold">30 يوم</button>
-              </div>
-            </div>
-            <div class="h-56 rounded-xl border border-slate-800 bg-gradient-to-br from-fuchsia-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط مشاعر</div>
-          </div>
-
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-            <div class="flex items-center justify-between">
-              <h3 class="text-lg font-semibold">مؤشرات الخدمة</h3>
-              <span class="text-xs text-slate-500">تحديث مباشر</span>
-            </div>
-            <div class="space-y-4 text-sm">
-              <div>
-                <p class="text-slate-400">متوسط زمن الاستجابة</p>
-                <p class="text-xl font-semibold text-fuchsia-200">2:14 دقيقة</p>
-                <p class="text-xs text-emerald-300">-38 ثانية هذا الأسبوع</p>
-              </div>
-              <div>
-                <p class="text-slate-400">معدل الحل من أول اتصال</p>
-                <p class="text-xl font-semibold text-emerald-300">78%</p>
-              </div>
-            </div>
-          </div>
-        </section>
-      </main>
-    </div>
-  </div> 
-
-  <!-- التحكم في القائمة الجانبية -->
+  <script src="dashboard-common.js"></script>
   <script>
-    (function () {
-      const sidebar = document.getElementById('sidebar');
-      const toggle = document.getElementById('sidebarToggle');
-      const close = document.getElementById('sidebarClose');
-      const backdrop = document.getElementById('sidebarBackdrop');
-      const body = document.body;
-
-      if (!sidebar || !toggle || !close || !backdrop) return;
-
-      const openSidebar = () => {
-        sidebar.classList.remove('translate-x-full');
-        backdrop.classList.remove('opacity-0', 'pointer-events-none');
-        backdrop.classList.add('opacity-100');
-        body.classList.add('overflow-hidden');
-      };
-
-      const closeSidebar = () => {
-        sidebar.classList.add('translate-x-full');
-        backdrop.classList.add('opacity-0', 'pointer-events-none');
-        backdrop.classList.remove('opacity-100');
-        body.classList.remove('overflow-hidden');
-      };
-
-      toggle.addEventListener('click', openSidebar);
-      close.addEventListener('click', closeSidebar);
-      backdrop.addEventListener('click', closeSidebar);
-      window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') closeSidebar();
-      });
-    })();
-  </script> 
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة تجربة العملاء',
+          en: 'Customer Experience Cockpit'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
+      brand: {
+        badge: 'C',
+        name: { ar: 'Customer Pulse', en: 'Customer Pulse' },
+        tagline: { ar: 'تحليلات تجربة العملاء الشاملة', en: 'End-to-end CX analytics' }
+      },
+      theme: {
+        accentGradient: 'from-fuchsia-500 via-pink-500 to-rose-500',
+        accentText: 'text-fuchsia-200',
+        highlightBg: 'bg-fuchsia-500/10 border-fuchsia-400/30',
+        badgeBg: 'bg-fuchsia-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        { id: 'overview', icon: 'sparkles', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'تحديث مباشر', en: 'Live update' } },
+        { id: 'feedback', icon: 'chat-bubble', label: { ar: 'ملاحظات العملاء', en: 'Customer feedback' } },
+        { id: 'support', icon: 'stethoscope', label: { ar: 'الدعم', en: 'Support' } },
+        { id: 'journeys', icon: 'map', label: { ar: 'مسارات العملاء', en: 'Journeys' } }
+      ],
+      highlight: {
+        label: { ar: 'مؤشر الرضا اللحظي', en: 'Live satisfaction index' },
+        value: '87',
+        description: {
+          ar: 'ارتفع المؤشر 6 نقاط بعد تحسينات تجربة الاشتراك.',
+          en: 'Up 6 points after onboarding enhancements.'
+        }
+      },
+      header: {
+        title: { ar: 'لوحة قيادة تجربة العملاء', en: 'Customer experience cockpit' },
+        subtitle: {
+          ar: 'راقب المشاعر، SLA الدعم، ونبض العملاء عبر القنوات.',
+          en: 'Track sentiment, support SLAs, and customer pulse across channels.'
+        },
+        primary: { ar: 'إطلاق حملة تفاعل', en: 'Launch engagement campaign' },
+        secondary: { ar: 'آخر 30 يوماً', en: 'Last 30 days' }
+      },
+      stats: [
+        { icon: 'heart', label: { ar: 'مؤشر رضا العملاء', en: 'Customer satisfaction index' }, value: '87', delta: { ar: '+6 نقاط هذا الشهر', en: '+6 points this month' }, trend: 'positive' },
+        { icon: 'clock', label: { ar: 'زمن الاستجابة للدعم', en: 'Support response time' }, value: '38 ثانية', delta: { ar: '−12% عن الأسبوع الماضي', en: '−12% vs last week' }, trend: 'positive' },
+        { icon: 'chat-bubble', label: { ar: 'التذاكر المفتوحة', en: 'Open tickets' }, value: '124', delta: { ar: 'انخفاض 14%', en: '14% decrease' }, trend: 'positive' },
+        { icon: 'sparkles', label: { ar: 'الحل من أول تواصل', en: 'First-contact resolution' }, value: '71%', delta: { ar: '+5% بعد التدريب', en: '+5% post training' }, trend: 'positive' }
+      ].map(stat => ({ ...stat, icon: stat.icon === 'clock' ? 'calendar' : stat.icon })),
+      panels: [
+        {
+          id: 'sentiment',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى المشاعر عبر القنوات', en: 'Sentiment across channels' },
+          subtitle: { ar: 'تحليل البريد، التطبيق، والمكالمات خلال 30 يوماً.', en: 'Email, app, and voice sentiment across 30 days.' },
+          action: { ar: 'تحميل تقرير المشاعر', en: 'Download sentiment report' },
+          placeholder: { ar: 'مخطط المشاعر', en: 'Sentiment chart' }
+        },
+        {
+          id: 'top-drivers',
+          type: 'list',
+          title: { ar: 'أبرز محركات الرضا', en: 'Top satisfaction drivers' },
+          action: { ar: 'محدث منذ 5 دقائق', en: 'Refreshed 5 minutes ago' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'واجهة التطبيق', en: 'App interface' }, subtitle: { ar: 'تصميم جديد سجل 4.6⭐', en: 'Redesign trending at 4.6⭐' }, value: '+18', delta: { ar: 'تأثير إيجابي', en: 'Positive impact' } },
+            { icon: 'chat-bubble', title: { ar: 'دعم الدردشة الفوري', en: 'Live chat support' }, subtitle: { ar: 'متوسط الزمن 31 ثانية', en: 'Avg time 31 seconds' }, value: '+12', delta: { ar: 'مستوى رضا مرتفع', en: 'High satisfaction' } },
+            { icon: 'megaphone', title: { ar: 'حملات التفعيل', en: 'Activation campaigns' }, subtitle: { ar: 'سلسلة البريد الترحيبي', en: 'New welcome sequence' }, value: '+9', delta: { ar: 'تحسن الاحتفاظ', en: 'Retention improved' } }
+          ]
+        },
+        {
+          id: 'journey',
+          type: 'progress',
+          title: { ar: 'مراحل رحلة العميل', en: 'Customer journey stages' },
+          items: [
+            { title: { ar: 'التجربة الأولى', en: 'First experience' }, subtitle: { ar: 'معدل نقر 68%', en: '68% click-through' }, value: '68%', percent: '68%' },
+            { title: { ar: 'التفاعل المتكرر', en: 'Recurring engagement' }, subtitle: { ar: 'تدفق رسائل شخصية', en: 'Personalised messaging stream' }, value: '52%', percent: '52%' },
+            { title: { ar: 'الدفاع عن العلامة', en: 'Advocacy' }, subtitle: { ar: 'دعوات برنامج الإحالة', en: 'Referral program invites' }, value: '21%', percent: '21%' }
+          ]
+        },
+        {
+          id: 'support-queue',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'قائمة انتظار الدعم', en: 'Support queue health' },
+          action: { ar: 'عرض مركز الخدمة', en: 'Open help centre' },
+          headers: [
+            { ar: 'الفئة', en: 'Category' },
+            { ar: 'SLA الحالي', en: 'Current SLA' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: 'مشكلات الفوترة', en: 'Billing issues' }, metric: '24 دقيقة', delta: { ar: 'تحسن 6 دقائق', en: 'Improved by 6m' }, trend: 'positive' },
+            { name: { ar: 'أخطاء التطبيق', en: 'App defects' }, metric: '41 دقيقة', delta: { ar: '−4 دقائق بعد الإصدار', en: '−4m after release' }, trend: 'positive' },
+            { name: { ar: 'طلبات الميزات', en: 'Feature requests' }, metric: '3.1 يوم', delta: { ar: 'بدون تغيير', en: 'Unchanged' }, trend: 'neutral' }
+          ]
+        },
+        {
+          id: 'moments',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'لحظات صوت العميل', en: 'Voice-of-customer moments' },
+          items: [
+            { icon: 'megaphone', title: { ar: 'مجتمع المستخدمين الشهري', en: 'Monthly user council' }, subtitle: { ar: '15 عميلًا استعرضوا خارطة الطريق', en: '15 clients reviewed roadmap' }, time: { ar: 'قبل ساعتين', en: '2 hours ago' } },
+            { icon: 'chat-bubble', title: { ar: 'إطلاق برنامج الولاء', en: 'Loyalty program roll-out' }, subtitle: { ar: 'تسجيل 3.4 ألف عضو خلال اليوم الأول', en: '3.4k members joined day one' }, time: { ar: 'اليوم', en: 'Today' } },
+            { icon: 'sparkles', title: { ar: 'تحسين تجربة الدعم الهاتفي', en: 'Voice support uplift' }, subtitle: { ar: 'تدريب الوكلاء على السيناريوهات الحرجة', en: 'Agents trained on critical scripts' }, time: { ar: 'أمس', en: 'Yesterday' } }
+          ]
+        }
+      ]
+    });
+  </script>
 </body>
 </html>

--- a/dashboards/dashboard-7.html
+++ b/dashboards/dashboard-7.html
@@ -5,182 +5,187 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>لوحة الموارد البشرية</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
   </style>
 </head>
 <body class="bg-slate-950 text-slate-100">
-  <div class="min-h-screen flex flex-col">
-    <!-- الهيدر -->
-    <header class="border-b border-slate-800 bg-gradient-to-r from-lime-500/10 via-slate-950 to-slate-950">
-      <div class="max-w-7xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <!-- Mobile Header -->
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">P</div>
         <div>
-          <p class="text-xs uppercase tracking-[0.4em] text-lime-300">People Vision</p>
-          <h1 class="text-3xl font-bold">لوحة الموارد البشرية الشاملة</h1>
-          <p class="text-slate-300 mt-2">مؤشرات الأداء، الحضور، والتوظيف في واجهة واحدة.</p>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
         </div>
-        <div class="flex flex-wrap gap-3">
-          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">إضافة موظف</button>
-          <button class="px-4 py-2 rounded-xl bg-lime-500 text-sm text-slate-950 font-semibold">تحميل التقرير</button>
-        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
       </div>
     </header>
 
-    <!-- المحتوى الرئيسي -->
-    <main class="flex-1 max-w-7xl mx-auto w-full px-6 py-10 space-y-8">
-      <!-- إحصائيات -->
-      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">عدد الموظفين</p>
-          <p class="mt-3 text-3xl font-semibold">268</p>
-          <p class="mt-2 text-emerald-300 text-sm">+12 تعيين جديد</p>
-        </div>
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">معدل الحضور</p>
-          <div class="mt-3 flex items-center gap-3">
-            <div class="h-14 w-14 rounded-full bg-lime-500/15 flex items-center justify-center">
-              <span class="text-xl font-semibold text-lime-200">96%</span>
-            </div>
-            <p class="text-xs text-slate-500">تحسن بنسبة 4% هذا الشهر</p>
-          </div>
-        </div>
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">نسبة الدوران</p>
-          <p class="mt-3 text-3xl font-semibold text-amber-300">7.4%</p>
-          <p class="mt-2 text-xs text-slate-500">أقل من متوسط الصناعة</p>
-        </div>
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">برامج التدريب</p>
-          <p class="mt-3 text-3xl font-semibold">18</p>
-          <p class="mt-2 text-emerald-300 text-sm">معدل إكمال 82%</p>
-        </div>
-      </section>
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
 
-      <!-- توزيع القوى العاملة -->
-      <section class="rounded-2xl border border-slate-800 bg-slate-900/80">
-        <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+    <!-- Sidebar -->
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">P</div>
           <div>
-            <h2 class="text-xl font-semibold">مخطط القوى العاملة</h2>
-            <p class="text-sm text-slate-400">توزيع الموظفين حسب الإدارات</p>
-          </div>
-          <div class="flex gap-3 text-sm">
-            <button class="px-4 py-2 rounded-xl bg-slate-800">السنة الحالية</button>
-            <button class="px-4 py-2 rounded-xl bg-lime-500 text-slate-950 font-semibold">السنة الماضية</button>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
         </div>
-        <div class="p-6 grid gap-6 lg:grid-cols-3">
-          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm">
-            <p class="text-slate-400">الهندسة</p>
-            <p class="text-2xl font-semibold">94 موظف</p>
-            <p class="text-xs text-emerald-300">+6 هذا الربع</p>
-          </div>
-          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm">
-            <p class="text-slate-400">المنتج</p>
-            <p class="text-2xl font-semibold">42 موظف</p>
-            <p class="text-xs text-emerald-300">+3 هذا الربع</p>
-          </div>
-          <div class="rounded-xl border border-slate-800/60 bg-slate-900/60 p-4 text-sm">
-            <p class="text-slate-400">المبيعات</p>
-            <p class="text-2xl font-semibold">58 موظف</p>
-            <p class="text-xs text-emerald-300">+1 هذا الربع</p>
-          </div>
-          <div class="lg:col-span-3 h-56 rounded-xl border border-slate-800 bg-gradient-to-br from-lime-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط تراكمي</div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
         </div>
-      </section>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
 
-      <!-- قائمة الوظائف المفتوحة + نبض الموظفين -->
-      <section class="grid gap-6 xl:grid-cols-3">
-        <div class="xl:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80">
-          <div class="px-6 py-5 border-b border-slate-800 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 class="text-xl font-semibold">قائمة التوظيف المفتوحة</h2>
-              <p class="text-sm text-slate-400">الحالة الراهنة للوظائف</p>
-            </div>
-            <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تصدير</button>
-          </div>
-          <div class="p-6 overflow-x-auto">
-            <table class="w-full min-w-[720px] text-sm">
-              <thead>
-                <tr class="text-slate-400">
-                  <th class="text-right pb-3 font-medium">المسمى الوظيفي</th>
-                  <th class="text-right pb-3 font-medium">الفريق</th>
-                  <th class="text-right pb-3 font-medium">عدد المرشحين</th>
-                  <th class="text-right pb-3 font-medium">المرحلة</th>
-                  <th class="text-right pb-3 font-medium">الأولوية</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-slate-800">
-                <tr class="hover:bg-slate-800/40">
-                  <td class="py-4">قائد فريق الهندسة</td>
-                  <td>الهندسة</td>
-                  <td>12</td>
-                  <td>مقابلات نهائية</td>
-                  <td><span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">عاجلة</span></td>
-                </tr>
-                <tr class="hover:bg-slate-800/40">
-                  <td class="py-4">مصمم تجربة المستخدم</td>
-                  <td>المنتج</td>
-                  <td>18</td>
-                  <td>مراجعة محفظة</td>
-                  <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">متوسطة</span></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-          <h3 class="text-lg font-semibold">نبض الموظفين</h3>
-          <div class="space-y-4 text-sm">
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">استبيان الرضا</p>
-              <p class="text-slate-400 text-xs mt-1">معدل استجابة 78% - الموضوع: التوازن الوظيفي</p>
-            </div>
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">مبادرات الرفاهية</p>
-              <p class="text-slate-400 text-xs mt-1">إطلاق برنامج التدريب الذهني الأسبوع المقبل</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- مؤشرات الأداء -->
-      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
-          <div>
-            <h2 class="text-xl font-semibold">مؤشرات الأداء الرئيسية</h2>
-            <p class="text-sm text-slate-400">تتبع أهداف الموارد البشرية</p>
-          </div>
-          <div class="flex gap-3 text-sm">
-            <button class="px-4 py-2 rounded-xl bg-slate-800">ربع</button>
-            <button class="px-4 py-2 rounded-xl bg-lime-500 text-slate-950 font-semibold">سنة</button>
-          </div>
-        </div>
-        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4 text-sm">
-          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
-            <p class="text-slate-400">زمن التوظيف</p>
-            <p class="text-2xl font-semibold">28 يوم</p>
-            <p class="text-xs text-emerald-300 mt-1">مستهدف 30 يوم</p>
-          </div>
-          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
-            <p class="text-slate-400">التكلفة لكل تعيين</p>
-            <p class="text-2xl font-semibold">$1,840</p>
-            <p class="text-xs text-emerald-300 mt-1">انخفاض 12%</p>
-          </div>
-          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
-            <p class="text-slate-400">المشاركة</p>
-            <p class="text-2xl font-semibold">89%</p>
-            <p class="text-xs text-emerald-300 mt-1">أعلى من الهدف بـ 5%</p>
-          </div>
-          <div class="p-4 rounded-xl border border-slate-800/60 bg-slate-900/60">
-            <p class="text-slate-400">الترقيات الداخلية</p>
-            <p class="text-2xl font-semibold">28</p>
-            <p class="text-xs text-emerald-300 mt-1">45% من إجمالي التعيينات</p>
-          </div>
-        </div>
-      </section>
+    <!-- Main -->
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
     </main>
   </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الموارد البشرية',
+          en: 'People Operations Dashboard'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
+      brand: {
+        badge: 'P',
+        name: { ar: 'People Orbit', en: 'People Orbit' },
+        tagline: { ar: 'قيادة المواهب والنجاح الوظيفي', en: 'Talent and culture command' }
+      },
+      theme: {
+        accentGradient: 'from-lime-500 via-emerald-500 to-teal-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        { id: 'overview', icon: 'users', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'مستقر', en: 'Stable' } },
+        { id: 'recruiting', icon: 'briefcase', label: { ar: 'التوظيف', en: 'Hiring' } },
+        { id: 'development', icon: 'book-open', label: { ar: 'التطوير', en: 'Development' } },
+        { id: 'engagement', icon: 'heart', label: { ar: 'المشاركة', en: 'Engagement' } }
+      ],
+      highlight: {
+        label: { ar: 'الجاهزية التنظيمية', en: 'Organisational readiness' },
+        value: '93%',
+        description: {
+          ar: 'أغلب الفرق تمتلك خطط تعاقب ومعسكرات تدريب نشطة.',
+          en: 'Most squads have updated succession plans and active bootcamps.'
+        }
+      },
+      header: {
+        title: { ar: 'لوحة قيادة الموارد البشرية', en: 'People operations cockpit' },
+        subtitle: {
+          ar: 'تابع القوى العاملة، التوظيف، وصحة المشاركة في الوقت الفعلي.',
+          en: 'Monitor workforce health, hiring, and engagement in real time.'
+        },
+        primary: { ar: 'إطلاق حملة ولاء', en: 'Launch retention campaign' },
+        secondary: { ar: 'تقرير الربع الحالي', en: 'Current quarter report' }
+      },
+      stats: [
+        { icon: 'users', label: { ar: 'عدد الموظفين', en: 'Total headcount' }, value: '1,284', delta: { ar: '+42 منذ يناير', en: '+42 since January' }, trend: 'positive' },
+        { icon: 'briefcase', label: { ar: 'المناصب المفتوحة', en: 'Open roles' }, value: '38', delta: { ar: 'متوسط وقت التوظيف 23 يوماً', en: 'Time-to-fill 23 days' }, trend: 'positive' },
+        { icon: 'heart', label: { ar: 'معدل نبض الموظف', en: 'Employee pulse' }, value: '7.9/10', delta: { ar: '+0.4 عن الربع السابق', en: '+0.4 vs last quarter' }, trend: 'positive' },
+        { icon: 'sparkles', label: { ar: 'الاحتفاظ خلال 12 شهر', en: '12-month retention' }, value: '91%', delta: { ar: '+3% بعد برامج النمو', en: '+3% after growth tracks' }, trend: 'positive' }
+      ],
+      panels: [
+        {
+          id: 'headcount',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'تطور القوى العاملة', en: 'Workforce evolution' },
+          subtitle: { ar: 'مقارنة الاستقطاب مقابل الاستقالة حسب الفريق.', en: 'Hiring vs attrition by squad.' },
+          action: { ar: 'تحميل ملف Excel', en: 'Download Excel' },
+          placeholder: { ar: 'مخطط القوى العاملة', en: 'Headcount chart' }
+        },
+        {
+          id: 'roles',
+          type: 'list',
+          title: { ar: 'أهم الوظائف المفتوحة', en: 'Priority open roles' },
+          action: { ar: 'تحديث منذ 1 دقيقة', en: 'Refreshed 1 minute ago' },
+          items: [
+            { icon: 'briefcase', title: { ar: 'قائد هندسة منصات', en: 'Platform engineering lead' }, subtitle: { ar: 'المرحلة: مقابلات نهائية', en: 'Stage: Final interviews' }, value: 'مرشحان', delta: { ar: 'تعيين خلال أسبوع', en: 'Offer in 1 week' } },
+            { icon: 'sparkles', title: { ar: 'مدير نجاح عملاء', en: 'Customer success manager' }, subtitle: { ar: 'الموقع: دبي', en: 'Location: Dubai' }, value: '5 مرشحين', delta: { ar: 'تمت جدولة تمارين الحالة', en: 'Case rounds scheduled' } },
+            { icon: 'users', title: { ar: 'محلل شؤون موظفين', en: 'People analytics specialist' }, subtitle: { ar: 'المسار: تقييم المهارات', en: 'Stage: Skills assessment' }, value: '3 مرشحين', delta: { ar: 'قائمة مختصرة اليوم', en: 'Shortlist today' } }
+          ]
+        },
+        {
+          id: 'development-progress',
+          type: 'progress',
+          title: { ar: 'برامج التطوير', en: 'Development programs' },
+          items: [
+            { title: { ar: 'مسار القيادات الناشئة', en: 'Emerging leaders' }, subtitle: { ar: 'اكتمال 28 من أصل 30 وحدة', en: '28 of 30 modules complete' }, value: '93%', percent: '93%' },
+            { title: { ar: 'برنامج المهندسين الجدد', en: 'New engineers bootcamp' }, subtitle: { ar: 'الفوج الخامس قيد التنفيذ', en: 'Cohort 5 in progress' }, value: '61%', percent: '61%' },
+            { title: { ar: 'التعلم المستمر', en: 'Continuous learning credits' }, subtitle: { ar: 'استهلاك 72% من الميزانية', en: '72% credit usage' }, value: '72%', percent: '72%' }
+          ]
+        },
+        {
+          id: 'diversity',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'مصفوفة التنوع والإنصاف', en: 'Diversity & equity matrix' },
+          action: { ar: 'إرسال تقرير القيادة', en: 'Send leadership report' },
+          headers: [
+            { ar: 'الفريق', en: 'Team' },
+            { ar: 'تمثيل النساء', en: 'Women representation' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: 'الهندسة', en: 'Engineering' }, metric: '34%', delta: { ar: '+4% بعد حملة التوظيف', en: '+4% after hiring sprint' }, trend: 'positive' },
+            { name: { ar: 'المنتج', en: 'Product' }, metric: '48%', delta: { ar: 'مستقر', en: 'Flat' }, trend: 'neutral' },
+            { name: { ar: 'النجاح التجاري', en: 'Commercial success' }, metric: '55%', delta: { ar: '+2% مقابل الهدف', en: '+2% vs target' }, trend: 'positive' }
+          ]
+        },
+        {
+          id: 'people-updates',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أبرز تحديثات الناس والثقافة', en: 'People & culture updates' },
+          items: [
+            { icon: 'users', title: { ar: 'برنامج الإرشاد الموسع', en: 'Expanded mentoring program' }, subtitle: { ar: '75 زوج إرشادي نشط', en: '75 mentor pairs active' }, time: { ar: 'قبل ساعة', en: '1 hour ago' } },
+            { icon: 'heart', title: { ar: 'إطلاق مبادرة التوازن الصحي', en: 'Wellbeing balance initiative' }, subtitle: { ar: 'جلسات يوغا أسبوعية لجميع المواقع', en: 'Weekly yoga across hubs' }, time: { ar: 'اليوم', en: 'Today' } },
+            { icon: 'sparkles', title: { ar: 'حفل تكريم الأوائل', en: 'Top talent recognition' }, subtitle: { ar: 'تكريم 18 موظفاً على إنجازاتهم', en: 'Celebrated 18 top performers' }, time: { ar: 'هذا الأسبوع', en: 'Earlier this week' } }
+          ]
+        }
+      ]
+    });
+  </script>
 </body>
 </html>

--- a/dashboards/dashboard-8.html
+++ b/dashboards/dashboard-8.html
@@ -5,220 +5,187 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>لوحة إدارة التعليم الإلكتروني</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
   </style>
 </head>
 <body class="bg-slate-950 text-slate-100">
-  <div class="min-h-screen flex flex-col">
-    <!-- الهيدر -->
-    <header class="border-b border-slate-800 bg-gradient-to-r from-blue-500/10 via-slate-950 to-slate-950">
-      <div class="max-w-7xl mx-auto px-6 py-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <!-- Mobile Header -->
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">L</div>
         <div>
-          <p class="text-xs uppercase tracking-[0.4em] text-blue-300">LearnSphere</p>
-          <h1 class="text-3xl font-bold">لوحة التحليلات التعليمية</h1>
-          <p class="text-slate-300 mt-2">متابعة أداء المتعلمين، الدورات، ونسب الإكمال.</p>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
         </div>
-        <div class="flex flex-wrap gap-3">
-          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">إضافة دورة</button>
-          <button class="px-4 py-2 rounded-xl bg-blue-500 text-sm text-slate-950 font-semibold">تحميل التقارير</button>
-        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
       </div>
     </header>
 
-    <!-- المحتوى الرئيسي -->
-    <main class="flex-1 max-w-7xl mx-auto w-full px-6 py-10 space-y-8">
-      <!-- إحصائيات -->
-      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">إجمالي المتعلمين</p>
-          <p class="mt-3 text-3xl font-semibold">18,420</p>
-          <p class="mt-2 text-emerald-300 text-sm">+640 خلال الأسبوع</p>
-        </div>
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">نسبة الإكمال</p>
-          <p class="mt-3 text-3xl font-semibold">72%</p>
-          <p class="mt-2 text-xs text-slate-500">الهدف: 78%</p>
-        </div>
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">الساعات التدريبية</p>
-          <p class="mt-3 text-3xl font-semibold">4,860</p>
-          <p class="mt-2 text-emerald-300 text-sm">+18% مقارنة بالربع السابق</p>
-        </div>
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
-          <p class="text-sm text-slate-400">المهام المرسلة</p>
-          <p class="mt-3 text-3xl font-semibold">2,430</p>
-          <p class="mt-2 text-amber-300 text-sm">94% معدل تقييم</p>
-        </div>
-      </section>
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
 
-      <!-- منحنى المشاركة + الدورات الأعلى -->
-      <section class="grid gap-6 lg:grid-cols-3">
-        <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-            <div>
-              <h2 class="text-xl font-semibold">منحنى مشاركة المتعلمين</h2>
-              <p class="text-sm text-slate-400">نشاط المنصة خلال آخر 30 يوم</p>
-            </div>
-            <div class="flex gap-3 text-sm">
-              <button class="px-4 py-2 rounded-xl bg-slate-800">أسبوع</button>
-              <button class="px-4 py-2 rounded-xl bg-blue-500 text-slate-950 font-semibold">شهر</button>
-            </div>
-          </div>
-          <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-blue-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط نشاط</div>
-        </div>
-
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-          <div class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold">الدورات الأعلى تقييمًا</h3>
-            <span class="text-xs text-slate-500">تحديث 1 ساعة</span>
-          </div>
-          <div class="space-y-4 text-sm">
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">أساسيات علوم البيانات</p>
-              <p class="text-amber-300 text-xs mt-1">تقييم 4.9 / 5</p>
-            </div>
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">تصميم واجهات حديثة</p>
-              <p class="text-amber-300 text-xs mt-1">تقييم 4.8 / 5</p>
-            </div>
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">إدارة المنتجات الرقمية</p>
-              <p class="text-amber-300 text-xs mt-1">تقييم 4.7 / 5</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- قائمة المتعلمين -->
-      <section class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-        <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6">
+    <!-- Sidebar -->
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">L</div>
           <div>
-            <h2 class="text-xl font-semibold">قائمة المتعلمين النشطين</h2>
-            <p class="text-sm text-slate-400">أعلى معدل تقدم خلال هذا الأسبوع</p>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
-          <button class="px-4 py-2 rounded-xl bg-slate-800 text-sm">تحميل CSV</button>
         </div>
-        <div class="overflow-x-auto">
-          <table class="w-full min-w-[720px] text-sm">
-            <thead>
-              <tr class="text-slate-400">
-                <th class="text-right pb-3 font-medium">المتعلم</th>
-                <th class="text-right pb-3 font-medium">الدورة</th>
-                <th class="text-right pb-3 font-medium">نسبة التقدم</th>
-                <th class="text-right pb-3 font-medium">آخر نشاط</th>
-                <th class="text-right pb-3 font-medium">الحالة</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-800">
-              <tr class="hover:bg-slate-800/40">
-                <td class="py-4 flex items-center gap-3">
-                  <span class="h-10 w-10 rounded-xl bg-blue-500/20 text-blue-200 flex items-center justify-center text-xs">SA</span>
-                  <span>سارة الأنصاري</span>
-                </td>
-                <td>برمجة Python المتقدمة</td>
-                <td class="text-emerald-300">94%</td>
-                <td>قبل 2 ساعة</td>
-                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">مكتمل تقريبًا</span></td>
-              </tr>
-              <tr class="hover:bg-slate-800/40">
-                <td class="py-4 flex items-center gap-3">
-                  <span class="h-10 w-10 rounded-xl bg-blue-500/20 text-blue-200 flex items-center justify-center text-xs">HM</span>
-                  <span>حسين مطر</span>
-                </td>
-                <td>التسويق الرقمي الاحترافي</td>
-                <td class="text-emerald-300">88%</td>
-                <td>قبل 5 ساعات</td>
-                <td><span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">في التقدم</span></td>
-              </tr>
-              <tr class="hover:bg-slate-800/40">
-                <td class="py-4 flex items-center gap-3">
-                  <span class="h-10 w-10 rounded-xl bg-blue-500/20 text-blue-200 flex items-center justify-center text-xs">NR</span>
-                  <span>نور الراشد</span>
-                </td>
-                <td>تحليل البيانات باستخدام SQL</td>
-                <td class="text-emerald-300">81%</td>
-                <td>قبل يوم</td>
-                <td><span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">في المسار</span></td>
-              </tr>
-            </tbody>
-          </table>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
         </div>
-      </section>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
 
-      <!-- أقسام إضافية -->
-      <section class="grid gap-6 lg:grid-cols-3">
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-          <h3 class="text-lg font-semibold">قنوات التعلم</h3>
-          <div class="space-y-4 text-sm">
-            <div class="flex items-center justify-between">
-              <p>مسارات التعلم</p>
-              <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-200">52%</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <p>فصول مباشرة</p>
-              <span class="px-3 py-1 rounded-full bg-blue-500/10 text-blue-200">33%</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <p>تدريب ذاتي</p>
-              <span class="px-3 py-1 rounded-full bg-amber-500/10 text-amber-200">15%</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-          <h3 class="text-lg font-semibold">معدلات النجاح حسب المستوى</h3>
-          <div class="space-y-4 text-sm">
-            <div class="flex items-center justify-between">
-              <p>مبتدئ</p>
-              <div class="flex items-center gap-3">
-                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
-                  <div class="h-full w-[78%] bg-emerald-400"></div>
-                </div>
-                <span class="text-emerald-300">78%</span>
-              </div>
-            </div>
-            <div class="flex items-center justify-between">
-              <p>متوسط</p>
-              <div class="flex items-center gap-3">
-                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
-                  <div class="h-full w-[68%] bg-blue-400"></div>
-                </div>
-                <span class="text-emerald-300">68%</span>
-              </div>
-            </div>
-            <div class="flex items-center justify-between">
-              <p>متقدم</p>
-              <div class="flex items-center gap-3">
-                <div class="h-2 w-24 bg-slate-800 rounded-full overflow-hidden">
-                  <div class="h-full w-[58%] bg-rose-400"></div>
-                </div>
-                <span class="text-emerald-300">58%</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-          <h3 class="text-lg font-semibold">خطط المحتوى المقبلة</h3>
-          <div class="space-y-4 text-sm">
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">برنامج تحليل البيانات المتقدم</p>
-              <p class="text-slate-400 text-xs mt-1">الإطلاق: يونيو</p>
-            </div>
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">معسكر الأمن السيبراني للمبتدئين</p>
-              <p class="text-slate-400 text-xs mt-1">الإطلاق: يوليو</p>
-            </div>
-            <div class="p-4 rounded-xl bg-slate-800/60">
-              <p class="font-semibold">سلسلة إدارة المنتجات</p>
-              <p class="text-slate-400 text-xs mt-1">الإطلاق: أغسطس</p>
-            </div>
-          </div>
-        </div>
-      </section>
+    <!-- Main -->
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
     </main>
   </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة إدارة التعليم الإلكتروني',
+          en: 'E-learning Analytics Dashboard'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
+      brand: {
+        badge: 'L',
+        name: { ar: 'Learning Atlas', en: 'Learning Atlas' },
+        tagline: { ar: 'منصة ذكاء التعلم الرقمي', en: 'Digital learning intelligence' }
+      },
+      theme: {
+        accentGradient: 'from-blue-500 via-sky-400 to-indigo-500',
+        accentText: 'text-sky-200',
+        highlightBg: 'bg-sky-500/10 border-sky-400/30',
+        badgeBg: 'bg-sky-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        { id: 'overview', icon: 'presentation-chart', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'مباشر', en: 'Live' } },
+        { id: 'courses', icon: 'book-open', label: { ar: 'الدورات', en: 'Courses' } },
+        { id: 'learners', icon: 'users', label: { ar: 'المتعلمون', en: 'Learners' } },
+        { id: 'engagement', icon: 'chart-bar', label: { ar: 'التفاعل', en: 'Engagement' } }
+      ],
+      highlight: {
+        label: { ar: 'معدل الإكمال الكلي', en: 'Overall completion rate' },
+        value: '72%',
+        description: {
+          ar: 'تحسن 9 نقاط بعد إطلاق نظام الحوافز الجديد.',
+          en: 'Up 9 points following the new incentive system.'
+        }
+      },
+      header: {
+        title: { ar: 'لوحة تحليلات التعلم', en: 'Learning analytics cockpit' },
+        subtitle: {
+          ar: 'راقب تقدم المتعلمين، أداء الدورات، وتفاعل المحتوى لحظياً.',
+          en: 'Monitor learner progress, course health, and content engagement live.'
+        },
+        primary: { ar: 'إنشاء شهادة مخصصة', en: 'Create custom certificate' },
+        secondary: { ar: 'فلترة حسب الأكاديمية', en: 'Filter by academy' }
+      },
+      stats: [
+        { icon: 'users', label: { ar: 'متعلمين نشطين', en: 'Active learners' }, value: '18,420', delta: { ar: '+1.2K هذا الأسبوع', en: '+1.2k this week' }, trend: 'positive' },
+        { icon: 'book-open', label: { ar: 'نسبة الإكمال', en: 'Completion rate' }, value: '72%', delta: { ar: '+9% منذ الإطلاق', en: '+9% since launch' }, trend: 'positive' },
+        { icon: 'sparkles', label: { ar: 'الدروس الجديدة', en: 'New lessons released' }, value: '48', delta: { ar: '+12 خلال شهر', en: '+12 over month' }, trend: 'positive' },
+        { icon: 'heart', label: { ar: 'تقييم الدورات', en: 'Course satisfaction' }, value: '4.5/5', delta: { ar: '+0.2 عن الربع الماضي', en: '+0.2 vs last quarter' }, trend: 'positive' }
+      ],
+      panels: [
+        {
+          id: 'activity',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'نشاط المتعلمين اليومي', en: 'Daily learner activity' },
+          subtitle: { ar: 'جلسات، دقائق مشاهدة، وتمارين مكتملة.', en: 'Sessions, minutes viewed, and exercises completed.' },
+          action: { ar: 'تحميل ملف CSV', en: 'Download CSV' },
+          placeholder: { ar: 'مخطط نشاط المتعلمين', en: 'Learner activity chart' }
+        },
+        {
+          id: 'top-courses',
+          type: 'list',
+          title: { ar: 'الدورات الأعلى تقييماً', en: 'Top-rated courses' },
+          action: { ar: 'بيانات آخر 24 ساعة', en: 'Last 24h data' },
+          items: [
+            { icon: 'presentation-chart', title: { ar: 'تصميم تجربة المستخدم', en: 'UX design mastery' }, subtitle: { ar: 'نسبة الإكمال 84%', en: 'Completion 84%' }, value: '4.8★', delta: { ar: '+320 متعلماً جديداً', en: '+320 new learners' } },
+            { icon: 'sparkles', title: { ar: 'أساسيات الذكاء الاصطناعي', en: 'AI foundations' }, subtitle: { ar: 'مسار من 8 وحدات', en: '8-module pathway' }, value: '4.6★', delta: { ar: 'قوائم انتظار 140', en: 'Waitlist 140' } },
+            { icon: 'book-open', title: { ar: 'مهارات القيادة الحديثة', en: 'Modern leadership skills' }, subtitle: { ar: 'برنامج معتمد', en: 'Accredited program' }, value: '4.7★', delta: { ar: '98% رضا المتعلمين', en: '98% learner delight' } }
+          ]
+        },
+        {
+          id: 'learning-paths',
+          type: 'progress',
+          title: { ar: 'تقدم المسارات التعليمية', en: 'Learning path progress' },
+          items: [
+            { title: { ar: 'مسار المطور الشامل', en: 'Full-stack developer path' }, subtitle: { ar: '1,240 متعلماً نشطاً', en: '1,240 active learners' }, value: '64%', percent: '64%' },
+            { title: { ar: 'مسار نجاح العملاء', en: 'Customer success path' }, subtitle: { ar: 'جدولة ورشة مباشرة', en: 'Live workshop scheduled' }, value: '58%', percent: '58%' },
+            { title: { ar: 'مسار القيادة التنفيذية', en: 'Executive leadership path' }, subtitle: { ar: 'تقييم القيادة النهائي الأسبوع المقبل', en: 'Final leadership assessment next week' }, value: '41%', percent: '41%' }
+          ]
+        },
+        {
+          id: 'learner-progress',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'تقدم المتعلمين المميز', en: 'Featured learner progress' },
+          action: { ar: 'إرسال المتابعة', en: 'Send follow-up' },
+          headers: [
+            { ar: 'المتعلم', en: 'Learner' },
+            { ar: 'المسار', en: 'Path' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: 'نورة العتيبي', en: 'Noura Al-Otaibi' }, metric: '92% - مسار تحليل البيانات', delta: { ar: '+12% هذا الأسبوع', en: '+12% this week' }, trend: 'positive' },
+            { name: { ar: 'ليلى المصري', en: 'Leila El-Masry' }, metric: '78% - مسار الذكاء الاصطناعي', delta: { ar: '+6% بعد جلسة الإرشاد', en: '+6% post mentoring' }, trend: 'positive' },
+            { name: { ar: 'جاسم القحطاني', en: 'Jasem Al-Qahtani' }, metric: '56% - مسار القيادة', delta: { ar: 'يحتاج متابعة', en: 'Needs nudges' }, trend: 'neutral' }
+          ]
+        },
+        {
+          id: 'academy-updates',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'تحديثات الأكاديمية', en: 'Academy updates' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'إطلاق معمل الواقع الافتراضي', en: 'VR practice lab launch' }, subtitle: { ar: 'دعم التمارين العملية لمهارات الواقع الافتراضي', en: 'Hands-on VR skill drills available' }, time: { ar: 'قبل 3 ساعات', en: '3 hours ago' } },
+            { icon: 'book-open', title: { ar: 'تعاون مع جامعة دولية', en: 'New university partnership' }, subtitle: { ar: 'شهادات مشتركة في علوم البيانات', en: 'Joint certifications in data science' }, time: { ar: 'اليوم', en: 'Today' } },
+            { icon: 'presentation-chart', title: { ar: 'ندوة مباشرة حول التعلم المصغر', en: 'Microlearning live seminar' }, subtitle: { ar: 'حضور أكثر من 2,100 متعلم', en: '2,100+ attendees' }, time: { ar: 'أمس', en: 'Yesterday' } }
+          ]
+        }
+      ]
+    });
+  </script>
 </body>
 </html>

--- a/dashboards/dashboard-9.html
+++ b/dashboards/dashboard-9.html
@@ -5,145 +5,187 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>لوحة أمن المعلومات</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
   </style>
 </head>
-<body class="bg-slate-950 text-slate-100"> 
-  <div class="min-h-screen">
-    <!-- الهيدر للموبايل -->
-    <div class="lg:hidden flex items-center justify-between border-b border-slate-800 bg-slate-900/80 px-4 py-4">
-      <div>
-        <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Cyber Shield</p>
-        <h1 class="text-lg font-semibold">لوحة أمن المعلومات</h1>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <!-- Mobile Header -->
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">S</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
       </div>
-      <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-slate-700 px-4 py-2 text-sm font-semibold text-white">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <span>فتح القائمة</span>
-      </button>
-    </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
 
-    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-slate-950/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+    <!-- Mobile Backdrop -->
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
 
-    <div class="lg:flex lg:flex-row">
-      <!-- القائمة الجانبية -->
-      <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-slate-800 bg-gradient-to-b from-slate-700/40 via-slate-950 to-slate-950 p-6 space-y-8 transform translate-x-full transition-transform duration-300 ease-in-out backdrop-blur-sm lg:static lg:w-80 lg:translate-x-0 lg:bg-gradient-to-b lg:from-slate-700/30 lg:via-slate-950 lg:to-slate-950">
-        <div class="flex items-start justify-between gap-3">
+    <!-- Sidebar -->
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">S</div>
           <div>
-            <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Cyber Shield</p>
-            <h1 class="text-3xl font-bold">لوحة أمن المعلومات</h1>
-            <p class="text-sm text-slate-400 mt-2">مراقبة التهديدات، الامتثال، والاستجابة.</p>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
           </div>
-          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-1 rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-300">
-            <span>إغلاق</span>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
 
-        <!-- مثال على صندوق إحصائيات -->
-        <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-5 text-sm space-y-3">
-          <div class="flex items-center justify-between">
-            <p class="text-slate-400">مستوى الخطر</p>
-            <span class="px-3 py-1 rounded-full bg-rose-500/20 text-rose-200">متوسط</span>
-          </div>
-          <div class="flex items-center justify-between">
-            <p class="text-slate-400">أحداث اليوم</p>
-            <span class="text-lg font-semibold">42</span>
-          </div>
-          <p class="text-xs text-slate-500">تم إغلاق 36 حدث وتم تصعيد 6.</p>
-        </div>
+    <!-- Main -->
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
 
-        <!-- فلاتر -->
-        <div class="space-y-2 text-sm">
-          <p class="text-xs uppercase text-slate-500">الفلاتر</p>
-          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/60 text-right">جميع الأنظمة</button>
-          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">النقاط الطرفية</button>
-          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">الخوادم</button>
-          <button class="w-full px-4 py-3 rounded-xl bg-slate-800/20 text-right">الشبكات</button>
-        </div>
-      </aside>
-
-      <!-- المحتوى الرئيسي -->
-      <main class="flex-1 p-6 lg:p-10 space-y-8 lg:pr-10">
-        <!-- مثال على قسم إحصائيات -->
-        <section class="grid gap-6 lg:grid-cols-3">
-          <div class="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-              <div>
-                <h2 class="text-xl font-semibold">زمن الاستجابة للحوادث</h2>
-                <p class="text-sm text-slate-400">متوسط الزمن لكل مستوى خطورة</p>
-              </div>
-              <div class="flex gap-3 text-sm">
-                <button class="px-4 py-2 rounded-xl bg-slate-800">آخر 24 ساعة</button>
-                <button class="px-4 py-2 rounded-xl bg-slate-600 text-white font-semibold">آخر 7 أيام</button>
-              </div>
-            </div>
-            <div class="h-64 rounded-xl border border-slate-800 bg-gradient-to-br from-slate-500/10 via-slate-900 to-slate-900 flex items-center justify-center text-slate-500">مخطط الأعمدة</div>
-          </div>
-
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 space-y-5">
-            <div class="flex items-center justify-between">
-              <h3 class="text-lg font-semibold">مؤشر الامتثال</h3>
-              <span class="text-xs text-slate-500">محدث الآن</span>
-            </div>
-            <div class="space-y-4 text-sm">
-              <div class="flex items-center justify-between">
-                <span>ISO 27001</span>
-                <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">متوافق</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span>NIST</span>
-                <span class="px-3 py-1 rounded-full bg-amber-500/20 text-amber-200">قيد التحسين</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span>CIS</span>
-                <span class="px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-200">متوافق</span>
-              </div>
-            </div>
-          </div>
-        </section>
-      </main>
-    </div>
-  </div> 
-
-  <!-- سكربت التحكم في القائمة الجانبية -->
+  <script src="dashboard-common.js"></script>
   <script>
-    (function () {
-      const sidebar = document.getElementById('sidebar');
-      const toggle = document.getElementById('sidebarToggle');
-      const close = document.getElementById('sidebarClose');
-      const backdrop = document.getElementById('sidebarBackdrop');
-      const body = document.body;
-
-      if (!sidebar || !toggle || !close || !backdrop) return;
-
-      const openSidebar = () => {
-        sidebar.classList.remove('translate-x-full');
-        backdrop.classList.remove('opacity-0', 'pointer-events-none');
-        backdrop.classList.add('opacity-100');
-        body.classList.add('overflow-hidden');
-      };
-
-      const closeSidebar = () => {
-        sidebar.classList.add('translate-x-full');
-        backdrop.classList.add('opacity-0', 'pointer-events-none');
-        backdrop.classList.remove('opacity-100');
-        body.classList.remove('overflow-hidden');
-      };
-
-      toggle.addEventListener('click', openSidebar);
-      close.addEventListener('click', closeSidebar);
-      backdrop.addEventListener('click', closeSidebar);
-
-      window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') closeSidebar();
-      });
-    })();
-  </script> 
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة أمن المعلومات',
+          en: 'Cyber Security Dashboard'
+        }
+      },
+      actions: {
+        open: { ar: 'فتح القائمة', en: 'Open menu' },
+        close: { ar: 'إغلاق', en: 'Close' },
+        collapse: { ar: 'طي الشريط الجانبي', en: 'Collapse sidebar' },
+        expand: { ar: 'توسيع الشريط الجانبي', en: 'Expand sidebar' }
+      },
+      brand: {
+        badge: 'S',
+        name: { ar: 'Security Nexus', en: 'Security Nexus' },
+        tagline: { ar: 'مركز القيادة والامتثال', en: 'Threat & compliance command' }
+      },
+      theme: {
+        accentGradient: 'from-slate-600 via-emerald-500 to-slate-800',
+        accentText: 'text-emerald-300',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        { id: 'overview', icon: 'shield', label: { ar: 'نظرة عامة', en: 'Overview' }, badge: { ar: 'مراقبة', en: 'Monitoring' } },
+        { id: 'threats', icon: 'sparkles', label: { ar: 'التهديدات', en: 'Threats' } },
+        { id: 'compliance', icon: 'scale', label: { ar: 'الامتثال', en: 'Compliance' } },
+        { id: 'response', icon: 'calendar', label: { ar: 'الاستجابة', en: 'Response' } }
+      ],
+      highlight: {
+        label: { ar: 'مستوى الخطر الحالي', en: 'Current risk level' },
+        value: { ar: 'مرتفع معتدل', en: 'Elevated' },
+        description: {
+          ar: 'نشاط برمجيات خبيثة في مركز بيانات أوروبا، تم تفعيل العزل.',
+          en: 'Malware activity in EU datacentre, containment activated.'
+        }
+      },
+      header: {
+        title: { ar: 'لوحة قيادة الأمن السيبراني', en: 'Cyber defence cockpit' },
+        subtitle: {
+          ar: 'تابع التهديدات، الامتثال، وسرعة الاستجابة لحوادث الأمن الرقمي.',
+          en: 'Track threats, compliance posture, and incident response velocity.'
+        },
+        primary: { ar: 'إطلاق تحليل الأصول', en: 'Launch asset scan' },
+        secondary: { ar: 'عرض بروتوكول الطوارئ', en: 'View emergency protocol' }
+      },
+      stats: [
+        { icon: 'sparkles', label: { ar: 'تهديدات نشطة', en: 'Active threats' }, value: '12', delta: { ar: '−5 خلال 24 ساعة', en: '−5 in 24h' }, trend: 'positive' },
+        { icon: 'clock', label: { ar: 'متوسط زمن الاستجابة', en: 'Average response time' }, value: '14 دقيقة', delta: { ar: 'الهدف 20 دقيقة', en: 'Target 20 minutes' }, trend: 'positive' },
+        { icon: 'scale', label: { ar: 'حالات الامتثال', en: 'Compliance cases' }, value: '3', delta: { ar: 'تحت المراجعة', en: 'Under review' }, trend: 'neutral' },
+        { icon: 'shield', label: { ar: 'الحوادث خلال 24 ساعة', en: 'Incidents last 24h' }, value: '4', delta: { ar: '+1 مقارنة بالأمس', en: '+1 vs yesterday' }, trend: 'negative' }
+      ].map(stat => ({ ...stat, icon: stat.icon === 'clock' ? 'calendar' : stat.icon })),
+      panels: [
+        {
+          id: 'threat-levels',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مستويات التهديد حسب السطح', en: 'Threat levels by surface' },
+          subtitle: { ar: 'الشبكة، المستخدمون المميزون، وواجهات التطبيقات.', en: 'Network, privileged users, and application interfaces.' },
+          action: { ar: 'تصدير JSON', en: 'Export JSON' },
+          placeholder: { ar: 'مخطط مستويات التهديد', en: 'Threat level chart' }
+        },
+        {
+          id: 'alerts',
+          type: 'list',
+          title: { ar: 'تنبيهات ذات أولوية', en: 'Priority alerts' },
+          action: { ar: 'تحديث منذ دقيقة', en: 'Updated 1 minute ago' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'Ransomware - خدمة الملفات', en: 'Ransomware - file service' }, subtitle: { ar: 'تم عزل عقدة التخزين', en: 'Storage node isolated' }, value: 'P1', delta: { ar: 'فريق الاستجابة يعمل', en: 'IR team engaged' } },
+            { icon: 'shield', title: { ar: 'توقيع دخول مريب', en: 'Suspicious privileged login' }, subtitle: { ar: 'مستخدم من سنغافورة', en: 'User from Singapore' }, value: 'مراقبة', delta: { ar: 'يتطلب MFA إضافي', en: 'Extra MFA required' } },
+            { icon: 'cloud', title: { ar: 'كشف نشاط API غير معتاد', en: 'Anomalous API activity' }, subtitle: { ar: 'معدل مكالمات مرتفع', en: 'Elevated call rate' }, value: 'P2', delta: { ar: 'أرسل إلى فريق المنصة', en: 'Forwarded to platform team' } }
+          ]
+        },
+        {
+          id: 'response-readiness',
+          type: 'progress',
+          title: { ar: 'جاهزية الاستجابة للحوادث', en: 'Incident response readiness' },
+          items: [
+            { title: { ar: 'تحليل الحوادث', en: 'Triage analysis' }, subtitle: { ar: 'تغطية 24/7 عبر 3 فرق', en: '24/7 coverage across 3 squads' }, value: '88%', percent: '88%' },
+            { title: { ar: 'التصعيد والاحتواء', en: 'Escalation & containment' }, subtitle: { ar: 'أتمتة قواعد العزل', en: 'Automated isolation rules' }, value: '74%', percent: '74%' },
+            { title: { ar: 'المراجعة اللاحقة', en: 'Post-incident review' }, subtitle: { ar: 'سجل تقارير آخر 90 يوم', en: 'Reviews logged for last 90 days' }, value: '61%', percent: '61%' }
+          ]
+        },
+        {
+          id: 'attack-surface',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'مراقبة سطح الهجوم', en: 'Attack surface watchlist' },
+          action: { ar: 'مزامنة مع CMDB', en: 'Sync with CMDB' },
+          headers: [
+            { ar: 'الأصل', en: 'Asset' },
+            { ar: 'الحالة', en: 'Status' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            { name: { ar: 'بوابة العملاء', en: 'Customer gateway' }, metric: 'متصل بنظام WAF', delta: { ar: 'تقليل 32% من الهجمات', en: 'Blocked 32% attacks' }, trend: 'positive' },
+            { name: { ar: 'نظام الموارد البشرية', en: 'HR platform' }, metric: 'تحديث تصحيحات متأخر', delta: { ar: 'قيد النشر هذا المساء', en: 'Patch roll-out tonight' }, trend: 'neutral' },
+            { name: { ar: 'خدمة التخزين السحابي', en: 'Cloud storage service' }, metric: 'إشعار نشاط عالي', delta: { ar: '+12% عمليات تحميل غير معتادة', en: '+12% anomalous uploads' }, trend: 'negative' }
+          ]
+        },
+        {
+          id: 'incident-timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'خط زمني للحوادث الأخيرة', en: 'Latest incident timeline' },
+          items: [
+            { icon: 'sparkles', title: { ar: 'احتواء ملف خبيث', en: 'Malicious file contained' }, subtitle: { ar: 'تم إيقاف الحاويات المتأثرة', en: 'Impacted containers halted' }, time: { ar: 'قبل 20 دقيقة', en: '20 minutes ago' } },
+            { icon: 'scale', title: { ar: 'مراجعة امتثال PCI', en: 'PCI compliance audit' }, subtitle: { ar: 'إغلاق ملاحظتين ثانويتين', en: 'Closed two minor findings' }, time: { ar: 'اليوم', en: 'Today' } },
+            { icon: 'calendar', title: { ar: 'اختبار خطة الطوارئ', en: 'Disaster recovery drill' }, subtitle: { ar: 'اجتياز الاختبار دون تأثير', en: 'Passed without impact' }, time: { ar: 'أمس', en: 'Yesterday' } }
+          ]
+        }
+      ]
+    });
+  </script>
 </body>
 </html>

--- a/dashboards/dashboard-common.js
+++ b/dashboards/dashboard-common.js
@@ -33,7 +33,8 @@
     'film': 'M4.5 3A1.5 1.5 0 0 0 3 4.5v15A1.5 1.5 0 0 0 4.5 21H6v-4.5h3V21h6v-4.5h3V21h1.5a1.5 1.5 0 0 0 1.5-1.5v-15A1.5 1.5 0 0 0 19.5 3H18v4.5h-3V3H9v4.5H6V3H4.5z',
     'globe-alt': 'M12 2.25c-5.108 0-9.25 4.142-9.25 9.25s4.142 9.25 9.25 9.25 9.25-4.142 9.25-9.25S17.108 2.25 12 2.25zm7.698 8.25H15.7a15.81 15.81 0 0 0-1.124-5.098 7.754 7.754 0 0 1 5.122 5.098zM12 3.75c1.486 0 3.577 2.735 3.963 6.75H8.037C8.423 6.485 10.514 3.75 12 3.75zM7.3 12.75h9.4a15.81 15.81 0 0 1-1.124 5.098A7.754 7.754 0 0 1 7.3 12.75zm3.741 5.848A15.872 15.872 0 0 1 7.2 12.75H4.302a7.754 7.754 0 0 0 6.739 5.848zm6.017-5.848a15.872 15.872 0 0 1-3.841 5.848 7.754 7.754 0 0 0 6.739-5.848H17.058zM4.302 11.25H7.3A15.81 15.81 0 0 1 8.424 6.152 7.754 7.754 0 0 0 4.302 11.25z',
     'leaf': 'M12.75 3a9.75 9.75 0 0 1 9.75 9.75 9.75 9.75 0 0 1-12.6 9.303A5.251 5.251 0 0 1 5.5 17.25H4.125a2.625 2.625 0 0 1-2.625-2.625v-.375A11.25 11.25 0 0 1 12.75 3zm-4.5 9.75a4.5 4.5 0 0 0-4.5 4.5c0 .621.504 1.125 1.125 1.125h1.375a3.75 3.75 0 0 0 3.75-3.75v-1.875z',
-    'basketball': 'M12 2.25A9.75 9.75 0 1 0 21.75 12 9.75 9.75 0 0 0 12 2.25zm7.314 8.25h-4.564a12.3 12.3 0 0 0-.753-4.43A8.255 8.255 0 0 1 19.314 10.5zm-6.064 0H10.75V4.058a10.77 10.77 0 0 1 2.5 6.442zm-3.5 0H4.686a8.255 8.255 0 0 1 5.317-6.68 12.3 12.3 0 0 0-.753 4.43zm0 3h2.5v6.442a10.77 10.77 0 0 1-2.5-6.442zm3.5 0h4.564a8.255 8.255 0 0 1-5.317 6.68 12.3 12.3 0 0 0 .753-4.43zm-6.81 0a12.3 12.3 0 0 0 .753 4.43A8.255 8.255 0 0 1 4.686 13.5z'
+    'basketball': 'M12 2.25A9.75 9.75 0 1 0 21.75 12 9.75 9.75 0 0 0 12 2.25zm7.314 8.25h-4.564a12.3 12.3 0 0 0-.753-4.43A8.255 8.255 0 0 1 19.314 10.5zm-6.064 0H10.75V4.058a10.77 10.77 0 0 1 2.5 6.442zm-3.5 0H4.686a8.255 8.255 0 0 1 5.317-6.68 12.3 12.3 0 0 0-.753 4.43zm0 3h2.5v6.442a10.77 10.77 0 0 1-2.5-6.442zm3.5 0h4.564a8.255 8.255 0 0 1-5.317 6.68 12.3 12.3 0 0 0 .753-4.43zm-6.81 0a12.3 12.3 0 0 0 .753 4.43A8.255 8.255 0 0 1 4.686 13.5z',
+    'sidebar-toggle': 'M4 6a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1zm0 6a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1zm0 6a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1z'
   };
 
   function createIcon(name, classes) {
@@ -64,10 +65,119 @@
       theme.body.split(' ').forEach(cls => cls && body.classList.add(cls));
     }
 
+    const styleId = 'dashboard-collapsible-style';
+    if (!document.getElementById(styleId)) {
+      const style = document.createElement('style');
+      style.id = styleId;
+      style.textContent = `
+        @media (min-width: 1024px) {
+          #sidebar {
+            transition: width 0.3s ease, padding 0.3s ease;
+          }
+          body.sidebar-mini #sidebar {
+            width: 6rem;
+            padding-inline: 1rem;
+          }
+          body.sidebar-mini #sidebar [data-role="brand-name"],
+          body.sidebar-mini #sidebar [data-role="brand-tagline"],
+          body.sidebar-mini #sidebar [data-role="sidebar-highlight"] {
+            display: none !important;
+          }
+          body.sidebar-mini #sidebar nav a {
+            padding-inline: 0.75rem;
+          }
+          body.sidebar-mini #sidebar nav a .sidebar-link-content {
+            justify-content: center;
+            gap: 0;
+          }
+          body.sidebar-mini #sidebar nav a .sidebar-icon {
+            margin-inline-end: 0;
+          }
+          body.sidebar-mini #sidebar nav a .sidebar-label,
+          body.sidebar-mini #sidebar nav a .sidebar-badge {
+            display: none !important;
+          }
+          body.sidebar-mini #sidebarCollapse {
+            width: 100%;
+            justify-content: center;
+          }
+          body.sidebar-mini #sidebarCollapse [data-role="collapse-label"] {
+            display: none;
+          }
+        }
+      `;
+      document.head.appendChild(style);
+    }
+
+    const defaultActions = {
+      open: { ar: 'فتح القائمة', en: 'Open menu' },
+      close: { ar: 'إغلاق', en: 'Close' },
+      collapse: { ar: 'تصغير القائمة الجانبية', en: 'Collapse sidebar' },
+      expand: { ar: 'توسيع القائمة الجانبية', en: 'Expand sidebar' }
+    };
+
+    const providedActions = Object.assign({}, config.actions || {});
+    config.actions = {};
+    Object.keys(defaultActions).forEach(key => {
+      config.actions[key] = Object.assign({}, defaultActions[key], providedActions[key] || {});
+    });
+
     const sidebar = document.getElementById('sidebar');
     const sidebarBackdrop = document.getElementById('sidebarBackdrop');
     const sidebarToggle = document.getElementById('sidebarToggle');
     const sidebarClose = document.getElementById('sidebarClose');
+
+    const storageKey = config.storageKey || `dashboard-mini-${window.location.pathname}`;
+    let isMini = false;
+    try {
+      isMini = window.localStorage.getItem(storageKey) === '1';
+    } catch (error) {
+      isMini = false;
+    }
+
+    let collapseButton = null;
+
+    function updateCollapseButton(lang) {
+      if (!collapseButton) return;
+      const label = collapseButton.querySelector('[data-role="collapse-label"]');
+      const text = isMini ? config.actions.expand[lang] : config.actions.collapse[lang];
+      if (label) {
+        label.textContent = text;
+      }
+      collapseButton.setAttribute('aria-label', text);
+      collapseButton.title = text;
+      collapseButton.setAttribute('aria-pressed', isMini ? 'true' : 'false');
+    }
+
+    function applyMiniState(mini, lang = 'ar') {
+      if (!sidebar) return;
+      isMini = mini;
+      body.classList.toggle('sidebar-mini', mini);
+      try {
+        window.localStorage.setItem(storageKey, mini ? '1' : '0');
+      } catch (error) {
+        /* ignore persistence issues */
+      }
+      updateCollapseButton(lang);
+    }
+
+    if (sidebar) {
+      const actionsContainer = sidebar.querySelector('[data-role="sidebar-actions"]') || sidebar;
+      collapseButton = document.createElement('button');
+      collapseButton.type = 'button';
+      collapseButton.id = 'sidebarCollapse';
+      collapseButton.className = 'hidden lg:inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200 hover:bg-white/5 transition';
+      collapseButton.innerHTML = `
+        <span class="h-5 w-5 flex items-center justify-center text-slate-200">
+          ${createIcon('sidebar-toggle', 'h-4 w-4')}
+        </span>
+        <span data-role="collapse-label" class="whitespace-nowrap"></span>
+      `;
+      actionsContainer.prepend(collapseButton);
+      collapseButton.addEventListener('click', () => {
+        applyMiniState(!isMini, currentLang);
+      });
+    }
 
     function openSidebar() {
       if (!sidebar) return;
@@ -156,14 +266,16 @@
         link.href = `#${item.id}`;
         link.className = `flex items-center justify-between px-4 py-3 rounded-xl border ${index === 0 ? 'bg-white/10 border-white/10' : 'border-white/5 hover:bg-white/5'} transition`;
         link.innerHTML = `
-          <span class="flex items-center gap-3 text-sm">
-            <span class="h-9 w-9 rounded-xl flex items-center justify-center bg-white/5">
+          <span class="flex items-center gap-3 text-sm sidebar-link-content">
+            <span class="h-9 w-9 rounded-xl flex items-center justify-center bg-white/5 sidebar-icon">
               ${createIcon(item.icon, `h-5 w-5 ${theme.accentText}`)}
             </span>
-            <span class="font-medium">${item.label[lang]}</span>
+            <span class="font-medium sidebar-label">${item.label[lang]}</span>
           </span>
-          <span class="text-xs text-slate-400">${item.badge ? item.badge[lang] : ''}</span>
+          <span class="text-xs text-slate-400 sidebar-badge">${item.badge ? item.badge[lang] : ''}</span>
         `;
+        link.setAttribute('aria-label', item.label[lang]);
+        link.title = item.label[lang];
         navContainer.appendChild(link);
       });
     }
@@ -171,10 +283,13 @@
     function renderHighlight(lang) {
       const highlight = document.querySelector('[data-role="sidebar-highlight"]');
       if (!highlight || !config.highlight) return;
+      const highlightValue = typeof config.highlight.value === 'object'
+        ? config.highlight.value[lang]
+        : config.highlight.value;
       highlight.innerHTML = `
         <div class="rounded-2xl border ${theme.highlightBg} p-5 space-y-3">
           <p class="text-xs uppercase tracking-wide text-slate-400">${config.highlight.label[lang]}</p>
-          <p class="text-2xl font-semibold">${config.highlight.value}</p>
+          <p class="text-2xl font-semibold">${highlightValue}</p>
           <p class="text-sm text-slate-300">${config.highlight.description[lang]}</p>
         </div>
       `;
@@ -356,8 +471,10 @@
       const closeLabel = document.querySelector('[data-role="close-label"]');
       if (openLabel) openLabel.textContent = config.actions.open[lang];
       if (closeLabel) closeLabel.textContent = config.actions.close[lang];
+      applyMiniState(isMini, lang);
     }
 
+    applyMiniState(isMini, currentLang);
     setLanguage(currentLang);
   }
 


### PR DESCRIPTION
## Summary
- add a reusable mini-sidebar control with persistence and localization to the shared dashboard script
- rebuild dashboards 3-9 on the interactive template with complete bilingual data for each vertical
- tag existing sidebars with an actions container so the collapse toggle renders consistently across dashboards

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d871f81628832f90ee668f228407f1