### PR TITLE
Refine dashboards with animated theming and mini sidebars

### DIFF
--- a/dashboard-gallery.html
+++ b/dashboard-gallery.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>معرض لوحات التحكم - TailwindCSS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-900 text-slate-100 min-h-screen">
+  <header class="relative overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-indigo-500/20 via-slate-900 to-slate-900"></div>
+    <div class="relative max-w-6xl mx-auto px-6 py-20 space-y-10">
+      <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div class="space-y-6 max-w-3xl">
+          <div class="space-y-4">
+            <p data-i18n="hero-tag" class="text-indigo-300 text-sm uppercase tracking-widest">TailwindCSS Premium</p>
+            <h1 data-i18n="hero-title" class="text-4xl md:text-5xl font-bold">أفضل 20 تصميمًا متجاوبًا للوحات التحكم</h1>
+            <p data-i18n="hero-description" class="text-slate-300">
+              استكشف مجموعة من لوحات التحكم المتكاملة المبنية بـ TailwindCSS مع دعم كامل للغتين العربية والإنجليزية.
+              كل تصميم مجهز للمنتجات الحديثة ويأتي بواجهة متجاوبة تدعم مختلف الأجهزة.
+            </p>
+          </div>
+          <div data-role="hero-badges" class="flex flex-wrap gap-3"></div>
+        </div>
+        <div class="self-start">
+          <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-6 pb-20 space-y-8">
+    <h2 data-i18n="section-title" class="text-2xl font-semibold">اختر تصميمك المفضل</h2>
+    <div data-role="card-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"></div>
+  </main>
+
+  <footer class="border-t border-slate-800 py-8">
+    <div class="max-w-6xl mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+      <p data-i18n="footer-text">© 2024 لوحات تحكم Tailwind. جميع الحقوق محفوظة.</p>
+      <div class="flex gap-4">
+        <a href="#" data-i18n="footer-privacy" class="hover:text-slate-200">سياسة الخصوصية</a>
+        <a href="#" data-i18n="footer-terms" class="hover:text-slate-200">شروط الاستخدام</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      const html = document.documentElement;
+      const body = document.body;
+
+      const translations = {
+        pageTitle: {
+          ar: 'معرض لوحات التحكم - TailwindCSS',
+          en: 'Dashboard Gallery - TailwindCSS'
+        },
+        heroTag: {
+          ar: 'TailwindCSS Premium',
+          en: 'TailwindCSS Premium'
+        },
+        heroTitle: {
+          ar: 'أفضل 20 تصميمًا متجاوبًا للوحات التحكم',
+          en: 'Top 20 responsive dashboard designs'
+        },
+        heroDescription: {
+          ar: 'استكشف مجموعة من لوحات التحكم المتكاملة المبنية بـ TailwindCSS مع دعم كامل للغتين العربية والإنجليزية. كل تصميم مجهز للمنتجات الحديثة ويأتي بواجهة متجاوبة تدعم مختلف الأجهزة.',
+          en: 'Explore a curated set of TailwindCSS dashboards with full Arabic and English support. Each layout is production-ready and adapts beautifully to every device.'
+        },
+        sectionTitle: {
+          ar: 'اختر تصميمك المفضل',
+          en: 'Pick your favorite layout'
+        },
+        footerText: {
+          ar: '© 2024 لوحات تحكم Tailwind. جميع الحقوق محفوظة.',
+          en: '© 2024 Tailwind Dashboards. All rights reserved.'
+        },
+        footerPrivacy: {
+          ar: 'سياسة الخصوصية',
+          en: 'Privacy policy'
+        },
+        footerTerms: {
+          ar: 'شروط الاستخدام',
+          en: 'Terms of use'
+        },
+        linkLabel: {
+          ar: 'استعراض التصميم →',
+          en: 'View dashboard →'
+        },
+        badges: [
+          {
+            classes: 'px-4 py-2 bg-indigo-500/20 text-indigo-200 rounded-full text-sm',
+            text: {
+              ar: 'متجاوبة بالكامل',
+              en: 'Fully responsive'
+            }
+          },
+          {
+            classes: 'px-4 py-2 bg-emerald-500/20 text-emerald-200 rounded-full text-sm',
+            text: {
+              ar: 'واجهات غنية بالبيانات',
+              en: 'Data-rich interfaces'
+            }
+          },
+          {
+            classes: 'px-4 py-2 bg-amber-500/20 text-amber-200 rounded-full text-sm',
+            text: {
+              ar: 'دعم عربي وإنجليزي',
+              en: 'Arabic & English support'
+            }
+          }
+        ]
+      };
+
+      const dashboards = [
+        {
+          number: '01',
+          href: 'dashboards/dashboard-1.html',
+          gradient: 'from-indigo-500 to-purple-500',
+          accent: 'text-indigo-300',
+          title: {
+            ar: 'لوحة تحليلات النمو',
+            en: 'Growth analytics dashboard'
+          },
+          description: {
+            ar: 'تتبع مؤشرات الأداء الرئيسية ومصادر النمو في الوقت الفعلي.',
+            en: 'Monitor key KPIs and growth sources in real time.'
+          }
+        },
+        {
+          number: '02',
+          href: 'dashboards/dashboard-2.html',
+          gradient: 'from-emerald-500 to-teal-500',
+          accent: 'text-emerald-300',
+          title: {
+            ar: 'لوحة إدارة المشاريع',
+            en: 'Project delivery dashboard'
+          },
+          description: {
+            ar: 'تتبع الإنجاز والمخاطر والاعتمادات عبر المحافظ.',
+            en: 'Track completion, risks, and dependencies across the portfolio.'
+          }
+        },
+        {
+          number: '03',
+          href: 'dashboards/dashboard-3.html',
+          gradient: 'from-amber-500 to-orange-500',
+          accent: 'text-amber-200',
+          title: {
+            ar: 'لوحة تجارة إلكترونية',
+            en: 'E-commerce performance hub'
+          },
+          description: {
+            ar: 'راقب المبيعات وسلوك العملاء والعمليات اللوجستية لحظياً.',
+            en: 'Monitor revenue, customer behaviour, and fulfilment in real time.'
+          }
+        },
+        {
+          number: '04',
+          href: 'dashboards/dashboard-4.html',
+          gradient: 'from-sky-500 to-cyan-500',
+          accent: 'text-sky-200',
+          title: {
+            ar: 'لوحة البنية السحابية',
+            en: 'Cloud infrastructure dashboard'
+          },
+          description: {
+            ar: 'تحليلات زمن الاستجابة، السعة، والإنفاق عبر البيئات.',
+            en: 'Analyse latency, capacity, and spend across environments.'
+          }
+        },
+        {
+          number: '05',
+          href: 'dashboards/dashboard-5.html',
+          gradient: 'from-rose-500 to-pink-500',
+          accent: 'text-rose-200',
+          title: {
+            ar: 'لوحة إدارة المحتوى',
+            en: 'Content operations dashboard'
+          },
+          description: {
+            ar: 'تنسيق جدول النشر، جودة المواد، وأداء القنوات.',
+            en: 'Coordinate publishing schedules, content quality, and channel performance.'
+          }
+        },
+        {
+          number: '06',
+          href: 'dashboards/dashboard-6.html',
+          gradient: 'from-fuchsia-500 to-purple-500',
+          accent: 'text-fuchsia-200',
+          title: {
+            ar: 'لوحة تجربة العملاء',
+            en: 'Customer experience dashboard'
+          },
+          description: {
+            ar: 'أثر الدعم، الملاحظات، والتحويلات عبر كل نقطة تواصل.',
+            en: 'Track support, feedback, and conversions across every touchpoint.'
+          }
+        },
+        {
+          number: '07',
+          href: 'dashboards/dashboard-7.html',
+          gradient: 'from-lime-500 to-emerald-500',
+          accent: 'text-lime-200',
+          title: {
+            ar: 'لوحة الموارد البشرية',
+            en: 'People operations dashboard'
+          },
+          description: {
+            ar: 'نظرة شاملة على القوى العاملة، المواهب، والرفاهية.',
+            en: 'Holistic view of workforce, talent pipelines, and wellbeing.'
+          }
+        },
+        {
+          number: '08',
+          href: 'dashboards/dashboard-8.html',
+          gradient: 'from-blue-500 to-indigo-500',
+          accent: 'text-blue-200',
+          title: {
+            ar: 'لوحة التعليم الإلكتروني',
+            en: 'E-learning experience dashboard'
+          },
+          description: {
+            ar: 'حلّل مشاركة المتعلمين، فعالية المحتوى، وأداء البرامج الحية.',
+            en: 'Analyse learner engagement, content effectiveness, and live cohort performance.'
+          }
+        },
+        {
+          number: '09',
+          href: 'dashboards/dashboard-9.html',
+          gradient: 'from-slate-500 to-slate-700',
+          accent: 'text-slate-200',
+          title: {
+            ar: 'لوحة أمن المعلومات',
+            en: 'Cybersecurity operations dashboard'
+          },
+          description: {
+            ar: 'رؤية فورية للهجمات، التصحيحات، والتدقيق التنظيمي.',
+            en: 'Instant insight into attacks, patching, and regulatory audits.'
+          }
+        },
+        {
+          number: '10',
+          href: 'dashboards/dashboard-10.html',
+          gradient: 'from-cyan-500 to-emerald-500',
+          accent: 'text-cyan-200',
+          title: {
+            ar: 'لوحة الخدمات المالية',
+            en: 'Financial services dashboard'
+          },
+          description: {
+            ar: 'مراقبة الأصول المدارة، العائدات، والمخاطر التشغيلية.',
+            en: 'Monitor assets under management, returns, and operational risk.'
+          }
+        },
+        {
+          number: '11',
+          href: 'dashboards/dashboard-11.html',
+          gradient: 'from-red-500 to-rose-500',
+          accent: 'text-rose-200',
+          title: {
+            ar: 'لوحة عمليات الرعاية الصحية',
+            en: 'Healthcare operations dashboard'
+          },
+          description: {
+            ar: 'راقب سلامة المرضى، الكفاءات السريرية، وكفاءة الموارد.',
+            en: 'Monitor patient safety, clinical efficiency, and resource utilisation.'
+          }
+        },
+        {
+          number: '12',
+          href: 'dashboards/dashboard-12.html',
+          gradient: 'from-purple-500 to-indigo-500',
+          accent: 'text-purple-200',
+          title: {
+            ar: 'لوحة حملات التسويق',
+            en: 'Marketing campaigns dashboard'
+          },
+          description: {
+            ar: 'تتبع أداء القنوات، تحويل الحملات، وتجارب الرسائل.',
+            en: 'Track channel performance, campaign conversions, and messaging experiments.'
+          }
+        },
+        {
+          number: '13',
+          href: 'dashboards/dashboard-13.html',
+          gradient: 'from-amber-600 to-lime-500',
+          accent: 'text-amber-200',
+          title: {
+            ar: 'لوحة سلسلة الإمداد',
+            en: 'Supply chain dashboard'
+          },
+          description: {
+            ar: 'تتبع تدفق الشحنات، تغطية المخزون، وأداء الموردين.',
+            en: 'Track shipments, inventory coverage, and supplier performance.'
+          }
+        },
+        {
+          number: '14',
+          href: 'dashboards/dashboard-14.html',
+          gradient: 'from-emerald-600 to-teal-600',
+          accent: 'text-emerald-200',
+          title: {
+            ar: 'لوحة إدارة العقارات',
+            en: 'Real estate management dashboard'
+          },
+          description: {
+            ar: 'مراقبة الإشغال، التدفقات المالية، وحالة الأصول عبر المحافظ.',
+            en: 'Monitor occupancy, financial flows, and asset condition across portfolios.'
+          }
+        },
+        {
+          number: '15',
+          href: 'dashboards/dashboard-15.html',
+          gradient: 'from-orange-500 to-red-500',
+          accent: 'text-amber-200',
+          title: {
+            ar: 'لوحة العمليات التصنيعية',
+            en: 'Manufacturing operations dashboard'
+          },
+          description: {
+            ar: 'راقب الإنتاج، الجودة، والصيانة في جميع الخطوط.',
+            en: 'Monitor output, quality, and maintenance across lines.'
+          }
+        },
+        {
+          number: '16',
+          href: 'dashboards/dashboard-16.html',
+          gradient: 'from-fuchsia-500 to-cyan-500',
+          accent: 'text-cyan-200',
+          title: {
+            ar: 'لوحة منصة البث',
+            en: 'Streaming platform dashboard'
+          },
+          description: {
+            ar: 'إدارة المشتركين، أداء المحتوى، وجاهزية الشبكة.',
+            en: 'Manage subscribers, content performance, and network readiness.'
+          }
+        },
+        {
+          number: '17',
+          href: 'dashboards/dashboard-17.html',
+          gradient: 'from-cyan-500 to-lime-500',
+          accent: 'text-cyan-200',
+          title: {
+            ar: 'لوحة المدينة الذكية',
+            en: 'Smart city dashboard'
+          },
+          description: {
+            ar: 'قياس الأداء الحضري عبر التنقل، الطاقة، والخدمات الرقمية.',
+            en: 'Measure urban performance across mobility, energy, and digital services.'
+          }
+        },
+        {
+          number: '18',
+          href: 'dashboards/dashboard-18.html',
+          gradient: 'from-rose-500 via-amber-500 to-emerald-500',
+          accent: 'text-amber-200',
+          title: {
+            ar: 'لوحة تجربة الضيوف',
+            en: 'Guest experience intelligence'
+          },
+          description: {
+            ar: 'راقب معدلات الإشغال، رضا الضيوف، وإيرادات الغرف عبر محفظة الفنادق.',
+            en: 'Monitor occupancy, guest sentiment, and room revenue across the hotel portfolio.'
+          }
+        },
+        {
+          number: '19',
+          href: 'dashboards/dashboard-19.html',
+          gradient: 'from-emerald-500 via-teal-500 to-sky-500',
+          accent: 'text-emerald-200',
+          title: {
+            ar: 'لوحة عمليات الطاقة المتجددة',
+            en: 'Renewable operations overview'
+          },
+          description: {
+            ar: 'راقب إنتاج الطاقة، توازن الشبكة، ومبادرات الاستدامة في الوقت الفعلي.',
+            en: 'Track generation, grid balance, and sustainability programs in real time.'
+          }
+        },
+        {
+          number: '20',
+          href: 'dashboards/dashboard-20.html',
+          gradient: 'from-indigo-500 via-violet-500 to-rose-500',
+          accent: 'text-violet-200',
+          title: {
+            ar: 'لوحة أداء النادي الرياضي',
+            en: 'Club performance intelligence'
+          },
+          description: {
+            ar: 'تابع نتائج المباريات، صحة اللاعبين، وتفاعل الجماهير عبر موسم البطولة.',
+            en: 'Follow match results, player wellness, and fan engagement throughout the season.'
+          }
+        }
+      ];
+
+      const heroTagEl = document.querySelector('[data-i18n="hero-tag"]');
+      const heroTitleEl = document.querySelector('[data-i18n="hero-title"]');
+      const heroDescriptionEl = document.querySelector('[data-i18n="hero-description"]');
+      const sectionTitleEl = document.querySelector('[data-i18n="section-title"]');
+      const footerTextEl = document.querySelector('[data-i18n="footer-text"]');
+      const footerPrivacyEl = document.querySelector('[data-i18n="footer-privacy"]');
+      const footerTermsEl = document.querySelector('[data-i18n="footer-terms"]');
+      const badgesContainer = document.querySelector('[data-role="hero-badges"]');
+      const cardsContainer = document.querySelector('[data-role="card-grid"]');
+
+      const languageSwitchers = document.querySelectorAll('[data-role="language-switcher"]');
+      const langButtons = [];
+      let currentLang = 'ar';
+
+      languageSwitchers.forEach(container => {
+        container.innerHTML = '';
+        ['ar', 'en'].forEach(lang => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.dataset.lang = lang;
+          button.textContent = lang === 'ar' ? 'ع' : 'En';
+          button.className = 'px-3 py-1 text-xs font-semibold rounded-lg transition border border-white/10 text-slate-200 bg-transparent hover:bg-white/10';
+          button.addEventListener('click', () => setLanguage(lang));
+          container.appendChild(button);
+          langButtons.push(button);
+        });
+      });
+
+      function updateSwitcherButtons() {
+        langButtons.forEach(btn => {
+          const active = btn.dataset.lang === currentLang;
+          btn.classList.toggle('bg-white/10', active);
+          btn.classList.toggle('text-white', active);
+          btn.classList.toggle('opacity-70', !active);
+        });
+      }
+
+      function renderBadges(lang) {
+        if (!badgesContainer) return;
+        badgesContainer.innerHTML = translations.badges.map(badge => `
+          <span class="${badge.classes}">${badge.text[lang]}</span>
+        `).join('');
+      }
+
+      function renderCards(lang) {
+        if (!cardsContainer) return;
+        cardsContainer.innerHTML = dashboards.map(card => `
+          <a href="${card.href}" class="group bg-slate-800/60 hover:bg-slate-800 transition rounded-2xl overflow-hidden shadow-lg border border-slate-700/50">
+            <div class="h-40 bg-gradient-to-br ${card.gradient} flex items-center justify-center">
+              <span class="text-4xl font-bold text-white/80">${card.number}</span>
+            </div>
+            <div class="p-5 space-y-3">
+              <h3 class="text-xl font-semibold">${card.title[lang]}</h3>
+              <p class="text-slate-300 text-sm leading-relaxed">${card.description[lang]}</p>
+              <span class="mt-2 inline-flex items-center ${card.accent} text-sm group-hover:translate-x-1 transition">
+                ${translations.linkLabel[lang]}
+              </span>
+            </div>
+          </a>
+        `).join('');
+      }
+
+      function setLanguage(lang) {
+        currentLang = lang;
+        html.setAttribute('lang', lang);
+        html.setAttribute('dir', lang === 'ar' ? 'rtl' : 'ltr');
+        body.classList.toggle('font-english', lang === 'en');
+        document.title = translations.pageTitle[lang];
+
+        if (heroTagEl) heroTagEl.textContent = translations.heroTag[lang];
+        if (heroTitleEl) heroTitleEl.textContent = translations.heroTitle[lang];
+        if (heroDescriptionEl) heroDescriptionEl.textContent = translations.heroDescription[lang];
+        if (sectionTitleEl) sectionTitleEl.textContent = translations.sectionTitle[lang];
+        if (footerTextEl) footerTextEl.textContent = translations.footerText[lang];
+        if (footerPrivacyEl) footerPrivacyEl.textContent = translations.footerPrivacy[lang];
+        if (footerTermsEl) footerTermsEl.textContent = translations.footerTerms[lang];
+
+        renderBadges(lang);
+        renderCards(lang);
+        updateSwitcherButtons();
+      }
+
+      setLanguage(currentLang);
+    })();
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-1.html
+++ b/dashboards/dashboard-1.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تحليلات النمو</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">G</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">G</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة تحليلات النمو',
+          en: 'Growth Analytics Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'G',
+        name: {
+          ar: 'مؤشرات النمو',
+          en: 'Growth Metrics'
+        },
+        tagline: {
+          ar: 'لوحة أداء الشركات الناشئة',
+          en: 'Startup performance cockpit'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-indigo-950 to-purple-950',
+        sidebarGradient: 'from-slate-950 via-indigo-950 to-purple-900',
+        cardBg: 'bg-slate-900/70 backdrop-blur-xl',
+        cardBorder: 'border-indigo-500/30',
+        accentGradient: 'from-indigo-500 via-purple-500 to-blue-500',
+        accentText: 'text-indigo-300',
+        highlightBg: 'bg-indigo-500/10 border-indigo-500/20',
+        badgeBg: 'bg-indigo-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'chart-bar',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'مباشر', en: 'Live' }
+        },
+        {
+          id: 'acquisition',
+          icon: 'cursor-arrow',
+          label: { ar: 'الاكتساب', en: 'Acquisition' }
+        },
+        {
+          id: 'segments',
+          icon: 'users',
+          label: { ar: 'شرائح العملاء', en: 'Customer Segments' }
+        },
+        {
+          id: 'retention',
+          icon: 'sparkles',
+          label: { ar: 'الاحتفاظ', en: 'Retention' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'نمو ربع سنوي', en: 'Quarterly growth' },
+        value: '+32%',
+        description: {
+          ar: 'الحملات المخصصة رفعت التسجيلات وتحويلات القنوات المدفوعة.',
+          en: 'Personalised campaigns boosted signups and paid channel conversions.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة تحليلات النمو',
+          en: 'Growth analytics dashboard'
+        },
+        subtitle: {
+          ar: 'تتبع مؤشرات الأداء الرئيسية ومصادر النمو في الوقت الفعلي.',
+          en: 'Monitor key KPIs and growth sources in real time.'
+        },
+        primary: {
+          ar: 'إنشاء تقرير تنفيذي',
+          en: 'Create executive report'
+        },
+        secondary: {
+          ar: 'آخر 30 يوماً',
+          en: 'Last 30 days'
+        }
+      },
+      stats: [
+        {
+          icon: 'users',
+          label: { ar: 'مستخدمون نشطون', en: 'Active users' },
+          value: '128,940',
+          delta: { ar: '+6.4% مقارنة بالأسبوع الماضي', en: '+6.4% vs last week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cursor-arrow',
+          label: { ar: 'نسبة التحويل', en: 'Conversion rate' },
+          value: '4.87%',
+          delta: { ar: '+0.42 نقطة مئوية', en: '+0.42 percentage points' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'قيمة عمر العميل', en: 'Customer lifetime value' },
+          value: '$1,240',
+          delta: { ar: '+12% نمو سنوي', en: '+12% YoY growth' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'صافي نقاط الترويج', en: 'Net promoter score' },
+          value: '68',
+          delta: { ar: '+4 نقاط خلال الشهر', en: '+4 points this month' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى النمو الأسبوعي', en: 'Weekly growth curve' },
+          subtitle: { ar: 'مقارنة الاكتساب والاحتفاظ عبر القنوات الأساسية.', en: 'Acquisition vs retention across primary channels.' },
+          action: { ar: 'تحميل CSV', en: 'Download CSV' },
+          placeholder: { ar: 'مخطط موجه', en: 'Insightful chart' }
+        },
+        {
+          id: 'channels',
+          type: 'list',
+          title: { ar: 'أفضل القنوات', en: 'Top channels' },
+          action: { ar: 'تحديث قبل 5 دقائق', en: 'Updated 5 minutes ago' },
+          items: [
+            {
+              icon: 'megaphone',
+              title: { ar: 'إعلانات البحث', en: 'Search ads' },
+              subtitle: { ar: 'تكلفة الاكتساب 12.4$', en: 'Acquisition cost $12.4' },
+              value: '46%',
+              delta: { ar: '+5% نمو', en: '+5% growth' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'الإحالات', en: 'Referrals' },
+              subtitle: { ar: 'تجربة ترحيب جديدة', en: 'New welcome experience' },
+              value: '32%',
+              delta: { ar: '+8% نمو', en: '+8% growth' }
+            },
+            {
+              icon: 'tv',
+              title: { ar: 'وسائل التواصل', en: 'Social media' },
+              subtitle: { ar: 'حملات المؤثرين', en: 'Influencer campaigns' },
+              value: '18%',
+              delta: { ar: '+2% نمو', en: '+2% growth' }
+            }
+          ]
+        },
+        {
+          id: 'journey',
+          type: 'progress',
+          title: { ar: 'رحلة التحويل', en: 'Conversion journey' },
+          items: [
+            {
+              title: { ar: 'زيارة الصفحة المقصودة', en: 'Landing page visit' },
+              subtitle: { ar: 'زمن تحميل أقل من 1.2 ثانية', en: 'Load time under 1.2s' },
+              value: '82%',
+              percent: '82%'
+            },
+            {
+              title: { ar: 'التسجيل التجريبي', en: 'Trial signup' },
+              subtitle: { ar: 'اختبار A/B للعرض', en: 'Offer A/B testing' },
+              value: '47%',
+              percent: '47%'
+            },
+            {
+              title: { ar: 'التحويل المدفوع', en: 'Paid conversion' },
+              subtitle: { ar: 'تحفيز الترقيات السنوية', en: 'Incentivise annual upgrades' },
+              value: '22%',
+              percent: '22%'
+            }
+          ]
+        },
+        {
+          id: 'milestones',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أحداث رئيسية', en: 'Key milestones' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق لوحة القيادة الجديدة', en: 'New dashboard launch' },
+              subtitle: { ar: 'رفع تفاعل العملاء 18%', en: 'Raised customer engagement by 18%' },
+              time: { ar: 'قبل ساعتين', en: '2 hours ago' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'تجزئة جمهور جديدة', en: 'New audience cohort' },
+              subtitle: { ar: 'تمت إضافة شريحة مستخدمين مخلصين', en: 'Loyal user segment added' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'chart-bar',
+              title: { ar: 'إنجاز هدف النمو', en: 'Growth target reached' },
+              subtitle: { ar: 'تحقيق هدف MRR للأسبوع', en: 'Met weekly MRR target' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-10.html
+++ b/dashboards/dashboard-10.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الخدمات المالية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">F</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">F</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الخدمات المالية',
+          en: 'Financial Services Performance Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'F',
+        name: {
+          ar: 'إيقاع التمويل',
+          en: 'Finance Pulse'
+        },
+        tagline: {
+          ar: 'إدارة الأصول، المخاطر، والعوائد في الوقت الفعلي',
+          en: 'Real-time asset, risk, and revenue management'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-emerald-950 to-cyan-900',
+        sidebarGradient: 'from-emerald-950 via-teal-900 to-cyan-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-emerald-400/30',
+        accentGradient: 'from-slate-900 via-blue-600 to-emerald-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'bank',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'أساسي', en: 'Core' }
+        },
+        {
+          id: 'portfolios',
+          icon: 'chart-bar',
+          label: { ar: 'المحافظ', en: 'Portfolios' }
+        },
+        {
+          id: 'risk',
+          icon: 'scale',
+          label: { ar: 'المخاطر', en: 'Risk' }
+        },
+        {
+          id: 'revenue',
+          icon: 'sparkles',
+          label: { ar: 'الإيرادات', en: 'Revenue' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'مؤشر الأداء', en: 'Performance index' },
+        value: '126.4 نقطة',
+        description: {
+          ar: 'تفوقت المحافظ المتوازنة على المؤشر المرجعي بنسبة 4.6% منذ بداية العام.',
+          en: 'Balanced portfolios outperformed benchmark by 4.6% year-to-date.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة الخدمات المالية',
+          en: 'Financial services dashboard'
+        },
+        subtitle: {
+          ar: 'مراقبة الأصول المدارة، العائدات، والمخاطر التشغيلية.',
+          en: 'Monitor assets under management, returns, and operational risk.'
+        },
+        primary: {
+          ar: 'إرسال تقرير تنفيذي',
+          en: 'Send executive brief'
+        },
+        secondary: {
+          ar: 'مقارنة بالمؤشرات',
+          en: 'Compare to benchmarks'
+        }
+      },
+      stats: [
+        {
+          icon: 'bank',
+          label: { ar: 'الأصول تحت الإدارة', en: 'Assets under management' },
+          value: '$3.8B',
+          delta: { ar: '+6.2% منذ بداية العام', en: '+6.2% year-to-date' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'الإيرادات اليومية', en: 'Daily revenue' },
+          value: '$12.4M',
+          delta: { ar: '+1.3M عن المتوسط', en: '+1.3M vs average' },
+          trend: 'positive'
+        },
+        {
+          icon: 'scale',
+          label: { ar: 'التعرّض للمخاطر', en: 'Risk exposure' },
+          value: '0.78',
+          delta: { ar: '-0.05 مقارنة بالربع الماضي', en: '-0.05 vs last quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'احتفاظ العملاء', en: 'Client retention' },
+          value: '97%',
+          delta: { ar: '+2 نقاط بعد مبادرة تجربة العملاء', en: '+2 pts after CX initiative' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'أداء المحافظ', en: 'Portfolio performance' },
+          subtitle: { ar: 'العوائد الشهرية مقارنة بالمؤشرات الرئيسية.', en: 'Monthly returns vs key benchmarks.' },
+          action: { ar: 'تنزيل CSV', en: 'Download CSV' },
+          placeholder: { ar: 'مخطط العوائد', en: 'Performance chart' }
+        },
+        {
+          id: 'portfolios',
+          type: 'list',
+          title: { ar: 'محافظ قيد المراقبة', en: 'Portfolios on watch' },
+          action: { ar: 'تحديث كل ساعتين', en: 'Updated every 2 hours' },
+          items: [
+            {
+              icon: 'chart-bar',
+              title: { ar: 'محفظة النمو العالمية', en: 'Global growth fund' },
+              subtitle: { ar: 'عائد سنوي 14.2%', en: '14.2% annual return' },
+              value: '$820M',
+              delta: { ar: '+1.8% هذا الشهر', en: '+1.8% this month' }
+            },
+            {
+              icon: 'scale',
+              title: { ar: 'محفظة الدخل المتوازن', en: 'Balanced income fund' },
+              subtitle: { ar: 'انحراف معياري 0.62', en: 'Std deviation 0.62' },
+              value: '$610M',
+              delta: { ar: '+0.9% نمو صافي', en: '+0.9% net growth' }
+            },
+            {
+              icon: 'bank',
+              title: { ar: 'صندوق البنية التحتية', en: 'Infrastructure fund' },
+              subtitle: { ar: 'مشاريع طاقة وخدمات', en: 'Energy and utilities projects' },
+              value: '$480M',
+              delta: { ar: 'تدفقات جديدة 42M$', en: 'New inflows $42M' }
+            }
+          ]
+        },
+        {
+          id: 'risk',
+          type: 'progress',
+          title: { ar: 'حالة الامتثال والمخاطر', en: 'Risk & compliance status' },
+          items: [
+            {
+              title: { ar: 'التقارير التنظيمية', en: 'Regulatory filings' },
+              subtitle: { ar: 'مكتمل مع مراجعة قانونية', en: 'Completed with legal review' },
+              value: '92%',
+              percent: '92%'
+            },
+            {
+              title: { ar: 'التدقيق الداخلي', en: 'Internal audit actions' },
+              subtitle: { ar: '14 عنصر قيد التنفيذ', en: '14 items in progress' },
+              value: '68%',
+              percent: '68%'
+            },
+            {
+              title: { ar: 'اختبارات الضغط', en: 'Stress testing coverage' },
+              subtitle: { ar: 'ثلاث سيناريوهات جديدة', en: 'Three new scenarios' },
+              value: '54%',
+              percent: '54%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أحداث مالية حديثة', en: 'Recent financial events' },
+          items: [
+            {
+              icon: 'bank',
+              title: { ar: 'إغلاق صفقة استحواذ', en: 'Acquisition deal closed' },
+              subtitle: { ar: 'تم دمج منصة إدارة الثروات', en: 'Wealth platform integrated' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق منتج استثماري جديد', en: 'New investment product launch' },
+              subtitle: { ar: 'محفظة خضراء بعائد مستهدف 11%', en: 'Green portfolio targeting 11% yield' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'scale',
+              title: { ar: 'اعتماد سياسة مخاطر محدثة', en: 'Updated risk policy adopted' },
+              subtitle: { ar: 'يشمل تغطية الأصول الرقمية', en: 'Includes digital asset coverage' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-11.html
+++ b/dashboards/dashboard-11.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة عمليات الرعاية الصحية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">HC</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">HC</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة عمليات الرعاية الصحية',
+          en: 'Healthcare Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'HC',
+        name: {
+          ar: 'إدارة الرعاية',
+          en: 'Care Command'
+        },
+        tagline: {
+          ar: 'تدفق المرضى، جودة الخدمة، والجاهزية السريرية',
+          en: 'Patient flow, care quality, and bed readiness'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-teal-950 to-emerald-900',
+        sidebarGradient: 'from-teal-950 via-emerald-900 to-cyan-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-teal-400/30',
+        accentGradient: 'from-rose-500 via-red-500 to-amber-500',
+        accentText: 'text-amber-200',
+        highlightBg: 'bg-rose-500/10 border-rose-400/30',
+        badgeBg: 'bg-rose-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'heart',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'رعاية', en: 'Care' }
+        },
+        {
+          id: 'clinical',
+          icon: 'stethoscope',
+          label: { ar: 'المؤشرات السريرية', en: 'Clinical metrics' }
+        },
+        {
+          id: 'capacity',
+          icon: 'users',
+          label: { ar: 'الطاقة الاستيعابية', en: 'Capacity' }
+        },
+        {
+          id: 'finance',
+          icon: 'bank',
+          label: { ar: 'المالية والإدارة', en: 'Finance & admin' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'مستوى الإنذار', en: 'Alert level' },
+        value: 'مستقر',
+        description: {
+          ar: 'وحدة العناية الحرجة تعمل بنسبة 92% وتتوفر أسرة احتياطية للطوارئ.',
+          en: 'Critical care running at 92% with surge beds ready for emergencies.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة عمليات الرعاية الصحية',
+          en: 'Healthcare operations dashboard'
+        },
+        subtitle: {
+          ar: 'راقب سلامة المرضى، الكفاءات السريرية، وكفاءة الموارد.',
+          en: 'Monitor patient safety, clinical efficiency, and resource utilisation.'
+        },
+        primary: {
+          ar: 'تفعيل خطة الطوارئ',
+          en: 'Activate contingency plan'
+        },
+        secondary: {
+          ar: 'عرض تقرير الجودة',
+          en: 'View quality report'
+        }
+      },
+      stats: [
+        {
+          icon: 'heart',
+          label: { ar: 'نسبة إشغال الأسرة', en: 'Bed occupancy' },
+          value: '84%',
+          delta: { ar: '-3% عن الأسبوع الماضي', en: '-3% vs last week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'stethoscope',
+          label: { ar: 'متوسط انتظار العيادات', en: 'Average clinic wait time' },
+          value: '12 دقيقة',
+          delta: { ar: '-5 دقائق بعد تحسين الجدولة', en: '-5 minutes after scheduling optimisation' },
+          trend: 'positive'
+        },
+        {
+          icon: 'users',
+          label: { ar: 'توافر الطواقم', en: 'Staff availability' },
+          value: '92%',
+          delta: { ar: '+4% بعد برنامج المناوبة الذكية', en: '+4% with smart rostering' },
+          trend: 'positive'
+        },
+        {
+          icon: 'scale',
+          label: { ar: 'امتثال أحداث السلامة', en: 'Safety incident compliance' },
+          value: '99%',
+          delta: { ar: 'جميع الحوادث مُغلقة خلال 48 ساعة', en: 'All incidents closed within 48h' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'تدفق المرضى اليومي', en: 'Daily patient flow' },
+          subtitle: { ar: 'دخول، خروج، وتحويلات عبر الأقسام.', en: 'Admissions, discharges, and transfers across units.' },
+          action: { ar: 'عرض حسب القسم', en: 'View by unit' },
+          placeholder: { ar: 'مخطط التدفق', en: 'Flow chart' }
+        },
+        {
+          id: 'alerts',
+          type: 'list',
+          title: { ar: 'تنبيهات سريرية', en: 'Clinical alerts' },
+          action: { ar: 'آخر تحديث 5 دقائق', en: 'Updated 5 minutes ago' },
+          items: [
+            {
+              icon: 'heart',
+              title: { ar: 'ارتفاع ضغط طارئ', en: 'Hypertension escalation' },
+              subtitle: { ar: 'جناح الباطنية', en: 'Internal medicine ward' },
+              value: 'تم التدخل',
+              delta: { ar: 'ممرضة مسؤولة تم تكليفها', en: 'Charge nurse assigned' }
+            },
+            {
+              icon: 'stethoscope',
+              title: { ar: 'متابعة مضاد حيوي', en: 'Antibiotic stewardship follow-up' },
+              subtitle: { ar: 'قائمة مراجعة الجرعات متاحة', en: 'Dosage checklist available' },
+              value: 'قيد المراجعة',
+              delta: { ar: 'ينتظر موافقة الاستشاري', en: 'Awaiting consultant sign-off' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'نقص فريق التمريض الليلي', en: 'Night shift staffing gap' },
+              subtitle: { ar: 'تغطية إضافية من الوحدة B', en: 'Backfilled from Unit B' },
+              value: 'تم الحل',
+              delta: { ar: 'تمت جدولة المناوبة', en: 'Shift scheduled' }
+            }
+          ]
+        },
+        {
+          id: 'capacity',
+          type: 'progress',
+          title: { ar: 'استعداد الخدمات', en: 'Service readiness' },
+          items: [
+            {
+              title: { ar: 'غرف العمليات', en: 'Operating theatres' },
+              subtitle: { ar: '8 من 9 غرف جاهزة', en: '8 of 9 theatres ready' },
+              value: '89%',
+              percent: '89%'
+            },
+            {
+              title: { ar: 'المختبر المركزي', en: 'Central laboratory' },
+              subtitle: { ar: 'نتائج خلال 35 دقيقة', en: '35 minute turnaround' },
+              value: '94%',
+              percent: '94%'
+            },
+            {
+              title: { ar: 'وحدة الطوارئ', en: 'Emergency unit' },
+              subtitle: { ar: 'جاهزية المسار السريع', en: 'Fast-track readiness' },
+              value: '76%',
+              percent: '76%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'مستجدات الرعاية', en: 'Care updates timeline' },
+          items: [
+            {
+              icon: 'heart',
+              title: { ar: 'إطلاق برنامج متابعة المنزل', en: 'Home monitoring programme launch' },
+              subtitle: { ar: 'يتضمن أجهزة تتبع حيوية', en: 'Includes remote vital devices' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'bank',
+              title: { ar: 'تحديث نظام الفوترة الطبية', en: 'Medical billing system refresh' },
+              subtitle: { ar: 'تكامل مع التأمين الصحي', en: 'Integrated with insurers' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'scale',
+              title: { ar: 'مراجعة سلامة شهرية', en: 'Monthly safety review' },
+              subtitle: { ar: 'صفر حوادث عالية الخطورة', en: 'Zero high-risk events' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-12.html
+++ b/dashboards/dashboard-12.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة حملات التسويق</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MK</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MK</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة حملات التسويق',
+          en: 'Marketing Campaigns Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'MK',
+        name: {
+          ar: 'نبض الحملات',
+          en: 'Campaign Pulse'
+        },
+        tagline: {
+          ar: 'إدارة الأداء، القنوات، والأتمتة الذكية',
+          en: 'Performance, channels, and smart automation'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-pink-950 to-purple-900',
+        sidebarGradient: 'from-pink-950 via-fuchsia-900 to-orange-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-pink-400/30',
+        accentGradient: 'from-purple-500 via-pink-500 to-red-500',
+        accentText: 'text-pink-200',
+        highlightBg: 'bg-pink-500/10 border-pink-400/30',
+        badgeBg: 'bg-pink-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'megaphone',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'مباشر', en: 'Live' }
+        },
+        {
+          id: 'campaigns',
+          icon: 'sparkles',
+          label: { ar: 'الحملات النشطة', en: 'Active campaigns' }
+        },
+        {
+          id: 'channels',
+          icon: 'tv',
+          label: { ar: 'القنوات والإعلانات', en: 'Channels & ads' }
+        },
+        {
+          id: 'automation',
+          icon: 'cog',
+          label: { ar: 'الأتمتة والتحسين', en: 'Automation & optimisation' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'حملة مميزة', en: 'Featured campaign' },
+        value: 'إطلاق الخدمة السحابية',
+        description: {
+          ar: 'تجاوز الهدف بنسبة 32% مع تكلفة اكتساب 18$.',
+          en: 'Exceeded goal by 32% with $18 CPA.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة حملات التسويق',
+          en: 'Marketing campaigns dashboard'
+        },
+        subtitle: {
+          ar: 'تتبع أداء القنوات، تحويل الحملات، وتجارب الرسائل.',
+          en: 'Track channel performance, campaign conversions, and messaging experiments.'
+        },
+        primary: {
+          ar: 'إطلاق حملة جديدة',
+          en: 'Launch new campaign'
+        },
+        secondary: {
+          ar: 'تصدير تقرير الأداء',
+          en: 'Export performance report'
+        }
+      },
+      stats: [
+        {
+          icon: 'megaphone',
+          label: { ar: 'العملاء المحتملون', en: 'Qualified leads' },
+          value: '48,200',
+          delta: { ar: '+11% مقابل الشهر الماضي', en: '+11% vs last month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'عائد الإنفاق الإعلاني', en: 'Return on ad spend' },
+          value: '4.3x',
+          delta: { ar: '+0.6 زيادة', en: '+0.6 lift' },
+          trend: 'positive'
+        },
+        {
+          icon: 'tv',
+          label: { ar: 'معدل فتح البريد', en: 'Email open rate' },
+          value: '38%',
+          delta: { ar: '+5 نقاط بفضل التخصيص', en: '+5 pts due to personalisation' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'تفاعل اجتماعي', en: 'Social engagement' },
+          value: '67K',
+          delta: { ar: '+14% نمو أسبوعي', en: '+14% weekly growth' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'أداء القنوات المتعددة', en: 'Omnichannel performance' },
+          subtitle: { ar: 'الإنفاق، الزيارات، والتحويلات لكل قناة.', en: 'Spend, visits, and conversions by channel.' },
+          action: { ar: 'تفاصيل حسب المنطقة', en: 'View by region' },
+          placeholder: { ar: 'مخطط الأداء', en: 'Performance chart' }
+        },
+        {
+          id: 'campaigns',
+          type: 'list',
+          title: { ar: 'حملات يجب مراقبتها', en: 'Campaigns to watch' },
+          action: { ar: 'مزامنة كل 30 دقيقة', en: 'Synced every 30 minutes' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'سلسلة الويب المباشر', en: 'Live webinar series' },
+              subtitle: { ar: 'نسبة التحويل 12%', en: '12% conversion rate' },
+              value: '$420K',
+              delta: { ar: '+18% نمو', en: '+18% growth' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'حملة المؤثرين الإقليمية', en: 'Regional influencer push' },
+              subtitle: { ar: 'تكلفة النقر 1.8$', en: 'CPC $1.8' },
+              value: '$260K',
+              delta: { ar: '+9% وصول', en: '+9% reach' }
+            },
+            {
+              icon: 'tv',
+              title: { ar: 'سلسلة الإعلانات التلفزيونية المتصلة', en: 'Connected TV flight' },
+              subtitle: { ar: 'نسبة مشاهدة 91%', en: '91% completion rate' },
+              value: '$310K',
+              delta: { ar: '+4.2 ROAS', en: 'ROAS 4.2' }
+            }
+          ]
+        },
+        {
+          id: 'automation',
+          type: 'progress',
+          title: { ar: 'رحلات الأتمتة', en: 'Automation journeys' },
+          items: [
+            {
+              title: { ar: 'استبقاء العملاء الجدد', en: 'New customer nurture' },
+              subtitle: { ar: '4 خطوات بريدية + رسائل تطبيق', en: '4 emails + in-app prompts' },
+              value: '82%',
+              percent: '82%'
+            },
+            {
+              title: { ar: 'إعادة استهداف المتسوقين', en: 'Cart retargeting' },
+              subtitle: { ar: 'تكامل مع عروض الوقت الحقيقي', en: 'Real-time offer sync' },
+              value: '61%',
+              percent: '61%'
+            },
+            {
+              title: { ar: 'تنشيط العملاء الخاملين', en: 'Dormant account activation' },
+              subtitle: { ar: 'تجربة محتوى ديناميكي', en: 'Dynamic content experiment' },
+              value: '47%',
+              percent: '47%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'تحديثات التسويق', en: 'Marketing updates timeline' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق نسخة الصفحة الرئيسية', en: 'Homepage variant launch' },
+              subtitle: { ar: 'اختبار A/B على 40% من الزوار', en: 'A/B test across 40% traffic' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'توقيع شراكة إعلامية', en: 'Media partnership signed' },
+              subtitle: { ar: 'حزم محتوى مشتركة للربع القادم', en: 'Co-branded content packages' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'cog',
+              title: { ar: 'تحديث منصة الأتمتة', en: 'Automation platform update' },
+              subtitle: { ar: 'محرك تنبؤي لحجم الجمهور', en: 'Predictive audience sizing' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-13.html
+++ b/dashboards/dashboard-13.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة سلسلة الإمداد</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">SC</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">SC</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة سلسلة الإمداد',
+          en: 'Supply Chain Command Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'SC',
+        name: {
+          ar: 'نبض الإمداد',
+          en: 'Supply Pulse'
+        },
+        tagline: {
+          ar: 'العمليات اللوجستية، المخزون، والشركاء',
+          en: 'Logistics, inventory, and supplier orchestration'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-emerald-950 to-amber-900',
+        sidebarGradient: 'from-emerald-950 via-emerald-900 to-amber-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-emerald-400/30',
+        accentGradient: 'from-amber-500 via-lime-500 to-emerald-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-lime-500/10 border-lime-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'truck',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'سلسلة', en: 'Chain' }
+        },
+        {
+          id: 'logistics',
+          icon: 'map',
+          label: { ar: 'العمليات اللوجستية', en: 'Logistics' }
+        },
+        {
+          id: 'inventory',
+          icon: 'cube',
+          label: { ar: 'المخزون', en: 'Inventory' }
+        },
+        {
+          id: 'suppliers',
+          icon: 'factory',
+          label: { ar: 'الموردون والشركاء', en: 'Suppliers & partners' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'مستوى المخاطر', en: 'Risk level' },
+        value: 'متوسط منخفض',
+        description: {
+          ar: 'لا توجد اختناقات كبرى، تم تأمين النقل البري للربع القادم.',
+          en: 'No major bottlenecks, road haulage secured for next quarter.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة سلسلة الإمداد',
+          en: 'Supply chain dashboard'
+        },
+        subtitle: {
+          ar: 'تتبع تدفق الشحنات، تغطية المخزون، وأداء الموردين.',
+          en: 'Track shipments, inventory coverage, and supplier performance.'
+        },
+        primary: {
+          ar: 'إنشاء أمر شراء جماعي',
+          en: 'Create bulk purchase order'
+        },
+        secondary: {
+          ar: 'عرض سيناريوهات المخاطر',
+          en: 'View risk scenarios'
+        }
+      },
+      stats: [
+        {
+          icon: 'truck',
+          label: { ar: 'التسليم في الوقت', en: 'On-time deliveries' },
+          value: '94%',
+          delta: { ar: '+3% بعد تحسين المسارات', en: '+3% after route optimisation' },
+          trend: 'positive'
+        },
+        {
+          icon: 'map',
+          label: { ar: 'شحنات قيد النقل', en: 'Shipments in transit' },
+          value: '128',
+          delta: { ar: '37% عبر البحر، 63% بري', en: '37% ocean, 63% road' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cube',
+          label: { ar: 'تغطية المخزون', en: 'Inventory coverage' },
+          value: '32 يوم',
+          delta: { ar: '+4 أيام عن الهدف', en: '+4 days vs target' },
+          trend: 'positive'
+        },
+        {
+          icon: 'factory',
+          label: { ar: 'تقييم الموردين', en: 'Supplier quality score' },
+          value: '87',
+          delta: { ar: '+6 نقاط في ربع واحد', en: '+6 points in one quarter' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'تقدم الشحنات اليومية', en: 'Daily shipment progress' },
+          subtitle: { ar: 'حالة الشحنات حسب القارة ونوع النقل.', en: 'Shipment status by region and mode.' },
+          action: { ar: 'عرض تفاصيل المسارات', en: 'View route details' },
+          placeholder: { ar: 'مخطط الشحنات', en: 'Shipments chart' }
+        },
+        {
+          id: 'routes',
+          type: 'list',
+          title: { ar: 'ممرات يجب مراقبتها', en: 'Lanes to monitor' },
+          action: { ar: 'تحديث كل ساعة', en: 'Updated hourly' },
+          items: [
+            {
+              icon: 'truck',
+              title: { ar: 'شنغهاي → روتردام', en: 'Shanghai → Rotterdam' },
+              subtitle: { ar: 'ETA خمسة أيام', en: 'ETA five days' },
+              value: 'حاويات 220',
+              delta: { ar: 'في الميناء 96 ساعة', en: 'Port dwell 96h' }
+            },
+            {
+              icon: 'map',
+              title: { ar: 'شيكاغو → تورنتو', en: 'Chicago → Toronto' },
+              subtitle: { ar: 'تسليم سريع عبر السكك الحديدية', en: 'Express rail service' },
+              value: 'شحنات 78',
+              delta: { ar: 'في الموعد', en: 'On schedule' }
+            },
+            {
+              icon: 'factory',
+              title: { ar: 'مورد الإلكترونيات - فيتنام', en: 'Electronics vendor - Vietnam' },
+              subtitle: { ar: 'زيادة الطاقة 12%', en: 'Capacity up 12%' },
+              value: 'POD الأسبوع المقبل',
+              delta: { ar: 'يتطلب فحص جودة إضافي', en: 'Extra QA required' }
+            }
+          ]
+        },
+        {
+          id: 'inventory',
+          type: 'progress',
+          title: { ar: 'صحة مستويات المخزون', en: 'Inventory health' },
+          items: [
+            {
+              title: { ar: 'مستودع الساحل الشرقي', en: 'East coast DC' },
+              subtitle: { ar: 'استخدام السعة 78%', en: 'Capacity usage 78%' },
+              value: '78%',
+              percent: '78%'
+            },
+            {
+              title: { ar: 'مستودع أوروبا', en: 'Europe hub' },
+              subtitle: { ar: 'أسابيع الغطاء 4.2', en: 'Weeks of cover 4.2' },
+              value: '68%',
+              percent: '68%'
+            },
+            {
+              title: { ar: 'مستودع أمريكا اللاتينية', en: 'LATAM hub' },
+              subtitle: { ar: 'يتطلب إعادة تخزين', en: 'Restock triggered' },
+              value: '42%',
+              percent: '42%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أخبار سلسلة الإمداد', en: 'Supply chain updates' },
+          items: [
+            {
+              icon: 'truck',
+              title: { ar: 'تفعيل شحنات خضراء', en: 'Green freight activated' },
+              subtitle: { ar: 'استخدام وقود منخفض الانبعاث', en: 'Low-emission fuel adoption' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'cube',
+              title: { ar: 'إطلاق أداة رؤية جديدة', en: 'Inventory visibility tool' },
+              subtitle: { ar: 'بيانات زمن فعلي للمخزون', en: 'Real-time inventory insights' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'factory',
+              title: { ar: 'تدقيق سلسلة التوريد', en: 'Supply audit completed' },
+              subtitle: { ar: 'تحسين اتفاقيات الخدمة', en: 'Service-level agreements improved' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-14.html
+++ b/dashboards/dashboard-14.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة العقارات</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">RE</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">RE</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة إدارة العقارات',
+          en: 'Real Estate Portfolio Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'RE',
+        name: {
+          ar: 'مركز الأصول',
+          en: 'Asset Center'
+        },
+        tagline: {
+          ar: 'الإشغال، الإيرادات، وصحة الأصول العقارية',
+          en: 'Occupancy, revenue, and asset health insights'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-indigo-950 to-sky-900',
+        sidebarGradient: 'from-indigo-950 via-blue-900 to-sky-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-indigo-400/30',
+        accentGradient: 'from-blue-500 via-slate-600 to-rose-500',
+        accentText: 'text-blue-200',
+        highlightBg: 'bg-blue-500/10 border-blue-400/30',
+        badgeBg: 'bg-rose-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'building',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'محفظة', en: 'Portfolio' }
+        },
+        {
+          id: 'listings',
+          icon: 'map',
+          label: { ar: 'العقارات والإدراجات', en: 'Properties & listings' }
+        },
+        {
+          id: 'occupancy',
+          icon: 'users',
+          label: { ar: 'الإشغال والإيجارات', en: 'Occupancy & leasing' }
+        },
+        {
+          id: 'revenue',
+          icon: 'bank',
+          label: { ar: 'الإيرادات والتكاليف', en: 'Revenue & costs' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'أولوية الأسبوع', en: 'Priority of the week' },
+        value: 'خطة تحديث برج المينا',
+        description: {
+          ar: 'رفع جودة الخدمات للمستأجرين المميزين وتحسين استدامة الطاقة.',
+          en: 'Enhancing premium tenant services and improving energy efficiency.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة إدارة العقارات',
+          en: 'Real estate management dashboard'
+        },
+        subtitle: {
+          ar: 'مراقبة الإشغال، التدفقات المالية، وحالة الأصول عبر المحافظ.',
+          en: 'Monitor occupancy, financial flows, and asset condition across portfolios.'
+        },
+        primary: {
+          ar: 'إطلاق حملة تأجير',
+          en: 'Launch leasing campaign'
+        },
+        secondary: {
+          ar: 'تحميل تقرير الملاك',
+          en: 'Download owner report'
+        }
+      },
+      stats: [
+        {
+          icon: 'building',
+          label: { ar: 'نسبة الإشغال', en: 'Portfolio occupancy' },
+          value: '91%',
+          delta: { ar: '+2 نقاط منذ الربع الماضي', en: '+2 pts vs last quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'عقود جديدة هذا الشهر', en: 'New leases this month' },
+          value: '38',
+          delta: { ar: '+9 عقود مقارنة بالسنة الماضية', en: '+9 YoY' },
+          trend: 'positive'
+        },
+        {
+          icon: 'bank',
+          label: { ar: 'صفقات قيد التفاوض', en: 'Deals in pipeline' },
+          value: '$124M',
+          delta: { ar: 'زيادة 18M$ خلال أسبوعين', en: '$18M increase in 2 weeks' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cog',
+          label: { ar: 'طلبات الصيانة المفتوحة', en: 'Open maintenance requests' },
+          value: '54',
+          delta: { ar: '-22% بعد نظام التتبع', en: '-22% after tracking rollout' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'العوائد الشهرية للمحافظ', en: 'Monthly returns by portfolio' },
+          subtitle: { ar: 'المباني المكتبية، السكنية، والتجارية.', en: 'Office, residential, and retail assets.' },
+          action: { ar: 'عرض حسب المنطقة', en: 'View by region' },
+          placeholder: { ar: 'مخطط العوائد', en: 'Returns chart' }
+        },
+        {
+          id: 'properties',
+          type: 'list',
+          title: { ar: 'عقارات تستحق الانتباه', en: 'Properties to watch' },
+          action: { ar: 'تحديث مرتين يومياً', en: 'Updated twice daily' },
+          items: [
+            {
+              icon: 'building',
+              title: { ar: 'برج الخليج للأعمال', en: 'Gulf Business Tower' },
+              subtitle: { ar: 'تجديد طابق كامل قيد التنفيذ', en: 'Floor refurbishment in progress' },
+              value: 'إشغال 96%',
+              delta: { ar: 'متوسط إيجار 64$/قدم²', en: 'Avg rent $64/sqft' }
+            },
+            {
+              icon: 'map',
+              title: { ar: 'حدائق السكن الذكية', en: 'Smart Gardens Residences' },
+              subtitle: { ar: 'قائمة انتظار إيجار 41 عائلة', en: 'Waitlist of 41 families' },
+              value: 'إشغال 99%',
+              delta: { ar: 'تقييم رضا 4.8/5', en: 'Satisfaction 4.8/5' }
+            },
+            {
+              icon: 'bank',
+              title: { ar: 'مجمع الميناء اللوجستي', en: 'Harbour Logistics Park' },
+              subtitle: { ar: 'تجديد عقد مع مستأجر رئيسي', en: 'Renewal with anchor tenant' },
+              value: 'عائد 12%',
+              delta: { ar: 'فرصة توسعة 45K متر²', en: 'Expansion opportunity 45K sqm' }
+            }
+          ]
+        },
+        {
+          id: 'occupancy',
+          type: 'progress',
+          title: { ar: 'مؤشرات الإشغال والصيانة', en: 'Occupancy & maintenance KPIs' },
+          items: [
+            {
+              title: { ar: 'الصيانة الوقائية', en: 'Preventive maintenance' },
+              subtitle: { ar: 'تم تنفيذ 92% من الجدول', en: '92% of plan executed' },
+              value: '92%',
+              percent: '92%'
+            },
+            {
+              title: { ar: 'سير الأعمال في العقود', en: 'Lease workflow completion' },
+              subtitle: { ar: 'إدارة رقمية جديدة للتوقيع', en: 'New digital signing process' },
+              value: '74%',
+              percent: '74%'
+            },
+            {
+              title: { ar: 'تجربة المستأجرين', en: 'Tenant experience actions' },
+              subtitle: { ar: 'استبيانات شهرية وتحسينات مشتركة', en: 'Monthly surveys & shared upgrades' },
+              value: '58%',
+              percent: '58%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أحداث العقارات الأخيرة', en: 'Recent real estate events' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'افتتاح صالة المستأجرين الجديدة', en: 'Tenant lounge opening' },
+              subtitle: { ar: 'تجربة ضيافة متكاملة في وسط المدينة', en: 'Hospitality experience in downtown tower' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'cog',
+              title: { ar: 'تحديث نظام إدارة الممتلكات', en: 'Property management system update' },
+              subtitle: { ar: 'تكامل مع واجهة تحليلات البيانات', en: 'Integrated with analytics workspace' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'bank',
+              title: { ar: 'تمويل تطوير جديد', en: 'New development financing' },
+              subtitle: { ar: 'تسهيلات بقيمة 220M$', en: '$220M facility secured' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-15.html
+++ b/dashboards/dashboard-15.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة العمليات التصنيعية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MF</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MF</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة العمليات التصنيعية',
+          en: 'Manufacturing Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'MF',
+        name: {
+          ar: 'مركز الإنتاج',
+          en: 'Production Hub'
+        },
+        tagline: {
+          ar: 'الإنتاجية، الجودة، وصيانة المصنع في الوقت الفعلي',
+          en: 'Productivity, quality, and plant maintenance in real time'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-amber-950 to-orange-900',
+        sidebarGradient: 'from-amber-950 via-orange-900 to-stone-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-amber-400/30',
+        accentGradient: 'from-slate-800 via-amber-500 to-orange-500',
+        accentText: 'text-amber-200',
+        highlightBg: 'bg-amber-500/10 border-amber-400/30',
+        badgeBg: 'bg-orange-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'factory',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'مصنع', en: 'Plant' }
+        },
+        {
+          id: 'production',
+          icon: 'chart-bar',
+          label: { ar: 'أداء الإنتاج', en: 'Production performance' }
+        },
+        {
+          id: 'quality',
+          icon: 'scale',
+          label: { ar: 'الجودة والعيوب', en: 'Quality & defects' }
+        },
+        {
+          id: 'maintenance',
+          icon: 'cog',
+          label: { ar: 'الصيانة والجاهزية', en: 'Maintenance & readiness' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'حالة المصنع', en: 'Plant status' },
+        value: 'تشغيل مستقر',
+        description: {
+          ar: 'خط الإنتاج 3 يعمل بالطاقة القصوى، خطة صيانة وقائية تبدأ غداً.',
+          en: 'Line 3 running at peak load, preventive maintenance scheduled tomorrow.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة العمليات التصنيعية',
+          en: 'Manufacturing operations dashboard'
+        },
+        subtitle: {
+          ar: 'راقب الإنتاج، الجودة، والصيانة في جميع الخطوط.',
+          en: 'Monitor output, quality, and maintenance across lines.'
+        },
+        primary: {
+          ar: 'ضبط خطة الإنتاج',
+          en: 'Adjust production plan'
+        },
+        secondary: {
+          ar: 'إرسال تقرير المصنع',
+          en: 'Send plant report'
+        }
+      },
+      stats: [
+        {
+          icon: 'factory',
+          label: { ar: 'معدل الإنتاج اللحظي', en: 'Real-time throughput' },
+          value: '1,240 وحدة/ساعة',
+          delta: { ar: '+6% عن متوسط الأسبوع', en: '+6% vs weekly average' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'الكفاءة الشاملة للمعدات', en: 'Overall equipment effectiveness' },
+          value: '87%',
+          delta: { ar: '+4 نقاط بعد تحسين الإعداد', en: '+4 pts after setup optimisation' },
+          trend: 'positive'
+        },
+        {
+          icon: 'scale',
+          label: { ar: 'نسبة الهدر', en: 'Scrap rate' },
+          value: '2.1%',
+          delta: { ar: '-0.7 نقطة بفضل مراقبة الجودة', en: '-0.7 pts with inline QA' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cog',
+          label: { ar: 'توقف مخطط للأسبوع', en: 'Planned downtime this week' },
+          value: '18 ساعة',
+          delta: { ar: '3 ساعات أقل من الميزانية', en: '3 hours under budget' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'إنتاج خطوط التصنيع', en: 'Production by line' },
+          subtitle: { ar: 'ساعات العمل الفعلية مقابل المخطط لكل خط.', en: 'Actual vs planned runtime for each line.' },
+          action: { ar: 'تفاصيل حسب الوردية', en: 'View by shift' },
+          placeholder: { ar: 'مخطط الإنتاج', en: 'Production chart' }
+        },
+        {
+          id: 'alerts',
+          type: 'list',
+          title: { ar: 'تنبيهات حرجة', en: 'Critical alerts' },
+          action: { ar: 'آخر تحديث 10 دقائق', en: 'Updated 10 minutes ago' },
+          items: [
+            {
+              icon: 'cog',
+              title: { ar: 'اهتزاز عالٍ على خط التغليف', en: 'High vibration on packaging line' },
+              subtitle: { ar: 'تم تخفيض السرعة حتى المعاينة', en: 'Speed reduced pending inspection' },
+              value: 'قيد المعالجة',
+              delta: { ar: 'فريق الصيانة في الطريق', en: 'Maintenance en route' }
+            },
+            {
+              icon: 'scale',
+              title: { ar: 'زيادة عيوب الجودة في خط 2', en: 'Quality spike on line 2' },
+              subtitle: { ar: 'التحليل يشير إلى مادة خام جديدة', en: 'Linked to new raw batch' },
+              value: 'تم التحقيق',
+              delta: { ar: 'جارٍ تعديل المورد', en: 'Supplier adjustment underway' }
+            },
+            {
+              icon: 'factory',
+              title: { ar: 'استهلاك طاقة أعلى من المتوقع', en: 'Energy consumption above target' },
+              subtitle: { ar: 'قيد المراقبة مع فريق الطاقة', en: 'Energy team monitoring' },
+              value: 'تنبيه متوسط',
+              delta: { ar: 'توصية بتحديث المحركات', en: 'Recommendation: motor upgrade' }
+            }
+          ]
+        },
+        {
+          id: 'maintenance',
+          type: 'progress',
+          title: { ar: 'جاهزية الصيانة', en: 'Maintenance readiness' },
+          items: [
+            {
+              title: { ar: 'الصيانة الوقائية', en: 'Preventive schedule' },
+              subtitle: { ar: 'اكتملت 28 من 30 مهمة', en: '28 of 30 tasks complete' },
+              value: '93%',
+              percent: '93%'
+            },
+            {
+              title: { ar: 'قطع الغيار الحرجة', en: 'Critical spare parts' },
+              subtitle: { ar: 'تغطية لمدة 21 يوم', en: 'Coverage for 21 days' },
+              value: '76%',
+              percent: '76%'
+            },
+            {
+              title: { ar: 'تدريب فرق الصيانة', en: 'Technician training' },
+              subtitle: { ar: 'دورات السلامة والروبوتات', en: 'Safety & robotics modules' },
+              value: '64%',
+              percent: '64%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أخبار المصنع', en: 'Plant news timeline' },
+          items: [
+            {
+              icon: 'factory',
+              title: { ar: 'تشغيل خط التغليف الجديد', en: 'New packaging line launched' },
+              subtitle: { ar: 'زيادة الطاقة بمقدار 14%', en: 'Capacity up 14%' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'تجربة نظام رؤية بالذكاء الاصطناعي', en: 'AI vision pilot deployed' },
+              subtitle: { ar: 'رصد العيوب في الوقت الحقيقي', en: 'Real-time defect detection' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'cog',
+              title: { ar: 'تحديث لوحة التشغيل', en: 'Operations dashboard update' },
+              subtitle: { ar: 'مؤشرات الأداء المباشرة لكل خط', en: 'Live KPIs for each line' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-16.html
+++ b/dashboards/dashboard-16.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة منصة البث</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MS</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MS</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة منصة البث',
+          en: 'Streaming Service Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'MS',
+        name: {
+          ar: 'نبض البث',
+          en: 'Stream Pulse'
+        },
+        tagline: {
+          ar: 'الاشتراكات، المحتوى، وجودة التجربة',
+          en: 'Subscriptions, content, and experience quality'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-fuchsia-950 to-purple-900',
+        sidebarGradient: 'from-fuchsia-950 via-purple-900 to-indigo-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-fuchsia-400/30',
+        accentGradient: 'from-purple-600 via-indigo-500 to-blue-500',
+        accentText: 'text-indigo-200',
+        highlightBg: 'bg-purple-500/10 border-purple-400/30',
+        badgeBg: 'bg-indigo-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'play',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'بث', en: 'Stream' }
+        },
+        {
+          id: 'content',
+          icon: 'sparkles',
+          label: { ar: 'المحتوى والأصناف', en: 'Content & genres' }
+        },
+        {
+          id: 'subscribers',
+          icon: 'users',
+          label: { ar: 'المشتركين والتحويل', en: 'Subscribers & conversion' }
+        },
+        {
+          id: 'performance',
+          icon: 'tv',
+          label: { ar: 'الأداء التقني', en: 'Technical performance' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'إصدار مميز', en: 'Featured release' },
+        value: 'مسلسل الخيال العلمي - الموسم 2',
+        description: {
+          ar: 'حقق 2.4M مشاهدة في 24 ساعة مع تقييم 4.7/5.',
+          en: 'Reached 2.4M views in 24h with 4.7/5 rating.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة منصة البث',
+          en: 'Streaming platform dashboard'
+        },
+        subtitle: {
+          ar: 'إدارة المشتركين، أداء المحتوى، وجاهزية الشبكة.',
+          en: 'Manage subscribers, content performance, and network readiness.'
+        },
+        primary: {
+          ar: 'إطلاق حملة ترويجية',
+          en: 'Launch promo campaign'
+        },
+        secondary: {
+          ar: 'عرض تقرير المحتوى',
+          en: 'View content report'
+        }
+      },
+      stats: [
+        {
+          icon: 'users',
+          label: { ar: 'مشتركين نشطين', en: 'Active subscribers' },
+          value: '3.2M',
+          delta: { ar: '+120K خلال الشهر', en: '+120K this month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'play',
+          label: { ar: 'عدد المشاهدات اليومية', en: 'Daily streams' },
+          value: '18.4M',
+          delta: { ar: '+14% بعد إطلاق الموسم', en: '+14% after season launch' },
+          trend: 'positive'
+        },
+        {
+          icon: 'tv',
+          label: { ar: 'معدل التخزين المؤقت', en: 'Buffering ratio' },
+          value: '0.9%',
+          delta: { ar: '-0.3 نقطة بفضل تحسين CDN', en: '-0.3 pts with CDN tuning' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'وقت مشاهدة أفضل تصنيف', en: 'Top genre watchtime' },
+          value: '6.3M ساعة',
+          delta: { ar: '+1.1M ساعة أسبوعياً', en: '+1.1M hours weekly' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى المشاهدات اليومية', en: 'Daily view curve' },
+          subtitle: { ar: 'توزيع المشاهدات حسب الجهاز والمنطقة.', en: 'Views segmented by device and region.' },
+          action: { ar: 'تصدير CSV', en: 'Export CSV' },
+          placeholder: { ar: 'مخطط المشاهدات', en: 'View chart' }
+        },
+        {
+          id: 'content',
+          type: 'list',
+          title: { ar: 'أعمال محتوى بارزة', en: 'Featured content performance' },
+          action: { ar: 'تحديث تلقائي', en: 'Auto refreshed' },
+          items: [
+            {
+              icon: 'play',
+              title: { ar: 'وثائقي الطاقة الشمسية', en: 'Solar energy documentary' },
+              subtitle: { ar: 'تقييم 4.9/5', en: 'Rating 4.9/5' },
+              value: '1.3M مشاهدة',
+              delta: { ar: '+32% نمو', en: '+32% growth' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'سلسلة الأكشن الليلية', en: 'Night action series' },
+              subtitle: { ar: 'معدل إكمال 71%', en: 'Completion 71%' },
+              value: '2.7M مشاهدة',
+              delta: { ar: '+0.8M منذ الأسبوع الماضي', en: '+0.8M since last week' }
+            },
+            {
+              icon: 'tv',
+              title: { ar: 'برنامج البث المباشر الرياضي', en: 'Live sports show' },
+              subtitle: { ar: 'متوسط مشاهدة متزامنة 420K', en: 'Concurrent viewers 420K' },
+              value: '90 دقيقة',
+              delta: { ar: 'زمن مشاهدة قياسي', en: 'Record watchtime' }
+            }
+          ]
+        },
+        {
+          id: 'experience',
+          type: 'progress',
+          title: { ar: 'جودة التجربة', en: 'Experience quality' },
+          items: [
+            {
+              title: { ar: 'تجربة الفيديو 4K', en: '4K streaming readiness' },
+              subtitle: { ar: 'تمكين في 16 دولة', en: 'Enabled in 16 countries' },
+              value: '84%',
+              percent: '84%'
+            },
+            {
+              title: { ar: 'تحديثات التطبيقات', en: 'App updates rollout' },
+              subtitle: { ar: 'أندرويد و iOS 97% تغطية', en: 'Android & iOS 97% coverage' },
+              value: '97%',
+              percent: '97%'
+            },
+            {
+              title: { ar: 'الدعم الفوري', en: 'Instant support resolution' },
+              subtitle: { ar: 'متوسط الرد 42 ثانية', en: 'Avg response 42s' },
+              value: '89%',
+              percent: '89%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أخبار المنصة', en: 'Platform updates timeline' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق واجهة التوصيات الجديدة', en: 'New recommendations UI launched' },
+              subtitle: { ar: 'دعم التخصيص العميق للمستخدم', en: 'Deep user personalisation' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'tv',
+              title: { ar: 'التوسع في البنية التحتية للبث', en: 'Streaming infrastructure expansion' },
+              subtitle: { ar: 'خوادم إضافية في آسيا وأوروبا', en: 'Additional POPs in Asia & Europe' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'برنامج إحالة مشتركين', en: 'Subscriber referral program' },
+              subtitle: { ar: 'مكافآت تجربة مجانية لمدة أسبوع', en: 'Free week rewards' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-17.html
+++ b/dashboards/dashboard-17.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة المدينة الذكية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">CT</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">CT</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة المدينة الذكية',
+          en: 'Smart City Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'CT',
+        name: {
+          ar: 'مركز المدينة الذكية',
+          en: 'Smart City Center'
+        },
+        tagline: {
+          ar: 'الحركة، الطاقة، والخدمات الحضرية الذكية',
+          en: 'Mobility, energy, and smart civic services'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-blue-950 to-lime-900',
+        sidebarGradient: 'from-blue-950 via-sky-900 to-lime-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-sky-400/30',
+        accentGradient: 'from-cyan-500 via-emerald-500 to-lime-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-cyan-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'map',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'مدينة', en: 'City' }
+        },
+        {
+          id: 'mobility',
+          icon: 'truck',
+          label: { ar: 'الحركة والتنقل', en: 'Mobility' }
+        },
+        {
+          id: 'energy',
+          icon: 'sun',
+          label: { ar: 'الطاقة والاستدامة', en: 'Energy & sustainability' }
+        },
+        {
+          id: 'services',
+          icon: 'sparkles',
+          label: { ar: 'الخدمات الحضرية', en: 'Urban services' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'تنبيه تشغيلي', en: 'Operational alert' },
+        value: 'إغلاق شارع رئيسي مؤقت',
+        description: {
+          ar: 'أعمال الصيانة الليلية تتطلب تحويل مسار حركة المرور حتى صباح الغد.',
+          en: 'Night maintenance requires rerouting traffic until tomorrow morning.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة المدينة الذكية',
+          en: 'Smart city dashboard'
+        },
+        subtitle: {
+          ar: 'قياس الأداء الحضري عبر التنقل، الطاقة، والخدمات الرقمية.',
+          en: 'Measure urban performance across mobility, energy, and digital services.'
+        },
+        primary: {
+          ar: 'إرسال تحديث للسكان',
+          en: 'Send resident update'
+        },
+        secondary: {
+          ar: 'عرض خريطة الاستشعار',
+          en: 'View sensor map'
+        }
+      },
+      stats: [
+        {
+          icon: 'truck',
+          label: { ar: 'انسيابية المرور', en: 'Traffic flow' },
+          value: '87%',
+          delta: { ar: '+5% بعد إدارة الإشارات الذكية', en: '+5% with smart signals' },
+          trend: 'positive'
+        },
+        {
+          icon: 'users',
+          label: { ar: 'التزام النقل العام بالمواعيد', en: 'Transit on-time rate' },
+          value: '92%',
+          delta: { ar: '+7 نقاط منذ الشهر الماضي', en: '+7 pts vs last month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sun',
+          label: { ar: 'استهلاك الطاقة اليومي', en: 'Daily energy consumption' },
+          value: '1.8GWh',
+          delta: { ar: '-9% بفضل الألواح الشمسية', en: '-9% via solar grid' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'طلبات المواطنين المنجزة', en: 'Citizen service requests resolved' },
+          value: '76%',
+          delta: { ar: '+12% بعد مركز الخدمة الموحد', en: '+12% after unified portal' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مؤشرات المدينة اليومية', en: 'Daily city indicators' },
+          subtitle: { ar: 'حركة المرور، الطاقة، وجودة الهواء عبر الأحياء.', en: 'Traffic, energy, and air quality across districts.' },
+          action: { ar: 'التفاصيل حسب الحي', en: 'Detail by district' },
+          placeholder: { ar: 'مخطط المؤشرات', en: 'City metrics' }
+        },
+        {
+          id: 'mobility',
+          type: 'list',
+          title: { ar: 'محاور الحركة النشطة', en: 'Active mobility corridors' },
+          action: { ar: 'تحديث كل 15 دقيقة', en: 'Refresh every 15 minutes' },
+          items: [
+            {
+              icon: 'map',
+              title: { ar: 'محور الشمال السريع', en: 'North expressway' },
+              subtitle: { ar: 'تدفق 93%، زمن رحلة 18 دقيقة', en: 'Flow 93%, travel time 18 min' },
+              value: 'في المسار',
+              delta: { ar: 'لا توجد اختناقات', en: 'No congestion' }
+            },
+            {
+              icon: 'truck',
+              title: { ar: 'شبكة الحافلات الذكية', en: 'Smart bus network' },
+              subtitle: { ar: '90% حافلات في الموعد', en: '90% buses on schedule' },
+              value: 'حالة جيدة',
+              delta: { ar: 'تشغيل 312 مركبة', en: '312 vehicles running' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'ممر الدراجات الخضراء', en: 'Green bike corridor' },
+              subtitle: { ar: 'أكثر من 6.2K رحلة يومية', en: '6.2K trips daily' },
+              value: 'نشط',
+              delta: { ar: 'حوافز استخدام جديدة', en: 'New usage incentives' }
+            }
+          ]
+        },
+        {
+          id: 'sustainability',
+          type: 'progress',
+          title: { ar: 'مؤشرات الاستدامة', en: 'Sustainability indicators' },
+          items: [
+            {
+              title: { ar: 'الطاقة المتجددة', en: 'Renewable energy share' },
+              subtitle: { ar: 'محطات شمسية جديدة على الأسطح', en: 'Rooftop solar expansion' },
+              value: '61%',
+              percent: '61%'
+            },
+            {
+              title: { ar: 'إدارة النفايات الذكية', en: 'Smart waste collection' },
+              subtitle: { ar: 'الحاويات الذكية في 12 حي', en: 'Smart bins in 12 districts' },
+              value: '74%',
+              percent: '74%'
+            },
+            {
+              title: { ar: 'المساحات الخضراء لكل مقيم', en: 'Green space per resident' },
+              subtitle: { ar: 'التوسع في المتنزهات الحضرية', en: 'Urban park expansions' },
+              value: '48%',
+              percent: '48%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'تحديثات المدينة', en: 'City updates timeline' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق منصة الخدمات الموحدة', en: 'Unified services portal launched' },
+              subtitle: { ar: '30 خدمة رقمية في مكان واحد', en: '30 digital services consolidated' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'sun',
+              title: { ar: 'بدء تشغيل مزرعة الطاقة الشمسية', en: 'Solar farm commissioned' },
+              subtitle: { ar: 'قدرة 25 ميجاوات للمنطقة الصناعية', en: '25MW for industrial zone' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'ورشة مشاركة مجتمعية', en: 'Community co-creation workshop' },
+              subtitle: { ar: 'مشاركة 280 مشاركاً في تخطيط الحي', en: '280 residents shaping neighborhood plan' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-18.html
+++ b/dashboards/dashboard-18.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تجربة الضيافة</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">HT</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">HT</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة تجربة الضيافة',
+          en: 'Hospitality Experience Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'HT',
+        name: {
+          ar: 'مجموعة الضيافة الراقية',
+          en: 'Prestige Hospitality Group'
+        },
+        tagline: {
+          ar: 'فنادق، منتجعات، وتجارب ضيافة فاخرة',
+          en: 'Hotels, resorts, and elevated guest journeys'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-rose-950 to-amber-900',
+        sidebarGradient: 'from-rose-950 via-amber-900 to-orange-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-rose-400/30',
+        accentGradient: 'from-rose-500 via-amber-500 to-emerald-500',
+        accentText: 'text-amber-200',
+        highlightBg: 'bg-amber-500/10 border-amber-400/30',
+        badgeBg: 'bg-rose-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'building',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'المجموعة', en: 'Group' }
+        },
+        {
+          id: 'occupancy',
+          icon: 'calendar',
+          label: { ar: 'الإشغال والحجوزات', en: 'Occupancy & bookings' }
+        },
+        {
+          id: 'experience',
+          icon: 'heart',
+          label: { ar: 'تجربة الضيوف', en: 'Guest experience' }
+        },
+        {
+          id: 'revenue',
+          icon: 'bank',
+          label: { ar: 'الإيرادات والتسعير', en: 'Revenue & pricing' }
+        },
+        {
+          id: 'operations',
+          icon: 'sparkles',
+          label: { ar: 'العمليات اليومية', en: 'Daily operations' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'فرصة مميزة', en: 'Featured opportunity' },
+        value: 'باقة موسم الأعياد الجديدة',
+        description: {
+          ar: 'استفد من معدل تحويل مرتفع لحزمة الأجنحة الفاخرة في عطلة نهاية الأسبوع.',
+          en: 'Capitalize on the high-converting luxury suite weekend package.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة تجربة الضيوف',
+          en: 'Guest experience intelligence'
+        },
+        subtitle: {
+          ar: 'راقب معدلات الإشغال، رضا الضيوف، وإيرادات الغرف عبر محفظة الفنادق.',
+          en: 'Monitor occupancy, guest sentiment, and room revenue across the hotel portfolio.'
+        },
+        primary: {
+          ar: 'إطلاق حملة ترقية',
+          en: 'Launch upgrade campaign'
+        },
+        secondary: {
+          ar: 'عرض الملاحظات التفصيلية',
+          en: 'View feedback details'
+        }
+      },
+      stats: [
+        {
+          icon: 'building',
+          label: { ar: 'متوسط إشغال الغرف', en: 'Average room occupancy' },
+          value: '88%',
+          delta: { ar: '+6% مقارنة بالأسبوع الماضي', en: '+6% vs last week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'calendar',
+          label: { ar: 'حجوزات الشهر القادم', en: 'Next-month bookings' },
+          value: '12.4K',
+          delta: { ar: '+1.2K بعد الحملة الرقمية', en: '+1.2K after digital push' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'مؤشر رضا الضيوف', en: 'Guest satisfaction index' },
+          value: '4.7 / 5',
+          delta: { ar: '+0.3 عن متوسط الموسم', en: '+0.3 vs seasonal avg.' },
+          trend: 'positive'
+        },
+        {
+          icon: 'bank',
+          label: { ar: 'متوسط العائد لكل غرفة', en: 'RevPAR' },
+          value: '$216',
+          delta: { ar: '+$14 عن العام الماضي', en: '+$14 YoY' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مؤشرات الضيافة اليومية', en: 'Daily hospitality metrics' },
+          subtitle: { ar: 'الإشغال، متوسط الأسعار، وقنوات الحجز لكل فندق.', en: 'Occupancy, ADR, and booking mix by property.' },
+          action: { ar: 'عرض حسب المنطقة', en: 'View by region' },
+          placeholder: { ar: 'مخطط الأداء اليومي', en: 'Daily performance chart' }
+        },
+        {
+          id: 'occupancy',
+          type: 'list',
+          title: { ar: 'أعلى الفنادق أداءً', en: 'Top performing hotels' },
+          action: { ar: 'مقارنة بكل الفنادق', en: 'Compare all hotels' },
+          items: [
+            {
+              icon: 'building',
+              title: { ar: 'منتجع الخليج الذهبي', en: 'Golden Gulf Resort' },
+              subtitle: { ar: 'إشغال 94% | إيراد غرفة $289', en: '94% occupancy | $289 ADR' },
+              value: 'NPS 72',
+              delta: { ar: '+8 نقاط خلال 30 يوماً', en: '+8 pts in 30 days' }
+            },
+            {
+              icon: 'building',
+              title: { ar: 'فندق سنترال سكاي', en: 'Central Sky Hotel' },
+              subtitle: { ar: 'إشغال 89% | إيراد غرفة $198', en: '89% occupancy | $198 ADR' },
+              value: 'NPS 66',
+              delta: { ar: '+5 نقاط بعد تجديد اللوبي', en: '+5 after lobby refresh' }
+            },
+            {
+              icon: 'building',
+              title: { ar: 'أجنحة الواحة', en: 'Oasis Suites' },
+              subtitle: { ar: 'إشغال 86% | إيراد غرفة $235', en: '86% occupancy | $235 ADR' },
+              value: 'NPS 70',
+              delta: { ar: '+4 نقاط من خدمة الكونسييرج', en: '+4 via concierge service' }
+            }
+          ]
+        },
+        {
+          id: 'experience',
+          type: 'progress',
+          title: { ar: 'مشروعات تجربة الضيوف', en: 'Guest experience initiatives' },
+          items: [
+            {
+              title: { ar: 'برنامج الترحيب الرقمي', en: 'Digital welcome program' },
+              subtitle: { ar: 'خدمة تسجيل الوصول المسبق والرسائل الشخصية.', en: 'Pre-arrival check-in with tailored messaging.' },
+              value: '78% مكتمل',
+              percent: '78%'
+            },
+            {
+              title: { ar: 'تحسين الإفطار الشامل', en: 'Breakfast experience revamp' },
+              subtitle: { ar: 'قوائم موسمية ومحطات طهي مباشرة.', en: 'Seasonal menus with live stations.' },
+              value: '62% مكتمل',
+              percent: '62%'
+            },
+            {
+              title: { ar: 'مساعد ضيوف بالذكاء الاصطناعي', en: 'AI concierge assistant' },
+              subtitle: { ar: 'اقتراحات فورية للغرف والفعاليات المحلية.', en: 'Instant in-room tips and local curation.' },
+              value: '45% مكتمل',
+              percent: '45%'
+            }
+          ]
+        },
+        {
+          id: 'revenue',
+          type: 'chart',
+          title: { ar: 'استراتيجية التسعير الديناميكي', en: 'Dynamic pricing strategy' },
+          subtitle: { ar: 'تتبع الأسعار المتغيرة حسب شريحة العملاء وتاريخ الحجز.', en: 'Track rate adjustments by segment and booking window.' },
+          action: { ar: 'إدارة الجداول الزمنية', en: 'Manage calendars' },
+          placeholder: { ar: 'مخطط التسعير حسب الشريحة', en: 'Pricing per segment' }
+        },
+        {
+          id: 'operations',
+          type: 'timeline',
+          span: 'xl:col-span-2',
+          title: { ar: 'جدول خدمات الضيوف', en: 'Guest services schedule' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'تدقيق أجنحة كبار الشخصيات', en: 'VIP suite inspection' },
+              subtitle: { ar: 'التأكد من تجهيزات الترحيب قبل الوصول.', en: 'Ensure welcome amenities before arrival.' },
+              time: { ar: '09:30 صباحاً', en: '09:30 AM' }
+            },
+            {
+              icon: 'calendar',
+              title: { ar: 'فعالية تذوق المأكولات', en: 'Culinary tasting event' },
+              subtitle: { ar: 'عرض قائمة الطاهي الجديدة لمجموعة من المؤثرين.', en: 'Showcase new chef menu to influencers.' },
+              time: { ar: '01:00 ظهراً', en: '01:00 PM' }
+            },
+            {
+              icon: 'heart',
+              title: { ar: 'متابعة تقييمات الضيوف', en: 'Guest feedback follow-up' },
+              subtitle: { ar: 'الاتصال بضيوف الباقات العائلية لضمان الرضا.', en: 'Call family package guests for satisfaction check.' },
+              time: { ar: '05:45 مساءً', en: '05:45 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-19.html
+++ b/dashboards/dashboard-19.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الطاقة المتجددة</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">RE</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">RE</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الطاقة المتجددة',
+          en: 'Renewable Energy Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'RE',
+        name: {
+          ar: 'شبكة الطاقة الخضراء',
+          en: 'Green Grid Alliance'
+        },
+        tagline: {
+          ar: 'طاقة شمسية، رياح، وتخزين ذكي للشبكات',
+          en: 'Solar, wind, and intelligent storage orchestration'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-emerald-950 to-lime-900',
+        sidebarGradient: 'from-emerald-950 via-lime-900 to-sky-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-lime-400/30',
+        accentGradient: 'from-emerald-500 via-teal-500 to-sky-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'chart-bar',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'تشغيل', en: 'Ops' }
+        },
+        {
+          id: 'generation',
+          icon: 'sun',
+          label: { ar: 'الإنتاج المباشر', en: 'Live generation' }
+        },
+        {
+          id: 'grid',
+          icon: 'cloud',
+          label: { ar: 'الشبكة والتخزين', en: 'Grid & storage' }
+        },
+        {
+          id: 'maintenance',
+          icon: 'cog',
+          label: { ar: 'الصيانة والمشاريع', en: 'Maintenance & projects' }
+        },
+        {
+          id: 'sustainability',
+          icon: 'leaf',
+          label: { ar: 'الاستدامة والأثر', en: 'Sustainability impact' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'تنبيه الشبكة', en: 'Grid alert' },
+        value: 'سحابة رملية تؤثر على محطات الطاقة الشمسية',
+        description: {
+          ar: 'انخفاض إنتاجية الألواح بنسبة 9% خلال الساعتين القادمتين، إعادة التوزيع مطلوبة.',
+          en: 'Solar output forecasted -9% for next 2 hours, redistribute load accordingly.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة عمليات الطاقة المتجددة',
+          en: 'Renewable operations overview'
+        },
+        subtitle: {
+          ar: 'راقب إنتاج الطاقة، توازن الشبكة، ومبادرات الاستدامة في الوقت الفعلي.',
+          en: 'Track generation, grid balance, and sustainability programs in real time.'
+        },
+        primary: {
+          ar: 'إعادة ضبط توزيع الأحمال',
+          en: 'Rebalance grid dispatch'
+        },
+        secondary: {
+          ar: 'استعراض خطة الصيانة',
+          en: 'Review maintenance plan'
+        }
+      },
+      stats: [
+        {
+          icon: 'sun',
+          label: { ar: 'الإنتاج الشمسي الحالي', en: 'Current solar output' },
+          value: '612 MW',
+          delta: { ar: '-5% بسبب الغبار', en: '-5% due to dust' },
+          trend: 'negative'
+        },
+        {
+          icon: 'cloud',
+          label: { ar: 'طاقة الرياح قيد الاستخدام', en: 'Wind capacity utilized' },
+          value: '74%',
+          delta: { ar: '+11% خلال آخر 24 ساعة', en: '+11% over 24h' },
+          trend: 'positive'
+        },
+        {
+          icon: 'leaf',
+          label: { ar: 'انبعاثات تم تجنبها اليوم', en: 'Emissions avoided today' },
+          value: '1.9 kt CO₂e',
+          delta: { ar: '+0.4 مقارنة بالهدف', en: '+0.4 vs target' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'كفاءة التخزين', en: 'Storage efficiency' },
+          value: '91%',
+          delta: { ar: '+3 نقاط عن المتوسط الشهري', en: '+3 pts vs monthly avg.' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مؤشرات توليد الطاقة المباشرة', en: 'Live generation overview' },
+          subtitle: { ar: 'مزيج الطاقة حسب المصدر والموقع، مع توقعات الساعات الأربع القادمة.', en: 'Generation mix by source and site with 4-hour forecast.' },
+          action: { ar: 'تفاصيل محطات الطاقة', en: 'View plant details' },
+          placeholder: { ar: 'مخطط الإنتاج الفوري', en: 'Real-time output chart' }
+        },
+        {
+          id: 'generation',
+          type: 'list',
+          title: { ar: 'أعلى المزارع إنتاجاً', en: 'Top producing farms' },
+          action: { ar: 'عرض كامل المحفظة', en: 'View full portfolio' },
+          items: [
+            {
+              icon: 'sun',
+              title: { ar: 'مجمع شمس الجنوب', en: 'Southern Sun Complex' },
+              subtitle: { ar: 'إنتاج 182 ميجاوات | انحراف -4%', en: '182 MW output | -4% deviation' },
+              value: 'إتاحة 96%',
+              delta: { ar: 'عمليات التنظيف تبدأ خلال ساعة', en: 'Cleaning crews in 1 hr' }
+            },
+            {
+              icon: 'cloud',
+              title: { ar: 'محطة رياح الساحل', en: 'Coastal Wind Hub' },
+              subtitle: { ar: 'إنتاج 154 ميجاوات | انحراف +7%', en: '154 MW output | +7% deviation' },
+              value: 'إتاحة 99%',
+              delta: { ar: 'سرعة رياح مستقرة', en: 'Stable wind speeds' }
+            },
+            {
+              icon: 'leaf',
+              title: { ar: 'مختبر التخزين الأخضر', en: 'Green Storage Lab' },
+              subtitle: { ar: 'شحن 68 ميجاوات | تفريغ 52 ميجاوات', en: 'Charging 68 MW | Discharging 52 MW' },
+              value: 'دورة 18%',
+              delta: { ar: 'وضع تحسين ذاتي', en: 'Auto-optimization active' }
+            }
+          ]
+        },
+        {
+          id: 'grid',
+          type: 'progress',
+          title: { ar: 'صحة الشبكة والتخزين', en: 'Grid & storage health' },
+          items: [
+            {
+              title: { ar: 'مستوى امتلاء البطاريات الإقليمية', en: 'Regional battery state of charge' },
+              subtitle: { ar: 'متوسط 82% عبر 14 موقع تخزين.', en: 'Averaging 82% across 14 storage sites.' },
+              value: '82%',
+              percent: '82%'
+            },
+            {
+              title: { ar: 'مرونة الشبكة الذكية', en: 'Smart grid flexibility' },
+              subtitle: { ar: 'قدرة تحويل أحمال فورية تصل إلى 320 ميجاوات.', en: 'Instant demand response up to 320 MW.' },
+              value: '76%',
+              percent: '76%'
+            },
+            {
+              title: { ar: 'مؤشر انقطاعات العملاء', en: 'Customer outage index' },
+              subtitle: { ar: 'أقل من 3 دقائق انقطاع متوسط لكل عميل.', en: 'Under 3 min interruption per customer.' },
+              value: '98%',
+              percent: '98%'
+            }
+          ]
+        },
+        {
+          id: 'maintenance',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'جدول الصيانة الحرجة', en: 'Critical maintenance schedule' },
+          action: { ar: 'تحميل خطة العمل', en: 'Download work plan' },
+          headers: [
+            { ar: 'الموقع', en: 'Site' },
+            { ar: 'الأولوية', en: 'Priority' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            {
+              name: { ar: 'توربين رياح - خليج الشمال', en: 'Wind Turbine - North Bay' },
+              metric: 'حرجة خلال 18 ساعة | Critical in 18h',
+              delta: { ar: '-12% إنتاج', en: '-12% output' },
+              trend: 'negative'
+            },
+            {
+              name: { ar: 'محطة شمسية - الواحة', en: 'Solar Field - Oasis' },
+              metric: 'تنظيف الانعكاس العالي | High-reflection cleaning',
+              delta: { ar: '+6% كفاءة متوقعة', en: '+6% efficiency' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'بطارية - مركز المدن', en: 'Battery - Urban Core' },
+              metric: 'ترقية برمجية الليلة | Firmware tonight',
+              delta: { ar: 'لا تغيير', en: 'No change' },
+              trend: 'neutral'
+            }
+          ]
+        },
+        {
+          id: 'sustainability',
+          type: 'timeline',
+          title: { ar: 'مبادرات الاستدامة اليوم', en: 'Today’s sustainability actions' },
+          items: [
+            {
+              icon: 'leaf',
+              title: { ar: 'تدشين حملة الترشيد', en: 'Demand reduction launch' },
+              subtitle: { ar: 'إشعار للمنازل الذكية لتقليل الاستهلاك المسائي.', en: 'Smart homes notified to trim evening usage.' },
+              time: { ar: '08:00 صباحاً', en: '08:00 AM' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'تجربة خلايا تخزين جديدة', en: 'Pilot of new storage cells' },
+              subtitle: { ar: 'اختبار تقنية تبريد سائل للهياكل المعيارية.', en: 'Testing liquid-cooled modular racks.' },
+              time: { ar: '02:15 ظهراً', en: '02:15 PM' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'ورشة تعليم مجتمعية', en: 'Community energy workshop' },
+              subtitle: { ar: 'جلسة تعريفية حول طاقة الأسطح للمراكز الحضرية.', en: 'Urban centers intro to rooftop solar.' },
+              time: { ar: '06:30 مساءً', en: '06:30 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-2.html
+++ b/dashboards/dashboard-2.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة المشاريع</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">P</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">P</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة إدارة المشاريع',
+          en: 'Project Portfolio Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'P',
+        name: {
+          ar: 'تحكم المشاريع',
+          en: 'Project Pulse'
+        },
+        tagline: {
+          ar: 'متابعة التسليم متعدد الفرق',
+          en: 'Multi-team delivery monitor'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-sky-950 to-cyan-900',
+        sidebarGradient: 'from-slate-950 via-sky-900 to-cyan-900',
+        cardBg: 'bg-slate-900/65 backdrop-blur-xl',
+        cardBorder: 'border-cyan-400/30',
+        accentGradient: 'from-cyan-500 via-sky-500 to-blue-500',
+        accentText: 'text-cyan-200',
+        highlightBg: 'bg-cyan-500/10 border-cyan-400/30',
+        badgeBg: 'bg-cyan-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'presentation-chart',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'حالي', en: 'Current' }
+        },
+        {
+          id: 'roadmap',
+          icon: 'map',
+          label: { ar: 'خارطة الطريق', en: 'Roadmap' }
+        },
+        {
+          id: 'resources',
+          icon: 'users',
+          label: { ar: 'إدارة الموارد', en: 'Resource management' }
+        },
+        {
+          id: 'risks',
+          icon: 'shield',
+          label: { ar: 'المخاطر', en: 'Risks' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'إنجاز الربع', en: 'Quarter delivery' },
+        value: '78%',
+        description: {
+          ar: 'ثلاث مبادرات استراتيجية تسير وفق الخطة الزمنية.',
+          en: 'Three strategic initiatives remain on schedule.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة إدارة المشاريع',
+          en: 'Project delivery dashboard'
+        },
+        subtitle: {
+          ar: 'تتبع الإنجاز والمخاطر والاعتمادات عبر المحافظ.',
+          en: 'Track completion, risks, and dependencies across the portfolio.'
+        },
+        primary: {
+          ar: 'تصدير مخطط السعة',
+          en: 'Export capacity plan'
+        },
+        secondary: {
+          ar: 'عرض خط الأساس',
+          en: 'View baseline'
+        }
+      },
+      stats: [
+        {
+          icon: 'folder',
+          label: { ar: 'مشاريع جارية', en: 'Active projects' },
+          value: '18',
+          delta: { ar: '+3 مبادرات جديدة هذا الربع', en: '+3 new initiatives this quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'الالتزام بالموعد', en: 'On-time delivery' },
+          value: '86%',
+          delta: { ar: '+4% تحسن عن الشهر الماضي', en: '+4% improvement vs last month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'users',
+          label: { ar: 'استخدام الفرق', en: 'Team utilisation' },
+          value: '74%',
+          delta: { ar: '+6% توزيع أفضل للقدرات', en: '+6% better allocation of capacity' },
+          trend: 'positive'
+        },
+        {
+          icon: 'shield',
+          label: { ar: 'مخاطر مفتوحة', en: 'Open risks' },
+          value: '5',
+          delta: { ar: 'تمت معالجة خطرين هذا الأسبوع', en: 'Mitigated two risks this week' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'السرعة التراكمية', en: 'Cumulative velocity' },
+          subtitle: { ar: 'مقارنة المخرجات لكل فريق عبر ثمانية أسابيع.', en: 'Team output comparison across eight weeks.' },
+          action: { ar: 'مشاركة', en: 'Share link' },
+          placeholder: { ar: 'مخطط السرعة', en: 'Velocity chart' }
+        },
+        {
+          id: 'projects',
+          type: 'list',
+          title: { ar: 'أهم المشاريع', en: 'Top projects' },
+          action: { ar: 'تحديث منذ 10 دقائق', en: 'Updated 10 minutes ago' },
+          items: [
+            {
+              icon: 'briefcase',
+              title: { ar: 'منصة البيانات المؤسسية', en: 'Enterprise data platform' },
+              subtitle: { ar: 'مرحلة التطوير', en: 'Development phase' },
+              value: '92%',
+              delta: { ar: 'جاهز للتسليم', en: 'Ready for launch' }
+            },
+            {
+              icon: 'cloud',
+              title: { ar: 'ترحيل البنية السحابية', en: 'Cloud migration' },
+              subtitle: { ar: 'اكتمل 6 من 8 موجات', en: '6 of 8 waves completed' },
+              value: '75%',
+              delta: { ar: 'لا توجد مخاطر حرجة', en: 'No critical risks' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'برنامج تبني المنصة', en: 'Platform adoption program' },
+              subtitle: { ar: 'ورش تدريب أسبوعية', en: 'Weekly enablement workshops' },
+              value: '61%',
+              delta: { ar: 'يتطلب موارد إضافية', en: 'Needs additional capacity' }
+            }
+          ]
+        },
+        {
+          id: 'phases',
+          type: 'progress',
+          title: { ar: 'تقدم مراحل خارطة الطريق', en: 'Roadmap phase progress' },
+          items: [
+            {
+              title: { ar: 'مرحلة الاكتشاف', en: 'Discovery phase' },
+              subtitle: { ar: 'المخرجات معتمدة', en: 'Deliverables approved' },
+              value: '90%',
+              percent: '90%'
+            },
+            {
+              title: { ar: 'مرحلة البناء', en: 'Build phase' },
+              subtitle: { ar: 'دمج مستمر واختبارات جودة', en: 'Continuous integration and QA' },
+              value: '68%',
+              percent: '68%'
+            },
+            {
+              title: { ar: 'النشر والتبني', en: 'Rollout & adoption' },
+              subtitle: { ar: 'جاهزية خطة الاتصال', en: 'Communication plan ready' },
+              value: '54%',
+              percent: '54%'
+            }
+          ]
+        },
+        {
+          id: 'milestones',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'آخر المستجدات', en: 'Latest updates' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'اعتماد خارطة طريق الربع الثالث', en: 'Q3 roadmap approved' },
+              subtitle: { ar: 'تم اعتماد الميزانية المتعددة الفرق', en: 'Cross-team budget secured' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'اكتمال تدريب الفريق الجديد', en: 'New team onboarding complete' },
+              subtitle: { ar: '14 عضواً أنهوا برنامج السرعة', en: '14 members finished velocity bootcamp' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'shield',
+              title: { ar: 'خفض مستوى مخاطر الاندماج', en: 'Integration risk downgraded' },
+              subtitle: { ar: 'تم تنفيذ خطة التخفيف', en: 'Mitigation plan implemented' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-20.html
+++ b/dashboards/dashboard-20.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة الرياضة</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">SP</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">SP</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة إدارة الرياضة',
+          en: 'Sports Management Analytics Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'SP',
+        name: {
+          ar: 'مركز أداء البطولات',
+          en: 'Championship Performance Hub'
+        },
+        tagline: {
+          ar: 'تحليلات للفرق، الجماهير، والعمليات الميدانية',
+          en: 'Analytics for teams, fans, and game-day ops'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-indigo-950 to-amber-900',
+        sidebarGradient: 'from-indigo-950 via-amber-900 to-purple-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-indigo-400/30',
+        accentGradient: 'from-indigo-500 via-violet-500 to-rose-500',
+        accentText: 'text-violet-200',
+        highlightBg: 'bg-violet-500/10 border-violet-400/30',
+        badgeBg: 'bg-indigo-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'trophy',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'نادي', en: 'Club' }
+        },
+        {
+          id: 'performance',
+          icon: 'chart-bar',
+          label: { ar: 'أداء الفريق', en: 'Team performance' }
+        },
+        {
+          id: 'fans',
+          icon: 'users',
+          label: { ar: 'الجماهير والتذاكر', en: 'Fans & tickets' }
+        },
+        {
+          id: 'media',
+          icon: 'megaphone',
+          label: { ar: 'الإعلام والرعاة', en: 'Media & sponsors' }
+        },
+        {
+          id: 'operations',
+          icon: 'play',
+          label: { ar: 'عمليات يوم المباراة', en: 'Game-day operations' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'تنبيه المباراة', en: 'Match alert' },
+        value: 'مباراة نصف النهائي تبدأ خلال 4 ساعات',
+        description: {
+          ar: 'تأكد من جاهزية الفريق، التنسيق الجماهيري، وتفعيل مزايا الرعاة قبل الافتتاح.',
+          en: 'Ensure squad readiness, fan coordination, and sponsor activations before kickoff.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة أداء النادي الرياضي',
+          en: 'Club performance intelligence'
+        },
+        subtitle: {
+          ar: 'تابع نتائج المباريات، صحة اللاعبين، وتفاعل الجماهير عبر موسم البطولة.',
+          en: 'Follow match results, player wellness, and fan engagement throughout the season.'
+        },
+        primary: {
+          ar: 'إعداد تقرير ما قبل المباراة',
+          en: 'Prepare pre-match report'
+        },
+        secondary: {
+          ar: 'جدولة جلسة التدريب',
+          en: 'Schedule training session'
+        }
+      },
+      stats: [
+        {
+          icon: 'trophy',
+          label: { ar: 'سجل الانتصارات هذا الموسم', en: 'Season win record' },
+          value: '18-3',
+          delta: { ar: '+5 مباريات عن الموسم الماضي', en: '+5 vs last season' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'متوسط نقاط المباراة', en: 'Average points per game' },
+          value: '92.6',
+          delta: { ar: '+4.3 خلال آخر 6 مباريات', en: '+4.3 over last 6 games' },
+          trend: 'positive'
+        },
+        {
+          icon: 'users',
+          label: { ar: 'نسبة إشغال المدرجات', en: 'Stadium occupancy rate' },
+          value: '97%',
+          delta: { ar: '+8% بعد حملة الأعضاء', en: '+8% after member drive' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'جاهزية اللاعبين الأساسيين', en: 'Starting lineup fitness' },
+          value: '93%',
+          delta: { ar: '-2% بسبب إصابة طفيفة', en: '-2% minor knock' },
+          trend: 'negative'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'تحليلات الموسم الحالية', en: 'Season insights overview' },
+          subtitle: { ar: 'نقاط القوة والهجوم والدفاع مقارنة بأندية الدوري.', en: 'Offense vs defense strengths benchmarked to league.' },
+          action: { ar: 'تحميل ملف التحليل', en: 'Download analytics brief' },
+          placeholder: { ar: 'مخطط الأداء عبر الموسم', en: 'Season performance chart' }
+        },
+        {
+          id: 'performance',
+          type: 'list',
+          title: { ar: 'مؤشرات اللاعبين الرئيسيين', en: 'Key player metrics' },
+          action: { ar: 'مشاهدة لقطات الفيديو', en: 'Watch highlight reels' },
+          items: [
+            {
+              icon: 'trophy',
+              title: { ar: 'سامي الخطيب | جناح هجومي', en: 'Sami Alkhateeb | Forward' },
+              subtitle: { ar: 'متوسط 24.8 نقطة | 6 تمريرات', en: 'Avg 24.8 pts | 6 assists' },
+              value: 'دقيقة لعب 31',
+              delta: { ar: '+3 دقائق عن المتوسط', en: '+3 mins vs avg.' }
+            },
+            {
+              icon: 'chart-bar',
+              title: { ar: 'مازن عارف | حارس المرمى', en: 'Mazen Aref | Goalkeeper' },
+              subtitle: { ar: 'نسبة تصدي 81% | 4 شباك نظيفة', en: 'Save rate 81% | 4 clean sheets' },
+              value: 'ضغط 9.4',
+              delta: { ar: 'أعلى أداء في الدوري', en: 'Top league rating' }
+            },
+            {
+              icon: 'heart',
+              title: { ar: 'خالد البدر | خط الوسط', en: 'Khaled AlBadr | Midfield' },
+              subtitle: { ar: 'معدل جهد 89% | تغطية 11.2 كم', en: 'Effort 89% | Coverage 11.2 km' },
+              value: 'جاهزية 96%',
+              delta: { ar: 'متاح للمباراة القادمة', en: 'Cleared for next match' }
+            }
+          ]
+        },
+        {
+          id: 'fans',
+          type: 'progress',
+          title: { ar: 'مبادرات التفاعل الجماهيري', en: 'Fan engagement initiatives' },
+          items: [
+            {
+              title: { ar: 'برنامج الولاء الرقمي', en: 'Digital loyalty program' },
+              subtitle: { ar: 'تطبيق مكافآت فوري مع عروض يوم المباراة.', en: 'Instant rewards app with game-day offers.' },
+              value: '71%',
+              percent: '71%'
+            },
+            {
+              title: { ar: 'خطة المحتوى المرئي', en: 'Visual storytelling plan' },
+              subtitle: { ar: 'سلسلة وثائقية قصيرة عن اللاعبين.', en: 'Short-form documentary series.' },
+              value: '58%',
+              percent: '58%'
+            },
+            {
+              title: { ar: 'تجربة الاستاد الذكية', en: 'Smart stadium experience' },
+              subtitle: { ar: 'الدفع عبر الأجهزة القابلة للارتداء ومقاعد متصلة.', en: 'Wearable payments and connected seating.' },
+              value: '46%',
+              percent: '46%'
+            }
+          ]
+        },
+        {
+          id: 'media',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'صفقات الرعاية النشطة', en: 'Active sponsorship deals' },
+          action: { ar: 'إدارة العوائد', en: 'Manage revenue' },
+          headers: [
+            { ar: 'الشريك', en: 'Partner' },
+            { ar: 'قيمة الصفقة', en: 'Deal value' },
+            { ar: 'التغير', en: 'Change' }
+          ],
+          rows: [
+            {
+              name: { ar: 'بنك المستقبل', en: 'Future Bank' },
+              metric: '3.4 مليون دولار | موسم 2024 / $3.4M | 2024 season',
+              delta: { ar: '+12% تمديد مبكر', en: '+12% early renewal' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'شركة السفر العالمية', en: 'Global Travel Co.' },
+              metric: '2.1 مليون دولار | عقد لعامين / $2.1M | Two-year deal',
+              delta: { ar: 'قيمة ثابتة', en: 'Flat value' },
+              trend: 'neutral'
+            },
+            {
+              name: { ar: 'علامة التكنولوجيا الذكية', en: 'Smart Tech Brand' },
+              metric: '1.6 مليون دولار | حملة الواقع المعزز / $1.6M | AR campaign',
+              delta: { ar: '+6% مكافآت تفعيل', en: '+6% activation bonus' },
+              trend: 'positive'
+            }
+          ]
+        },
+        {
+          id: 'operations',
+          type: 'timeline',
+          title: { ar: 'الجدول التشغيلي ليوم المباراة', en: 'Game-day operations timeline' },
+          items: [
+            {
+              icon: 'play',
+              title: { ar: 'اجتماع الخطط التكتيكية', en: 'Tactical briefing' },
+              subtitle: { ar: 'مراجعة خطط الهجوم والدفاع مع الطاقم الفني.', en: 'Review offense/defense scripts with staff.' },
+              time: { ar: '11:30 صباحاً', en: '11:30 AM' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'فتح بوابات الجماهير', en: 'Gates open for fans' },
+              subtitle: { ar: 'تنشيط نقاط البيع والتجارب التفاعلية.', en: 'Activate concessions and fan zones.' },
+              time: { ar: '03:00 عصراً', en: '03:00 PM' }
+            },
+            {
+              icon: 'trophy',
+              title: { ar: 'الاستعراض الافتتاحي', en: 'Opening ceremony' },
+              subtitle: { ar: 'عرض ترفيهي مع مشاركة الرعاة واللاعبين القدامى.', en: 'Showcase with sponsors and alumni.' },
+              time: { ar: '05:45 مساءً', en: '05:45 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-3.html
+++ b/dashboards/dashboard-3.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تجارة إلكترونية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">E</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">E</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة تجارة إلكترونية',
+          en: 'E-commerce Intelligence Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'E',
+        name: {
+          ar: 'نبض التجارة',
+          en: 'Commerce Pulse'
+        },
+        tagline: {
+          ar: 'تحليلات المبيعات وتجربة العملاء',
+          en: 'Sales and experience analytics'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-amber-950 to-rose-900',
+        sidebarGradient: 'from-amber-950 via-orange-900 to-rose-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-amber-500/30',
+        accentGradient: 'from-amber-500 via-orange-500 to-rose-500',
+        accentText: 'text-amber-200',
+        highlightBg: 'bg-amber-500/10 border-amber-400/30',
+        badgeBg: 'bg-amber-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'shopping-bag',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'موسمي', en: 'Seasonal' }
+        },
+        {
+          id: 'sales',
+          icon: 'chart-bar',
+          label: { ar: 'المبيعات', en: 'Sales' }
+        },
+        {
+          id: 'marketing',
+          icon: 'megaphone',
+          label: { ar: 'التسويق', en: 'Marketing' }
+        },
+        {
+          id: 'fulfilment',
+          icon: 'truck',
+          label: { ar: 'التنفيذ والشحن', en: 'Fulfilment & shipping' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'إيرادات اليوم', en: 'Today’s revenue' },
+        value: '$482K',
+        description: {
+          ar: 'حملة الإطلاق الصيفية رفعت متوسط قيمة السلة 18%.',
+          en: 'Summer launch campaign lifted average order value by 18%.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة تجارة إلكترونية',
+          en: 'E-commerce performance hub'
+        },
+        subtitle: {
+          ar: 'راقب المبيعات وسلوك العملاء والعمليات اللوجستية لحظياً.',
+          en: 'Monitor revenue, customer behaviour, and fulfilment in real time.'
+        },
+        primary: {
+          ar: 'تصدير تقرير الإيرادات',
+          en: 'Export revenue report'
+        },
+        secondary: {
+          ar: 'إدارة حملات العروض',
+          en: 'Manage promo campaigns'
+        }
+      },
+      stats: [
+        {
+          icon: 'shopping-bag',
+          label: { ar: 'قيمة المبيعات اليومية', en: 'Daily sales value' },
+          value: '$482K',
+          delta: { ar: '+14% مقارنة بالأسبوع الماضي', en: '+14% vs previous week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cursor-arrow',
+          label: { ar: 'نسبة التحويل', en: 'Conversion rate' },
+          value: '3.9%',
+          delta: { ar: '+0.6 نقطة عن المتوسط', en: '+0.6 pts above average' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'متوسط قيمة السلة', en: 'Average order value' },
+          value: '$126',
+          delta: { ar: '+18% بعد الحملات', en: '+18% after campaigns' },
+          trend: 'positive'
+        },
+        {
+          icon: 'truck',
+          label: { ar: 'طلبات جاهزة للشحن', en: 'Orders ready to ship' },
+          value: '1,280',
+          delta: { ar: 'تم تسليم 92% خلال 24 ساعة', en: '92% delivered within 24h' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى الإيرادات', en: 'Revenue curve' },
+          subtitle: { ar: 'تدفق الطلبات والإيرادات الإجمالية خلال 14 يوماً.', en: 'Order flow and gross revenue across 14 days.' },
+          action: { ar: 'عرض حسب القناة', en: 'Segment by channel' },
+          placeholder: { ar: 'مخطط الإيرادات', en: 'Revenue chart' }
+        },
+        {
+          id: 'products',
+          type: 'list',
+          title: { ar: 'المنتجات الأعلى أداءً', en: 'Top performing products' },
+          action: { ar: 'تحديث تلقائي', en: 'Auto-updating' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'حزمة العناية بالبشرة', en: 'Skincare essentials kit' },
+              subtitle: { ar: 'متوسط تقييم 4.8', en: 'Average rating 4.8' },
+              value: '$96K',
+              delta: { ar: '+22% عائد يومي', en: '+22% daily revenue' }
+            },
+            {
+              icon: 'shopping-bag',
+              title: { ar: 'حذاء رياضي ذكي', en: 'Smart running shoe' },
+              subtitle: { ar: 'مخزون كافٍ لـ 12 يوماً', en: 'Stock cover for 12 days' },
+              value: '$72K',
+              delta: { ar: '+8% عائد', en: '+8% revenue' }
+            },
+            {
+              icon: 'heart',
+              title: { ar: 'اشتراك عضوية VIP', en: 'VIP membership subscription' },
+              subtitle: { ar: 'زيادة معدل التجديد 11%', en: 'Renewal rate up 11%' },
+              value: '$58K',
+              delta: { ar: '+3% عائد متكرر', en: '+3% recurring' }
+            }
+          ]
+        },
+        {
+          id: 'funnel',
+          type: 'progress',
+          title: { ar: 'مؤشرات مسار الشراء', en: 'Purchase funnel metrics' },
+          items: [
+            {
+              title: { ar: 'مشاهدات المنتجات', en: 'Product views' },
+              subtitle: { ar: 'استهداف شخصي بالصفحة الرئيسية', en: 'Personalised home targeting' },
+              value: '82%',
+              percent: '82%'
+            },
+            {
+              title: { ar: 'إضافة إلى السلة', en: 'Add to cart' },
+              subtitle: { ar: 'حملات استرجاع العربات', en: 'Cart recovery journeys' },
+              value: '46%',
+              percent: '46%'
+            },
+            {
+              title: { ar: 'إتمام الدفع', en: 'Checkout completion' },
+              subtitle: { ar: 'خيارات دفع جديدة', en: 'New payment options' },
+              value: '29%',
+              percent: '29%'
+            }
+          ]
+        },
+        {
+          id: 'updates',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'تحديثات تجربة العملاء', en: 'Customer experience updates' },
+          items: [
+            {
+              icon: 'megaphone',
+              title: { ar: 'إطلاق حملة العطلات', en: 'Holiday campaign launch' },
+              subtitle: { ar: 'تم تخصيص عروض للمشتركين المخلصين', en: 'Loyal subscribers receive tailored bundles' },
+              time: { ar: 'قبل ساعة', en: '1 hour ago' }
+            },
+            {
+              icon: 'truck',
+              title: { ar: 'مركز توزيع جديد', en: 'New fulfilment hub' },
+              subtitle: { ar: 'تقليل أوقات الشحن للمنطقة الغربية', en: 'Shorter lead times for western region' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'heart',
+              title: { ar: 'تقييمات خدمة مميزة', en: 'Service ratings highlight' },
+              subtitle: { ar: 'متوسط رضا العملاء 4.7/5', en: 'Customer satisfaction averages 4.7/5' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-4.html
+++ b/dashboards/dashboard-4.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة البنية السحابية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">C</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">C</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة البنية السحابية',
+          en: 'Cloud Infrastructure Control Panel'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'C',
+        name: {
+          ar: 'مرصد السحابة',
+          en: 'Cloud Atlas'
+        },
+        tagline: {
+          ar: 'مراقبة الصحة والأداء والتكاليف',
+          en: 'Health, performance, and cost monitoring'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-blue-950 to-sky-900',
+        sidebarGradient: 'from-slate-950 via-blue-900 to-cyan-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-sky-400/30',
+        accentGradient: 'from-sky-500 via-indigo-500 to-slate-500',
+        accentText: 'text-sky-200',
+        highlightBg: 'bg-sky-500/10 border-sky-400/30',
+        badgeBg: 'bg-sky-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'cloud',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'مراقبة', en: 'Monitor' }
+        },
+        {
+          id: 'health',
+          icon: 'shield',
+          label: { ar: 'الصحة والأمان', en: 'Health & security' }
+        },
+        {
+          id: 'capacity',
+          icon: 'cube',
+          label: { ar: 'السعة والاستيعاب', en: 'Capacity' }
+        },
+        {
+          id: 'costs',
+          icon: 'bank',
+          label: { ar: 'التكاليف', en: 'Costs' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'حالة المنصة', en: 'Platform status' },
+        value: '99.98% SLA',
+        description: {
+          ar: 'مناطق التوفر الثلاث تعمل دون حوادث خلال 27 يوماً.',
+          en: 'All three availability zones running incident-free for 27 days.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة البنية السحابية',
+          en: 'Cloud infrastructure dashboard'
+        },
+        subtitle: {
+          ar: 'تحليلات زمن الاستجابة، السعة، والإنفاق عبر البيئات.',
+          en: 'Analyse latency, capacity, and spend across environments.'
+        },
+        primary: {
+          ar: 'جدولة صيانة',
+          en: 'Schedule maintenance'
+        },
+        secondary: {
+          ar: 'عرض توصيات التوفير',
+          en: 'View savings plan'
+        }
+      },
+      stats: [
+        {
+          icon: 'cloud',
+          label: { ar: 'متوسط زمن الاستجابة', en: 'Average latency' },
+          value: '142ms',
+          delta: { ar: '-18% مقارنة بالأسبوع الماضي', en: '-18% vs last week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'shield',
+          label: { ar: 'حوادث حرجة', en: 'Critical incidents' },
+          value: '2',
+          delta: { ar: 'تم إغلاق 5 خلال 48 ساعة', en: '5 resolved within 48h' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cube',
+          label: { ar: 'العُقد النشطة', en: 'Active nodes' },
+          value: '1,240',
+          delta: { ar: '+7% توسع تلقائي', en: '+7% autoscaling boost' },
+          trend: 'positive'
+        },
+        {
+          icon: 'bank',
+          label: { ar: 'تكلفة يومية', en: 'Daily spend' },
+          value: '$38K',
+          delta: { ar: '-9% بفضل الخطة المحسّنة', en: '-9% with optimized plan' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مراقبة زمن الاستجابة', en: 'Latency monitor' },
+          subtitle: { ar: 'قياس عالمي بين المناطق الأساسية والخدمات الحرجة.', en: 'Global measurement across core regions and critical services.' },
+          action: { ar: 'تفاصيل الخدمة', en: 'Service detail' },
+          placeholder: { ar: 'مخطط الاستجابة', en: 'Latency visual' }
+        },
+        {
+          id: 'clusters',
+          type: 'list',
+          title: { ar: 'أعلى مجموعات الحمل', en: 'Top load clusters' },
+          action: { ar: 'تحديث في آخر 2 دقيقة', en: 'Updated 2 minutes ago' },
+          items: [
+            {
+              icon: 'cloud',
+              title: { ar: 'حوسبة المنطقة الشرقية', en: 'East compute cluster' },
+              subtitle: { ar: 'استخدام CPU 63%', en: 'CPU utilisation 63%' },
+              value: '512 عقدة',
+              delta: { ar: 'تم تفعيل أولوية الأداء', en: 'Performance priority enabled' }
+            },
+            {
+              icon: 'cube',
+              title: { ar: 'مزارع التحليلات', en: 'Analytics farms' },
+              subtitle: { ar: 'ذاكرة فائضة 12%', en: 'Memory headroom 12%' },
+              value: '386 عقدة',
+              delta: { ar: 'استهلاك ثابت', en: 'Stable consumption' }
+            },
+            {
+              icon: 'shield',
+              title: { ar: 'وحدة الأمان المُدارة', en: 'Managed security edge' },
+              subtitle: { ar: 'حجب 2.3M تهديد/يوم', en: 'Blocking 2.3M threats/day' },
+              value: 'كفاءة 98%',
+              delta: { ar: 'زيادة التدقيق', en: 'Inspection increased' }
+            }
+          ]
+        },
+        {
+          id: 'migration',
+          type: 'progress',
+          title: { ar: 'تقدم موجات الترحيل', en: 'Migration wave progress' },
+          items: [
+            {
+              title: { ar: 'الموجة الأولى - الخدمات الداخلية', en: 'Wave 1 - internal services' },
+              subtitle: { ar: 'مكتمل مع مراجعات أمنية', en: 'Complete with security reviews' },
+              value: '100%',
+              percent: '100%'
+            },
+            {
+              title: { ar: 'الموجة الثانية - قواعد البيانات', en: 'Wave 2 - databases' },
+              subtitle: { ar: 'اختبارات الأداء مستمرة', en: 'Performance testing underway' },
+              value: '71%',
+              percent: '71%'
+            },
+            {
+              title: { ar: 'الموجة الثالثة - التطبيقات العامة', en: 'Wave 3 - public apps' },
+              subtitle: { ar: 'جاهزية التدريج الأسبوع المقبل', en: 'Staging readiness next week' },
+              value: '46%',
+              percent: '46%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'مستجدات العمليات', en: 'Operations timeline' },
+          items: [
+            {
+              icon: 'shield',
+              title: { ar: 'تفعيل سياسات الحماية المتقدمة', en: 'Advanced guardrails enabled' },
+              subtitle: { ar: 'ضبط تلقائي لقواعد الجدار الناري', en: 'Firewall policies auto-tuned' },
+              time: { ar: 'قبل ساعة', en: '1 hour ago' }
+            },
+            {
+              icon: 'cloud',
+              title: { ar: 'إنهاء صيانة التدرج', en: 'Gradient maintenance completed' },
+              subtitle: { ar: 'إعادة توزيع السعة دون توقف', en: 'Capacity redistributed without downtime' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'bank',
+              title: { ar: 'توصيات خفض التكلفة', en: 'Cost optimisation tips' },
+              subtitle: { ar: 'فرص توفير سنوي 1.4M$', en: '$1.4M annual savings identified' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-5.html
+++ b/dashboards/dashboard-5.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة إدارة المحتوى</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">M</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">M</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة إدارة المحتوى',
+          en: 'Content Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'M',
+        name: {
+          ar: 'إيقاع المحتوى',
+          en: 'Content Rhythm'
+        },
+        tagline: {
+          ar: 'تخطيط النشر وتجربة القراء',
+          en: 'Publishing cadence & reader experience'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-fuchsia-950 to-indigo-900',
+        sidebarGradient: 'from-fuchsia-950 via-purple-900 to-indigo-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-fuchsia-500/30',
+        accentGradient: 'from-violet-500 via-purple-500 to-pink-500',
+        accentText: 'text-violet-200',
+        highlightBg: 'bg-fuchsia-500/10 border-fuchsia-400/30',
+        badgeBg: 'bg-fuchsia-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'sparkles',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'تحرير', en: 'Editorial' }
+        },
+        {
+          id: 'calendar',
+          icon: 'calendar',
+          label: { ar: 'الجدول التحريري', en: 'Editorial calendar' }
+        },
+        {
+          id: 'authors',
+          icon: 'users',
+          label: { ar: 'المحررون والمؤلفون', en: 'Authors & editors' }
+        },
+        {
+          id: 'distribution',
+          icon: 'megaphone',
+          label: { ar: 'التوزيع والترويج', en: 'Distribution & promotion' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'حملة الأسبوع', en: 'Campaign of the week' },
+        value: 'سلسلة التحولات الرقمية',
+        description: {
+          ar: 'ارتفعت القراءات العميقة بنسبة 26% بعد إطلاق السلسلة المكونة من خمسة أجزاء.',
+          en: 'Deep reads climbed 26% after launching the five-part digital transformation series.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة إدارة المحتوى',
+          en: 'Content operations dashboard'
+        },
+        subtitle: {
+          ar: 'تنسيق جدول النشر، جودة المواد، وأداء القنوات.',
+          en: 'Coordinate publishing schedules, content quality, and channel performance.'
+        },
+        primary: {
+          ar: 'إطلاق موضوع خاص',
+          en: 'Launch special topic'
+        },
+        secondary: {
+          ar: 'مراجعة الخطة الأسبوعية',
+          en: 'Review weekly plan'
+        }
+      },
+      stats: [
+        {
+          icon: 'sparkles',
+          label: { ar: 'مقالات منشورة هذا الشهر', en: 'Articles published this month' },
+          value: '64',
+          delta: { ar: '+12 عن الشهر السابق', en: '+12 vs last month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'معدل التفاعل', en: 'Engagement rate' },
+          value: '7.4%',
+          delta: { ar: '+1.2 نقطة', en: '+1.2 pts' },
+          trend: 'positive'
+        },
+        {
+          icon: 'folder',
+          label: { ar: 'مسودات قيد المراجعة', en: 'Drafts in review' },
+          value: '18',
+          delta: { ar: '-6 مقارنة بالأسبوع الماضي', en: '-6 vs last week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'users',
+          label: { ar: 'مساهمون نشطون', en: 'Active contributors' },
+          value: '27',
+          delta: { ar: '+4 أصوات جديدة', en: '+4 new voices' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'منحنى التفاعل اليومي', en: 'Daily engagement curve' },
+          subtitle: { ar: 'مقارنة التفاعل بين المقالات الطويلة والقصيرة عبر القنوات.', en: 'Long-form vs short-form engagement across channels.' },
+          action: { ar: 'عرض حسب الفئة', en: 'Segment by category' },
+          placeholder: { ar: 'مخطط التفاعل', en: 'Engagement chart' }
+        },
+        {
+          id: 'stories',
+          type: 'list',
+          title: { ar: 'مواضيع رائجة', en: 'Trending stories' },
+          action: { ar: 'آخر تحديث 15 دقيقة', en: 'Updated 15 minutes ago' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'مستقبل الذكاء الاصطناعي التوليدي', en: 'Future of generative AI' },
+              subtitle: { ar: '3 أجزاء | 12 دقيقة قراءة', en: '3-part | 12 min read' },
+              value: '24K',
+              delta: { ar: 'معدل إكمال 68%', en: 'Completion rate 68%' }
+            },
+            {
+              icon: 'book-open',
+              title: { ar: 'دليل استراتيجيات المحتوى لعام 2024', en: '2024 content strategy guide' },
+              subtitle: { ar: 'PDF قابل للتنزيل', en: 'Downloadable PDF' },
+              value: '18K',
+              delta: { ar: '600 مشاركة اجتماعية', en: '600 social shares' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'بودكاست صوت الصناعة', en: 'Industry voice podcast' },
+              subtitle: { ar: 'حلقة جديدة كل ثلاثاء', en: 'New episode every Tuesday' },
+              value: '9.3K',
+              delta: { ar: 'متوسط استماع 21 دقيقة', en: 'Avg listen 21 mins' }
+            }
+          ]
+        },
+        {
+          id: 'pipeline',
+          type: 'progress',
+          title: { ar: 'خط إنتاج المحتوى', en: 'Content production pipeline' },
+          items: [
+            {
+              title: { ar: 'البحث وتحديد الفكرة', en: 'Research & ideation' },
+              subtitle: { ar: 'جلسات عصف أسبوعية', en: 'Weekly brainstorming sessions' },
+              value: '88%',
+              percent: '88%'
+            },
+            {
+              title: { ar: 'الكتابة والتحرير', en: 'Writing & editing' },
+              subtitle: { ar: 'قوالب مراجعة جديدة', en: 'New review templates' },
+              value: '62%',
+              percent: '62%'
+            },
+            {
+              title: { ar: 'التصميم والنشر', en: 'Design & publishing' },
+              subtitle: { ar: 'اختبارات A/B للعناوين', en: 'Headline A/B testing' },
+              value: '48%',
+              percent: '48%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'تحديثات تحريرية', en: 'Editorial updates' },
+          items: [
+            {
+              icon: 'calendar',
+              title: { ar: 'إطلاق جدول النشر الجديد', en: 'New publishing calendar launched' },
+              subtitle: { ar: 'أولويات موجهة نحو القصص المتعمقة', en: 'Focus on deep-dive features' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'users',
+              title: { ar: 'تعيين محرر ضيف', en: 'Guest editor assignment' },
+              subtitle: { ar: 'سلسلة ريادة الأعمال الناشئة', en: 'Emerging founders series' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'حملة النشرة الأسبوعية', en: 'Weekly newsletter push' },
+              subtitle: { ar: 'زيادة معدل الفتح إلى 41%', en: 'Open rate up to 41%' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-6.html
+++ b/dashboards/dashboard-6.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تجربة العملاء</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">X</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">X</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة تجربة العملاء',
+          en: 'Customer Experience Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'X',
+        name: {
+          ar: 'إشراق التجربة',
+          en: 'Experience Glow'
+        },
+        tagline: {
+          ar: 'صوت العميل، الدعم، والرحلات الرقمية',
+          en: 'Voice of customer, support, and journeys'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-pink-950 to-rose-900',
+        sidebarGradient: 'from-rose-950 via-pink-900 to-amber-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-rose-400/30',
+        accentGradient: 'from-emerald-500 via-teal-500 to-cyan-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'heart',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'رضا', en: 'Satisfaction' }
+        },
+        {
+          id: 'support',
+          icon: 'chat-bubble',
+          label: { ar: 'الدعم والتذاكر', en: 'Support & tickets' }
+        },
+        {
+          id: 'feedback',
+          icon: 'sparkles',
+          label: { ar: 'ملاحظات العملاء', en: 'Customer feedback' }
+        },
+        {
+          id: 'journeys',
+          icon: 'map',
+          label: { ar: 'الرحلات الرقمية', en: 'Digital journeys' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'نبض العملاء', en: 'Customer pulse' },
+        value: 'NPS 71',
+        description: {
+          ar: 'برنامج الترحيب الجديد رفع رضا المستخدمين الجدد بنسبة 14 نقطة.',
+          en: 'New onboarding journey increased new-user satisfaction by 14 points.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة تجربة العملاء',
+          en: 'Customer experience dashboard'
+        },
+        subtitle: {
+          ar: 'أثر الدعم، الملاحظات، والتحويلات عبر كل نقطة تواصل.',
+          en: 'Track support, feedback, and conversions across every touchpoint.'
+        },
+        primary: {
+          ar: 'إطلاق حملة وفاء',
+          en: 'Launch loyalty campaign'
+        },
+        secondary: {
+          ar: 'عرض لوحة الرحلات',
+          en: 'View journey board'
+        }
+      },
+      stats: [
+        {
+          icon: 'heart',
+          label: { ar: 'رضا العملاء (CSAT)', en: 'Customer satisfaction (CSAT)' },
+          value: '92%',
+          delta: { ar: '+3 نقاط هذا الربع', en: '+3 points this quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'مؤشر المروج الصافي', en: 'Net promoter score' },
+          value: '71',
+          delta: { ar: '+6 نقاط منذ الشهر الماضي', en: '+6 points since last month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chat-bubble',
+          label: { ar: 'طلبات مُغلقة خلال 24 ساعة', en: 'Tickets resolved within 24h' },
+          value: '87%',
+          delta: { ar: '+9% بعد أتمتة الردود', en: '+9% after automation rollout' },
+          trend: 'positive'
+        },
+        {
+          icon: 'map',
+          label: { ar: 'تغطية الرحلات المؤتمتة', en: 'Automated journey coverage' },
+          value: '63%',
+          delta: { ar: '+12% خلال 45 يوماً', en: '+12% over 45 days' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'تطور مؤشر الرضا', en: 'Satisfaction evolution' },
+          subtitle: { ar: 'مسار التقييمات اليومية عبر القنوات والدول.', en: 'Daily sentiment across channels and geographies.' },
+          action: { ar: 'تحليل الشرائح', en: 'Segment analysis' },
+          placeholder: { ar: 'مخطط الرضا', en: 'Satisfaction chart' }
+        },
+        {
+          id: 'channels',
+          type: 'list',
+          title: { ar: 'أفضل قنوات الخدمة', en: 'Top service channels' },
+          action: { ar: 'مقارنة أسبوعية', en: 'Week-over-week compare' },
+          items: [
+            {
+              icon: 'chat-bubble',
+              title: { ar: 'مركز المساعدة المباشر', en: 'Live help centre' },
+              subtitle: { ar: 'زمن استجابة 38 ثانية', en: 'Response time 38s' },
+              value: 'CSAT 95%',
+              delta: { ar: '+4 نقاط', en: '+4 points' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'الرسائل داخل التطبيق', en: 'In-app messaging' },
+              subtitle: { ar: 'حملات تفعيل سياقية', en: 'Contextual activation' },
+              value: 'تفاعل 67%',
+              delta: { ar: '+8% اعتماد', en: '+8% adoption' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'وسائل التواصل الاجتماعي', en: 'Social care' },
+              subtitle: { ar: 'فريق متعدد اللغات', en: 'Multi-lingual team' },
+              value: 'حل 78%',
+              delta: { ar: '+12% رضا', en: '+12% satisfaction' }
+            }
+          ]
+        },
+        {
+          id: 'journey',
+          type: 'progress',
+          title: { ar: 'مراحل رحلة العميل', en: 'Customer journey stages' },
+          items: [
+            {
+              title: { ar: 'الاكتشاف', en: 'Discovery' },
+              subtitle: { ar: 'محتوى تعليمي مخصص', en: 'Personalised learning content' },
+              value: '78%',
+              percent: '78%'
+            },
+            {
+              title: { ar: 'البدء والتفعيل', en: 'Onboarding & activation' },
+              subtitle: { ar: 'تجربة تفاعلية جديدة', en: 'New interactive walkthrough' },
+              value: '64%',
+              percent: '64%'
+            },
+            {
+              title: { ar: 'النجاح المستمر', en: 'Ongoing success' },
+              subtitle: { ar: 'متابعة ذكية للقيمة', en: 'Value tracking automations' },
+              value: '52%',
+              percent: '52%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'مستجدات تجربة العملاء', en: 'CX updates timeline' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق روبوت المحادثة الجديد', en: 'New chatbot launched' },
+              subtitle: { ar: 'يغطي 42% من الأسئلة المتكررة', en: 'Covers 42% of repeat questions' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'heart',
+              title: { ar: 'جلسات الاستماع للعملاء', en: 'Customer listening sessions' },
+              subtitle: { ar: '5 مجموعات تركيز في ثلاثة أسواق', en: '5 focus groups across three markets' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'map',
+              title: { ar: 'تدفق رحلة متكامل جديد', en: 'New integrated journey flow' },
+              subtitle: { ar: 'يُقلل الخطوات بنسبة 23%', en: 'Reduces steps by 23%' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-7.html
+++ b/dashboards/dashboard-7.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الموارد البشرية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">H</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">H</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الموارد البشرية',
+          en: 'People Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'H',
+        name: {
+          ar: 'نبض الموارد البشرية',
+          en: 'People Pulse'
+        },
+        tagline: {
+          ar: 'الاستقطاب، الأداء، وتجربة الموظفين',
+          en: 'Hiring, performance, and employee experience'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-amber-950 to-lime-900',
+        sidebarGradient: 'from-amber-950 via-orange-900 to-lime-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-orange-400/30',
+        accentGradient: 'from-rose-500 via-amber-500 to-orange-500',
+        accentText: 'text-amber-200',
+        highlightBg: 'bg-orange-500/10 border-orange-400/30',
+        badgeBg: 'bg-orange-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'users',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'فِرق', en: 'Teams' }
+        },
+        {
+          id: 'talent',
+          icon: 'briefcase',
+          label: { ar: 'المواهب والتوظيف', en: 'Talent & hiring' }
+        },
+        {
+          id: 'performance',
+          icon: 'sparkles',
+          label: { ar: 'الأداء والتطوير', en: 'Performance & development' }
+        },
+        {
+          id: 'wellbeing',
+          icon: 'heart',
+          label: { ar: 'الرفاهية', en: 'Wellbeing' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'نبض الفريق', en: 'Team pulse' },
+        value: '94% احتفاظ',
+        description: {
+          ar: 'برنامج الإرشاد المهني ساهم في رفع نسبة الاحتفاظ السنوية 6 نقاط.',
+          en: 'Mentorship program lifted annual retention by 6 points.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة الموارد البشرية',
+          en: 'People operations dashboard'
+        },
+        subtitle: {
+          ar: 'نظرة شاملة على القوى العاملة، المواهب، والرفاهية.',
+          en: 'Holistic view of workforce, talent pipelines, and wellbeing.'
+        },
+        primary: {
+          ar: 'إطلاق حملة التوظيف',
+          en: 'Launch hiring sprint'
+        },
+        secondary: {
+          ar: 'مراجعة خطة التطوير',
+          en: 'Review development plan'
+        }
+      },
+      stats: [
+        {
+          icon: 'users',
+          label: { ar: 'عدد الموظفين الحالي', en: 'Current headcount' },
+          value: '1,240',
+          delta: { ar: '+42 خلال الربع', en: '+42 this quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'briefcase',
+          label: { ar: 'مرشحون في المسار', en: 'Candidates in pipeline' },
+          value: '36',
+          delta: { ar: '20% أسرع من المتوسط', en: '20% faster than avg' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'إكمال تقييم الأداء', en: 'Performance review completion' },
+          value: '88%',
+          delta: { ar: '+9% مشاركة', en: '+9% participation' },
+          trend: 'positive'
+        },
+        {
+          icon: 'book-open',
+          label: { ar: 'ساعات التدريب', en: 'Training hours' },
+          value: '1,820',
+          delta: { ar: '+460 ساعة منذ يناير', en: '+460 hours since January' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'توزيع القوى العاملة', en: 'Workforce distribution' },
+          subtitle: { ar: 'مقارنة النمو بين الأقسام والمناطق.', en: 'Growth comparison by department and region.' },
+          action: { ar: 'تحميل تقرير القوى العاملة', en: 'Download workforce report' },
+          placeholder: { ar: 'مخطط القوى العاملة', en: 'Workforce chart' }
+        },
+        {
+          id: 'roles',
+          type: 'list',
+          title: { ar: 'أدوار حرجة مفتوحة', en: 'Critical open roles' },
+          action: { ar: 'آخر تحديث صباح اليوم', en: 'Updated this morning' },
+          items: [
+            {
+              icon: 'briefcase',
+              title: { ar: 'مدير هندسة المنصة', en: 'Platform engineering manager' },
+              subtitle: { ar: 'مرحلة المقابلة النهائية', en: 'Final interview stage' },
+              value: '3 مرشحين',
+              delta: { ar: 'متوسط قرار 8 أيام', en: 'Decision in 8 days' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'قائد تجربة العملاء', en: 'Customer experience lead' },
+              subtitle: { ar: 'تمت دعوة 5 متقدمين', en: '5 invites sent' },
+              value: 'قيد التقييم',
+              delta: { ar: 'تعاون مع الفريق التجاري', en: 'Working with commercial team' }
+            },
+            {
+              icon: 'book-open',
+              title: { ar: 'مصمم تعلم رقمي', en: 'Digital learning designer' },
+              subtitle: { ar: 'يبدأ برنامج التدريب في مايو', en: 'Enablement program kicks off May' },
+              value: '4 مرشحين',
+              delta: { ar: 'تجربة تقنية مطلوبة', en: 'Looking for tech background' }
+            }
+          ]
+        },
+        {
+          id: 'onboarding',
+          type: 'progress',
+          title: { ar: 'مراحل التهيئة للمنضمين', en: 'New hire onboarding stages' },
+          items: [
+            {
+              title: { ar: 'قبول العرض وتوقيع العقود', en: 'Offer acceptance & contracts' },
+              subtitle: { ar: 'أتمتة مستندات التوظيف', en: 'Automated hiring documents' },
+              value: '95%',
+              percent: '95%'
+            },
+            {
+              title: { ar: 'أسبوع التعريف والدمج', en: 'Orientation week' },
+              subtitle: { ar: 'جلسات تعريف مشتركة', en: 'Cross-functional introductions' },
+              value: '73%',
+              percent: '73%'
+            },
+            {
+              title: { ar: 'خطة التسعين يوماً', en: '90-day success plan' },
+              subtitle: { ar: 'متابعة المرشدين الفردية', en: 'Mentor check-ins' },
+              value: '58%',
+              percent: '58%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أخبار الموارد البشرية', en: 'People updates timeline' },
+          items: [
+            {
+              icon: 'users',
+              title: { ar: 'إطلاق منتدى القادة السنوي', en: 'Annual leadership forum kickoff' },
+              subtitle: { ar: '80 قائد يجتمعون لتحديد أولويات 2025', en: '80 leaders align on 2025 priorities' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'heart',
+              title: { ar: 'مبادرة العافية الجديدة', en: 'New wellbeing initiative' },
+              subtitle: { ar: 'جلسات يوغا ومرونة أسبوعية', en: 'Weekly yoga & resilience sessions' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'book-open',
+              title: { ar: 'برنامج التعلم القيادي', en: 'Leadership learning program' },
+              subtitle: { ar: 'إطلاق مسار التدريب المتقدم', en: 'Advanced coaching track launched' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-8.html
+++ b/dashboards/dashboard-8.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة التعليم الإلكتروني</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">L</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">L</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة التعليم الإلكتروني',
+          en: 'E-learning Experience Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'L',
+        name: {
+          ar: 'منصة التعلم الذكي',
+          en: 'Smart Learning Hub'
+        },
+        tagline: {
+          ar: 'تعليم ذاتي، بث مباشر، وشهادات احترافية',
+          en: 'Self-paced, live cohorts, and pro certifications'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-violet-950 to-blue-900',
+        sidebarGradient: 'from-violet-950 via-blue-900 to-indigo-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-violet-400/30',
+        accentGradient: 'from-blue-500 via-indigo-500 to-violet-500',
+        accentText: 'text-indigo-200',
+        highlightBg: 'bg-blue-500/10 border-blue-400/30',
+        badgeBg: 'bg-indigo-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'book-open',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'تعلم', en: 'Learning' }
+        },
+        {
+          id: 'courses',
+          icon: 'sparkles',
+          label: { ar: 'الدورات والبرامج', en: 'Courses & programs' }
+        },
+        {
+          id: 'learners',
+          icon: 'users',
+          label: { ar: 'المتعلمون', en: 'Learners' }
+        },
+        {
+          id: 'certs',
+          icon: 'trophy',
+          label: { ar: 'الشهادات', en: 'Certifications' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'أبرز برنامج', en: 'Featured program' },
+        value: 'قادة المنتجات الاحترافية',
+        description: {
+          ar: 'مسار من 8 أسابيع مع إرشاد مباشر ارتفع معدل إكماله إلى 84%.',
+          en: 'Eight-week mentored track now reaching 84% completion.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة التعليم الإلكتروني',
+          en: 'E-learning experience dashboard'
+        },
+        subtitle: {
+          ar: 'حلّل مشاركة المتعلمين، فعالية المحتوى، وأداء البرامج الحية.',
+          en: 'Analyse learner engagement, content effectiveness, and live cohort performance.'
+        },
+        primary: {
+          ar: 'إطلاق فصل جديد',
+          en: 'Launch new cohort'
+        },
+        secondary: {
+          ar: 'تصدير تقدم المتعلمين',
+          en: 'Export learner progress'
+        }
+      },
+      stats: [
+        {
+          icon: 'users',
+          label: { ar: 'متعلمين نشطين', en: 'Active learners' },
+          value: '6,480',
+          delta: { ar: '+18% نمو خلال 90 يوماً', en: '+18% growth over 90 days' },
+          trend: 'positive'
+        },
+        {
+          icon: 'book-open',
+          label: { ar: 'معدل إكمال الدورات', en: 'Course completion rate' },
+          value: '82%',
+          delta: { ar: '+7 نقاط بفضل التفاعل', en: '+7 pts after interactivity' },
+          trend: 'positive'
+        },
+        {
+          icon: 'play',
+          label: { ar: 'جلسات مباشرة هذا الأسبوع', en: 'Live sessions this week' },
+          value: '34',
+          delta: { ar: '+9 جلسات مقارنة بالأسبوع الماضي', en: '+9 sessions vs last week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'رضا المتعلمين', en: 'Learner satisfaction' },
+          value: '4.6/5',
+          delta: { ar: '+0.3 بعد تحسين التقييم', en: '+0.3 after feedback revamp' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مشاركة التعلم الأسبوعية', en: 'Weekly learning engagement' },
+          subtitle: { ar: 'الوقت المستغرق والتفاعل عبر مسارات التعلم.', en: 'Time spent and interactions across learning paths.' },
+          action: { ar: 'عرض حسب المسار', en: 'View by track' },
+          placeholder: { ar: 'مخطط المشاركة', en: 'Engagement plot' }
+        },
+        {
+          id: 'courses',
+          type: 'list',
+          title: { ar: 'الدورات الأعلى أداءً', en: 'Top performing courses' },
+          action: { ar: 'تحديث تلقائي', en: 'Auto refreshed' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'تصميم المنتج المعتمد', en: 'Certified product design' },
+              subtitle: { ar: 'نسبة إكمال 86%', en: 'Completion rate 86%' },
+              value: '1,240 متعلم',
+              delta: { ar: '+320 تسجيل جديد', en: '+320 new enrollments' }
+            },
+            {
+              icon: 'book-open',
+              title: { ar: 'تحليل البيانات المتقدم', en: 'Advanced data analytics' },
+              subtitle: { ar: 'مشروع تخرج فعلي', en: 'Capstone project' },
+              value: '980 متعلم',
+              delta: { ar: '+14% معدل نجاح', en: '+14% success rate' }
+            },
+            {
+              icon: 'trophy',
+              title: { ar: 'شهادة الأمن السيبراني', en: 'Cybersecurity certification' },
+              subtitle: { ar: 'مختبرات عملية مباشرة', en: 'Hands-on live labs' },
+              value: '760 متعلم',
+              delta: { ar: 'تحقيق 92% رضا', en: 'Achieved 92% satisfaction' }
+            }
+          ]
+        },
+        {
+          id: 'journey',
+          type: 'progress',
+          title: { ar: 'مسار تقدم المتعلمين', en: 'Learner progress stages' },
+          items: [
+            {
+              title: { ar: 'الاستكشاف والتسجيل', en: 'Discovery & enrolment' },
+              subtitle: { ar: 'رحلات بريدية مخصصة', en: 'Personalised nurture journeys' },
+              value: '91%',
+              percent: '91%'
+            },
+            {
+              title: { ar: 'التفاعل داخل الدورة', en: 'In-course engagement' },
+              subtitle: { ar: 'أنشطة تفاعلية وألعاب تعليمية', en: 'Interactive labs & gamification' },
+              value: '74%',
+              percent: '74%'
+            },
+            {
+              title: { ar: 'الحصول على الشهادة', en: 'Certification attainment' },
+              subtitle: { ar: 'جلسات مراجعة مباشرة', en: 'Live review bootcamps' },
+              value: '58%',
+              percent: '58%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'تحديثات المنصة التعليمية', en: 'Platform updates timeline' },
+          items: [
+            {
+              icon: 'play',
+              title: { ar: 'إطلاق استوديو البث الجديد', en: 'New live studio launch' },
+              subtitle: { ar: 'جودة بث 4K ودعم متعدد اللغات', en: '4K streaming with multi-language support' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'تحسين تجربة التطبيق', en: 'Mobile app refresh' },
+              subtitle: { ar: 'إشعارات تقدم ذكية', en: 'Smart progress alerts' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'trophy',
+              title: { ar: 'شراكة اعتماد جديدة', en: 'New accreditation partner' },
+              subtitle: { ar: 'اعتماد دولي للبرامج التقنية', en: 'Global certification for tech tracks' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-9.html
+++ b/dashboards/dashboard-9.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة أمن المعلومات</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div data-role="dashboard-shell" class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">S</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">S</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة أمن المعلومات',
+          en: 'Cybersecurity Operations Dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        },
+        collapse: {
+          ar: 'تصغير الشريط',
+          en: 'Collapse sidebar'
+        },
+        expand: {
+          ar: 'توسيع الشريط',
+          en: 'Expand sidebar'
+        }
+      },
+      brand: {
+        badge: 'S',
+        name: {
+          ar: 'درع الأمن',
+          en: 'Security Shield'
+        },
+        tagline: {
+          ar: 'مراقبة التهديدات، الامتثال، والاستجابة',
+          en: 'Threat monitoring, compliance, and response'
+        }
+      },
+      theme: {
+        bodyGradient: 'from-slate-950 via-slate-900 to-emerald-900',
+        sidebarGradient: 'from-slate-950 via-emerald-900 to-cyan-900',
+        cardBg: 'bg-slate-950/60 backdrop-blur-xl',
+        cardBorder: 'border-emerald-400/30',
+        accentGradient: 'from-emerald-500 via-lime-500 to-cyan-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'shield',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'آمن', en: 'Secure' }
+        },
+        {
+          id: 'threats',
+          icon: 'sparkles',
+          label: { ar: 'التهديدات الحية', en: 'Live threats' }
+        },
+        {
+          id: 'compliance',
+          icon: 'scale',
+          label: { ar: 'الامتثال', en: 'Compliance' }
+        },
+        {
+          id: 'operations',
+          icon: 'cog',
+          label: { ar: 'العمليات والاستجابة', en: 'Operations & response' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'وضع الأمان', en: 'Security posture' },
+        value: 'مستوى المخاطر: منخفض',
+        description: {
+          ar: 'تم تحديث سياسات XDR وإغلاق ثغرات الكتالوج خلال 48 ساعة.',
+          en: 'XDR policies refreshed and catalog vulnerabilities closed within 48 hours.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة أمن المعلومات',
+          en: 'Cybersecurity operations dashboard'
+        },
+        subtitle: {
+          ar: 'رؤية فورية للهجمات، التصحيحات، والتدقيق التنظيمي.',
+          en: 'Instant insight into attacks, patching, and regulatory audits.'
+        },
+        primary: {
+          ar: 'إطلاق اختبار اختراق',
+          en: 'Launch penetration test'
+        },
+        secondary: {
+          ar: 'مراجعة التقارير التنظيمية',
+          en: 'Review compliance reports'
+        }
+      },
+      stats: [
+        {
+          icon: 'shield',
+          label: { ar: 'محاولات تم صدّها', en: 'Blocked attempts' },
+          value: '2.3M',
+          delta: { ar: '+18% منذ الأمس', en: '+18% since yesterday' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'متوسط زمن الاكتشاف', en: 'Mean time to detect' },
+          value: '14 دقيقة',
+          delta: { ar: '-6 دقائق مقارنة بالربع الماضي', en: '-6 minutes vs last quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'scale',
+          label: { ar: 'ثغرات حرجة مفتوحة', en: 'Open critical vulnerabilities' },
+          value: '3',
+          delta: { ar: 'قيد الإغلاق خلال 24 ساعة', en: 'Due to close within 24h' },
+          trend: 'positive'
+        },
+        {
+          icon: 'cog',
+          label: { ar: 'تغطية سياسات الأمان', en: 'Security policy coverage' },
+          value: '94%',
+          delta: { ar: '+5% بعد التحديث الأخير', en: '+5% after latest update' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'سجل التنبيهات خلال 24 ساعة', en: '24h alert timeline' },
+          subtitle: { ar: 'تصنيف التنبيهات حسب المصدر والأولوية.', en: 'Alert classification by source and severity.' },
+          action: { ar: 'عرض التفاصيل', en: 'View details' },
+          placeholder: { ar: 'مخطط التنبيهات', en: 'Alerts visual' }
+        },
+        {
+          id: 'threats',
+          type: 'list',
+          title: { ar: 'أهم الحوادث', en: 'Top incidents' },
+          action: { ar: 'تحديث كل دقيقة', en: 'Updated every minute' },
+          items: [
+            {
+              icon: 'shield',
+              title: { ar: 'محاولة تصعيد امتيازات', en: 'Privilege escalation attempt' },
+              subtitle: { ar: 'مركز البيانات الأوروبي', en: 'EU data centre' },
+              value: 'تم الإحباط',
+              delta: { ar: 'حُظر على الفور', en: 'Blocked instantly' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'ملف خبيث موقّع', en: 'Signed malicious binary' },
+              subtitle: { ar: 'تم العزل في صندوق الرمل', en: 'Quarantined in sandbox' },
+              value: 'تحليل جارٍ',
+              delta: { ar: 'ينتظر تقرير المختبر', en: 'Awaiting lab report' }
+            },
+            {
+              icon: 'cog',
+              title: { ar: 'استثناء جدار ناري غير مطابق', en: 'Non-compliant firewall rule' },
+              subtitle: { ar: 'تم اكتشافه عبر التدقيق الآلي', en: 'Automated audit detection' },
+              value: 'قيد الإصلاح',
+              delta: { ar: 'جارٍ مع الفريق الشبكي', en: 'Working with network team' }
+            }
+          ]
+        },
+        {
+          id: 'patching',
+          type: 'progress',
+          title: { ar: 'تقدم التصحيحات', en: 'Patching progress' },
+          items: [
+            {
+              title: { ar: 'نظم الإنتاج الحرجة', en: 'Critical production systems' },
+              subtitle: { ar: 'تحديثات تلقائية يومية', en: 'Daily automated updates' },
+              value: '88%',
+              percent: '88%'
+            },
+            {
+              title: { ar: 'أجهزة المستخدمين', en: 'Endpoints' },
+              subtitle: { ar: 'برنامج إدارة جديد', en: 'New management agent' },
+              value: '76%',
+              percent: '76%'
+            },
+            {
+              title: { ar: 'الأصول السحابية', en: 'Cloud assets' },
+              subtitle: { ar: 'تكامل مع Terraform', en: 'Terraform integration' },
+              value: '64%',
+              percent: '64%'
+            }
+          ]
+        },
+        {
+          id: 'timeline',
+          type: 'timeline',
+          span: 'xl:col-span-3',
+          title: { ar: 'أحداث الأمن الأخيرة', en: 'Recent security events' },
+          items: [
+            {
+              icon: 'shield',
+              title: { ar: 'تمرين محاكاة هجوم', en: 'Attack simulation drill' },
+              subtitle: { ar: 'مشاركة 9 فرق استجابة', en: '9 response teams participated' },
+              time: { ar: 'اليوم', en: 'Today' }
+            },
+            {
+              icon: 'scale',
+              title: { ar: 'اجتياز تدقيق ISO 27001', en: 'ISO 27001 audit passed' },
+              subtitle: { ar: 'صفر ملاحظات رئيسية', en: 'Zero major findings' },
+              time: { ar: 'أمس', en: 'Yesterday' }
+            },
+            {
+              icon: 'cog',
+              title: { ar: 'تحديث مركز العمليات الأمنية', en: 'SOC platform update' },
+              subtitle: { ar: 'لوحة جديدة للرؤية الموحدة', en: 'New unified visibility console' },
+              time: { ar: 'قبل يومين', en: '2 days ago' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-common.js
+++ b/dashboards/dashboard-common.js
@@ -1,0 +1,560 @@
+(function () {
+  const RUNTIME_STYLE_ID = 'dashboard-runtime-style';
+  const RUNTIME_STYLE = `:root { color-scheme: dark; }
+body { transition: background-position 1s ease, background-color 0.6s ease, color 0.6s ease; }
+body.sidebar-mini #sidebar { overflow-y: auto; }
+@keyframes dashboardFadeUp { from { opacity: 0; transform: translateY(18px); } to { opacity: 1; transform: translateY(0); } }
+.dashboard-fade-in { animation: dashboardFadeUp 0.6s ease both; }
+.dashboard-fade-in[style*="--dashboard-delay"] { animation-delay: var(--dashboard-delay); }
+body.dashboard-animated { background-size: 260% 260%; animation: dashboardGradient 22s ease infinite; }
+@keyframes dashboardGradient { 0% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } 100% { background-position: 0% 50%; } }
+`;
+  if (!document.getElementById(RUNTIME_STYLE_ID)) {
+    const style = document.createElement('style');
+    style.id = RUNTIME_STYLE_ID;
+    style.textContent = RUNTIME_STYLE;
+    document.head.appendChild(style);
+  }
+
+  const ICON_PATHS = {
+    'chart-bar': 'M3 3a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3zm2 2v14h3V5H5zm5 4v10h3V9h-3zm5-4v14h3V5h-3z',
+    'cursor-arrow': 'M6.672 3.045 19.185 9.11a1 1 0 0 1-.012 1.814l-4.822 2.406-1.712 5.375a1 1 0 0 1-1.845.094L8.98 13.97l-5.42-1.8a1 1 0 0 1-.116-1.862l12.513-6.066a.25.25 0 0 0-.285-.443L6.672 3.045z',
+    'users': 'M7.5 7.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm9 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM3 15.75A4.75 4.75 0 0 1 7.75 11h.5A4.75 4.75 0 0 1 13 15.75v2.5a.75.75 0 0 1-.75.75h-8.5A.75.75 0 0 1 3 18.25v-2.5zm9.25 0A4.75 4.75 0 0 1 17 11h.5A4.75 4.75 0 0 1 22.25 15.75v2.5a.75.75 0 0 1-.75.75h-8.5a.75.75 0 0 1-.75-.75v-2.5z',
+    'sparkles': 'M12 2.25a.75.75 0 0 1 .699.474l1.02 2.422 2.422 1.02a.75.75 0 0 1 0 1.388l-2.422 1.02-1.02 2.422a.75.75 0 0 1-1.388 0l-1.02-2.422-2.422-1.02a.75.75 0 0 1 0-1.388l2.422-1.02 1.02-2.422A.75.75 0 0 1 12 2.25zm6.5 5.25a.75.75 0 0 1 .69.466l.57 1.355 1.355.57a.75.75 0 0 1 0 1.378l-1.355.57-.57 1.355a.75.75 0 0 1-1.38 0l-.569-1.355-1.355-.57a.75.75 0 0 1 0-1.378l1.355-.57.57-1.355A.75.75 0 0 1 18.5 7.5zM6.5 9a.75.75 0 0 1 .69.466l.57 1.355 1.355.57a.75.75 0 0 1 0 1.378l-1.355.57-.57 1.355a.75.75 0 0 1-1.38 0l-.569-1.355-1.355-.57a.75.75 0 0 1 0-1.378l1.355-.57.57-1.355A.75.75 0 0 1 6.5 9z',
+    'calendar': 'M6.75 2.25a.75.75 0 0 1 .75.75V4.5h9V3a.75.75 0 0 1 1.5 0v1.5h1.5A2.25 2.25 0 0 1 21.75 6.75v11.25A2.25 2.25 0 0 1 19.5 20.25H4.5a2.25 2.25 0 0 1-2.25-2.25V6.75A2.25 2.25 0 0 1 4.5 4.5H6V3a.75.75 0 0 1 .75-.75zM4.5 9h15v1.5h-15V9z',
+    'chat-bubble': 'M3 4.5A2.25 2.25 0 0 1 5.25 2.25h13.5A2.25 2.25 0 0 1 21 4.5v9a2.25 2.25 0 0 1-2.25 2.25H12.6l-3.9 3.12a.75.75 0 0 1-1.2-.585V15.75H5.25A2.25 2.25 0 0 1 3 13.5v-9zm3.75 3a.75.75 0 0 0 0 1.5h10.5a.75.75 0 0 0 0-1.5H6.75zm0 3a.75.75 0 0 0 0 1.5h6a.75.75 0 0 0 0-1.5h-6z',
+    'play': 'M5.25 4.432c0-1.885 2.036-3.046 3.674-2.033l9.093 5.568c1.567.96 1.567 3.106 0 4.066l-9.093 5.568c-1.638 1.013-3.674-.148-3.674-2.033V4.432z',
+    'shield': 'M12 2.25a.75.75 0 0 1 .361.09l7.5 3.75a.75.75 0 0 1 .414.671v6.724c0 4.97-3.215 9.532-8.028 10.958a.75.75 0 0 1-.394 0C7.04 22.987 3.825 18.425 3.825 13.455V6.711a.75.75 0 0 1 .414-.671l7.5-3.75A.75.75 0 0 1 12 2.25z',
+    'bank': 'M3 9.75a.75.75 0 0 1 .75-.75h.75V6a.75.75 0 0 1 .471-.696l6.75-2.7a.75.75 0 0 1 .558 0l6.75 2.7A.75.75 0 0 1 19.5 6v3h.75a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 9.75zm1.5 2.25h1.5v8.25H4.5V12zm3 0h1.5v8.25H7.5V12zm3 0h1.5v8.25h-1.5V12zm3 0h1.5v8.25h-1.5V12zm3 0h1.5v8.25h-1.5V12z',
+    'cloud': 'M7.5 19.5h10.5a3 3 0 0 0 .176-5.995A5.251 5.251 0 0 0 12.75 6a5.25 5.25 0 0 0-5.142 4.218 4.501 4.501 0 0 0-.108 9.282z',
+    'folder': 'M2.25 5.25A2.25 2.25 0 0 1 4.5 3h4.086a2.25 2.25 0 0 1 1.59.659l1.878 1.878H19.5A2.25 2.25 0 0 1 21.75 7.5v11.25A2.25 2.25 0 0 1 19.5 21H4.5A2.25 2.25 0 0 1 2.25 18.75V5.25z',
+    'cube': 'M9.53 2.882a1.5 1.5 0 0 1 .94 0l8.25 2.75A1.5 1.5 0 0 1 20 7.05v9.9a1.5 1.5 0 0 1-.94 1.418l-8.25 3a1.5 1.5 0 0 1-1.02 0l-8.25-3A1.5 1.5 0 0 1 1 16.95v-9.9a1.5 1.5 0 0 1 1.06-1.418l8.25-2.75zM3.5 8.041v7.815l7.5 2.727V10.79L3.5 8.04zm9 2.75v7.833l7.5-2.727V8.04l-7.5 2.75zm6.36-4.564L12 3.805 5.14 6.227 12 8.811l6.86-2.584z',
+    'heart': 'M11.645 20.91a1 1 0 0 0 .71 0C16.6 19.164 21 14.815 21 9.737 21 6.101 18.314 3 14.889 3c-1.93 0-3.832.99-4.89 2.54C8.94 3.99 7.039 3 5.111 3 1.686 3-.999 6.101-.999 9.737c0 5.078 4.4 9.427 9.645 11.173z',
+    'megaphone': 'M3 9a3 3 0 0 1 3-3h1.5a1.5 1.5 0 0 0 1.2-.6l2.475-3.3A1.5 1.5 0 0 1 15 2.7v18.6a1.5 1.5 0 0 1-3 .9l-2.475-3.3a1.5 1.5 0 0 0-1.2-.6H6a3 3 0 0 1-3-3V9z',
+    'truck': 'M2.25 5.25A2.25 2.25 0 0 1 4.5 3h11.25A2.25 2.25 0 0 1 18 5.25V7.5h2.25A2.25 2.25 0 0 1 22.5 9.75V15a3 3 0 0 1-3 3H18a3 3 0 0 1-6 0H9a3 3 0 0 1-6 0H2.25a.75.75 0 0 1-.75-.75V5.25zm3 11.25a1.5 1.5 0 1 0 3 0h-3zm9 0a1.5 1.5 0 1 0 3 0h-3z',
+    'building': 'M4.5 3.75A2.25 2.25 0 0 1 6.75 1.5h10.5A2.25 2.25 0 0 1 19.5 3.75V21a.75.75 0 0 1-.75.75H15V15a1.5 1.5 0 0 0-1.5-1.5h-3A1.5 1.5 0 0 0 9 15v6.75H5.25a.75.75 0 0 1-.75-.75V3.75zm6 0v3h3v-3h-3z',
+    'cog': 'M11.983 2a1 1 0 0 1 .997.92l.214 2.572a6.027 6.027 0 0 1 1.793.741l2.35-1.34a1 1 0 0 1 1.255.164l1.75 1.75a1 1 0 0 1-.164 1.255l-1.34 2.35a6.027 6.027 0 0 1 .741 1.793l2.572.214a1 1 0 0 1 .92.997v2.475a1 1 0 0 1-.92.997l-2.572.214a6.027 6.027 0 0 1-.741 1.793l1.34 2.35a1 1 0 0 1-.164 1.255l-1.75 1.75a1 1 0 0 1-1.255.164l-2.35-1.34a6.027 6.027 0 0 1-1.793.741l-.214 2.572a1 1 0 0 1-.997.92H9.508a1 1 0 0 1-.997-.92l-.214-2.572a6.027 6.027 0 0 1-1.793-.741l-2.35 1.34a1 1 0 0 1-1.255-.164l-1.75-1.75a1 1 0 0 1 .164-1.255l1.34-2.35a6.027 6.027 0 0 1-.741-1.793l-2.572-.214a1 1 0 0 1-.92-.997V11.49a1 1 0 0 1 .92-.997l2.572-.214a6.027 6.027 0 0 1 .741-1.793l-1.34-2.35a1 1 0 0 1 .164-1.255l1.75-1.75a1 1 0 0 1 1.255-.164l2.35 1.34a6.027 6.027 0 0 1 1.793-.741l.214-2.572A1 1 0 0 1 9.508 2h2.475zm1.517 10.737a2 2 0 1 0-3.999 0 2 2 0 0 0 3.999 0z',
+    'tv': 'M4.5 3.75A2.25 2.25 0 0 1 6.75 1.5h10.5A2.25 2.25 0 0 1 19.5 3.75V16.5h1.5a.75.75 0 0 1 0 1.5H3a.75.75 0 0 1 0-1.5h1.5V3.75z',
+    'map': 'M9.75 2.25a.75.75 0 0 1 .45.15l2.55 1.913 2.55-1.913a.75.75 0 0 1 .9 0l3 2.25a.75.75 0 0 1 .3.6v14.25a.75.75 0 0 1-1.2.6l-2.55-1.913-2.55 1.913a.75.75 0 0 1-.9 0l-2.55-1.913-2.55 1.913a.75.75 0 0 1-.9 0l-3-2.25a.75.75 0 0 1-.3-.6V3.15a.75.75 0 0 1 1.2-.6l2.55 1.913 2.55-1.913a.75.75 0 0 1 .45-.15z',
+    'sun': 'M12 3.75a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V4.5a.75.75 0 0 1 .75-.75zm6.364 1.636a.75.75 0 0 1 0 1.06l-1.061 1.061a.75.75 0 0 1-1.06-1.06l1.06-1.061a.75.75 0 0 1 1.061 0zM12 9a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm8.25 3a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5a.75.75 0 0 1 .75-.75zM6.75 12a.75.75 0 0 1-.75.75H4.5a.75.75 0 0 1 0-1.5h1.5a.75.75 0 0 1 .75.75zm13.114 4.886a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 1 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0zM12 18.75a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5a.75.75 0 0 1 .75-.75zm-6.364-1.364a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0zM5.114 6.614a.75.75 0 0 1 0-1.06l1.06-1.061a.75.75 0 1 1 1.061 1.06L6.175 6.614a.75.75 0 0 1-1.061 0z',
+    'trophy': 'M5.25 3A2.25 2.25 0 0 1 7.5.75h9A2.25 2.25 0 0 1 18.75 3v1.5H21a.75.75 0 0 1 .75.75 4.5 4.5 0 0 1-4.365 4.497A6.753 6.753 0 0 1 13.5 13.2v2.55h2.25a.75.75 0 0 1 0 1.5H8.25a.75.75 0 0 1 0-1.5H10.5V13.2a6.753 6.753 0 0 1-3.885-3.453A4.5 4.5 0 0 1 2.25 5.25a.75.75 0 0 1 .75-.75h2.25V3zm0 3h-1.5a3 3 0 0 0 2.829 2.987A6.717 6.717 0 0 1 5.25 6zm12 0a6.717 6.717 0 0 1-1.329 2.987A3 3 0 0 0 18.75 6h-1.5z',
+    'book-open': 'M12 4.5c-1.07-1-2.534-1.5-4.364-1.5C4.221 3 2 4.586 2 7.5v9a.75.75 0 0 0 .75.75c2.59 0 4.36.353 5.386 1.223.884.748 1.36 1.789 1.864 3.259a.75.75 0 0 0 1.4 0c.504-1.47.98-2.511 1.864-3.259 1.026-.87 2.795-1.223 5.386-1.223a.75.75 0 0 0 .75-.75v-9c0-2.914-2.221-4.5-5.636-4.5C14.534 3 13.07 3.5 12 4.5z',
+    'presentation-chart': 'M3 3.75A2.25 2.25 0 0 1 5.25 1.5h13.5A2.25 2.25 0 0 1 21 3.75V9H3V3.75zm0 7.5h18v4.5A2.25 2.25 0 0 1 18.75 18H13.5v2.25H15a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1 0-1.5h1.5V18H5.25A2.25 2.25 0 0 1 3 15.75v-4.5z',
+    'shopping-bag': 'M7.5 4.5V6h9V4.5a4.5 4.5 0 1 0-9 0zM3 9a1.5 1.5 0 0 1 1.5-1.5h15A1.5 1.5 0 0 1 21 9v10.5A3 3 0 0 1 18 22.5H6A3 3 0 0 1 3 19.5V9zm7.5 3.75a.75.75 0 0 0-1.5 0v3a.75.75 0 0 0 1.5 0v-3zm3 0a.75.75 0 0 0-1.5 0v3a.75.75 0 0 0 1.5 0v-3z',
+    'briefcase': 'M8.25 6V4.5A2.25 2.25 0 0 1 10.5 2.25h3a2.25 2.25 0 0 1 2.25 2.25V6H21a.75.75 0 0 1 .75.75v2.25H2.25V6.75A.75.75 0 0 1 3 6h5.25zm5.25 0V4.5a.75.75 0 0 0-.75-.75h-3a.75.75 0 0 0-.75.75V6h4.5zM2.25 10.5h19.5v8.25A2.25 2.25 0 0 1 19.5 21H4.5a2.25 2.25 0 0 1-2.25-2.25v-8.25zm9.75 3.75a.75.75 0 0 0-1.5 0v1.5a.75.75 0 0 0 1.5 0v-1.5z',
+    'stethoscope': 'M12 2.25a.75.75 0 0 1 .75.75v6.75a3.75 3.75 0 1 1-7.5 0V3a.75.75 0 0 1 1.5 0v6.75a2.25 2.25 0 1 0 4.5 0V3a.75.75 0 0 1 .75-.75zm6 6a3 3 0 0 1-.75 5.908V17.5a3.75 3.75 0 0 1-7.5 0v-1.5a.75.75 0 0 1 1.5 0v1.5a2.25 2.25 0 0 0 4.5 0v-3.342A3 3 0 0 1 18 8.25z',
+    'beaker': 'M5.25 2.25A.75.75 0 0 1 6 1.5h12a.75.75 0 0 1 .75.75V5.25a.75.75 0 0 1-.22.53l-5.53 5.53v6.94a2.25 2.25 0 0 1-4.5 0v-6.94l-5.53-5.53a.75.75 0 0 1-.22-.53V2.25z',
+    'scale': 'M12 2.25a.75.75 0 0 1 .75.75v3h4.5a.75.75 0 0 1 .619 1.18l-5.25 7.5a.75.75 0 0 1-1.238 0l-5.25-7.5A.75.75 0 0 1 6.75 6h4.5v-3a.75.75 0 0 1 .75-.75zm-5.332 9.24 2.25 3.214a3.75 3.75 0 1 1-2.25-3.214zm10.664 0a3.75 3.75 0 1 1-2.25 3.214l2.25-3.214z',
+    'factory': 'M3.75 3A.75.75 0 0 1 4.5 2.25h3a.75.75 0 0 1 .75.75V6l4.5-3v3l4.5-3v19.5H3.75A.75.75 0 0 1 3 21V3.75A.75.75 0 0 1 3.75 3zm9.75 15h3v-3h-3v3zm-4.5-3h3v3h-3v-3zm-4.5 0h3v3h-3v-3z',
+    'film': 'M4.5 3A1.5 1.5 0 0 0 3 4.5v15A1.5 1.5 0 0 0 4.5 21H6v-4.5h3V21h6v-4.5h3V21h1.5a1.5 1.5 0 0 0 1.5-1.5v-15A1.5 1.5 0 0 0 19.5 3H18v4.5h-3V3H9v4.5H6V3H4.5z',
+    'globe-alt': 'M12 2.25c-5.108 0-9.25 4.142-9.25 9.25s4.142 9.25 9.25 9.25 9.25-4.142 9.25-9.25S17.108 2.25 12 2.25zm7.698 8.25H15.7a15.81 15.81 0 0 0-1.124-5.098 7.754 7.754 0 0 1 5.122 5.098zM12 3.75c1.486 0 3.577 2.735 3.963 6.75H8.037C8.423 6.485 10.514 3.75 12 3.75zM7.3 12.75h9.4a15.81 15.81 0 0 1-1.124 5.098A7.754 7.754 0 0 1 7.3 12.75zm3.741 5.848A15.872 15.872 0 0 1 7.2 12.75H4.302a7.754 7.754 0 0 0 6.739 5.848zm6.017-5.848a15.872 15.872 0 0 1-3.841 5.848 7.754 7.754 0 0 0 6.739-5.848H17.058zM4.302 11.25H7.3A15.81 15.81 0 0 1 8.424 6.152 7.754 7.754 0 0 0 4.302 11.25z',
+    'leaf': 'M12.75 3a9.75 9.75 0 0 1 9.75 9.75 9.75 9.75 0 0 1-12.6 9.303A5.251 5.251 0 0 1 5.5 17.25H4.125a2.625 2.625 0 0 1-2.625-2.625v-.375A11.25 11.25 0 0 1 12.75 3zm-4.5 9.75a4.5 4.5 0 0 0-4.5 4.5c0 .621.504 1.125 1.125 1.125h1.375a3.75 3.75 0 0 0 3.75-3.75v-1.875z',
+    'basketball': 'M12 2.25A9.75 9.75 0 1 0 21.75 12 9.75 9.75 0 0 0 12 2.25zm7.314 8.25h-4.564a12.3 12.3 0 0 0-.753-4.43A8.255 8.255 0 0 1 19.314 10.5zm-6.064 0H10.75V4.058a10.77 10.77 0 0 1 2.5 6.442zm-3.5 0H4.686a8.255 8.255 0 0 1 5.317-6.68 12.3 12.3 0 0 0-.753 4.43zm0 3h2.5v6.442a10.77 10.77 0 0 1-2.5-6.442zm3.5 0h4.564a8.255 8.255 0 0 1-5.317 6.68 12.3 12.3 0 0 0 .753-4.43zm-6.81 0a12.3 12.3 0 0 0 .753 4.43A8.255 8.255 0 0 1 4.686 13.5z',
+    'layout-sidebar': 'M3 4.5A1.5 1.5 0 0 1 4.5 3h15A1.5 1.5 0 0 1 21 4.5v15a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 19.5v-15zM9 4.5H4.5v15H9v-15zm1.5 0v15h9v-15h-9z'
+  };
+
+  function createIcon(name, classes) {
+    const path = ICON_PATHS[name] || ICON_PATHS['sparkles'];
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="${classes}"><path d="${path}" /></svg>`;
+  }
+
+  function formatDelta(delta, trend) {
+    const base = trend === 'negative' ? 'text-rose-400' : trend === 'neutral' ? 'text-amber-400' : 'text-emerald-400';
+    return `${base} text-sm font-medium`;
+  }
+
+  function initDashboard(config) {
+    const html = document.documentElement;
+    const body = document.body;
+    const shell = document.querySelector('[data-role="dashboard-shell"]') || document.querySelector('.min-h-screen') || body;
+    const sidebar = document.getElementById('sidebar');
+    const sidebarToggle = document.getElementById('sidebarToggle');
+    const sidebarClose = document.getElementById('sidebarClose');
+    const sidebarBackdrop = document.getElementById('sidebarBackdrop');
+
+    const defaultActions = {
+      open: { ar: 'فتح القائمة', en: 'Open menu' },
+      close: { ar: 'إغلاق', en: 'Close' },
+      collapse: { ar: 'تصغير الشريط', en: 'Collapse sidebar' },
+      expand: { ar: 'توسيع الشريط', en: 'Expand sidebar' }
+    };
+    config.actions = Object.assign({}, defaultActions, config.actions || {});
+    for (const key of Object.keys(defaultActions)) {
+      config.actions[key] = Object.assign({}, defaultActions[key], config.actions[key] || {});
+    }
+
+    const theme = Object.assign({
+      bodyGradient: '',
+      sidebarGradient: '',
+      sidebarBorder: '',
+      cardBg: 'bg-slate-900/70 backdrop-blur-xl',
+      cardBorder: 'border-slate-800/60',
+      cardShadow: 'shadow-[0_28px_65px_-40px_rgba(15,23,42,0.8)]',
+      accentGradient: 'from-indigo-500 to-purple-500',
+      accentText: 'text-indigo-400',
+      highlightBg: 'bg-indigo-500/10 border-indigo-500/20',
+      badgeBg: 'bg-indigo-500/20',
+      badgeText: 'text-white'
+    }, config.theme || {});
+
+    body.classList.add('antialiased', 'bg-slate-950', 'text-slate-100', 'transition-colors', 'duration-500');
+    if (theme.bodyGradient) {
+      body.classList.add('bg-gradient-to-br');
+      theme.bodyGradient.split(/\s+/).filter(Boolean).forEach(cls => body.classList.add(cls));
+      body.classList.add('dashboard-animated');
+    }
+    if (shell) {
+      shell.classList.add('dashboard-shell');
+    }
+    if (sidebar) {
+      sidebar.classList.add('transition-all', 'duration-300', 'will-change-transform');
+      if (theme.sidebarGradient) {
+        sidebar.classList.add('bg-gradient-to-b');
+        theme.sidebarGradient.split(/\s+/).filter(Boolean).forEach(cls => sidebar.classList.add(cls));
+      }
+      if (theme.sidebarBorder) {
+        sidebar.classList.remove('border-white/10');
+        theme.sidebarBorder.split(/\s+/).filter(Boolean).forEach(cls => sidebar.classList.add(cls));
+      }
+    }
+
+    const storageKey = `dashboard:mini:${window.location.pathname}`;
+    const lgQuery = window.matchMedia('(min-width: 1024px)');
+    let miniState = false;
+    try {
+      miniState = localStorage.getItem(storageKey) === '1';
+    } catch (error) {
+      miniState = false;
+    }
+
+    let currentLang = config.defaultLang || 'ar';
+    let navLinks = [];
+    let navLabels = [];
+    let navBadges = [];
+    let miniLabelNodes = [];
+    let miniIconNodes = [];
+    let miniToggle = null;
+
+    function syncMiniPresentation() {
+      const active = miniState && lgQuery.matches;
+      body.classList.toggle('sidebar-mini', active);
+      if (sidebar) {
+        sidebar.style.width = active ? '6.5rem' : '';
+        sidebar.style.paddingInline = active ? '1.25rem' : '';
+      }
+      navLinks.forEach(link => {
+        link.style.justifyContent = active ? 'center' : '';
+        link.style.textAlign = active ? 'center' : '';
+      });
+      navLabels.forEach(label => {
+        label.style.display = active ? 'none' : '';
+        label.style.opacity = active ? '0' : '';
+        label.style.transform = active ? 'translateX(12px)' : '';
+      });
+      navBadges.forEach(badge => {
+        badge.style.display = active ? 'none' : '';
+        badge.style.opacity = active ? '0' : '';
+      });
+      const highlight = document.querySelector('[data-role="sidebar-highlight"]');
+      if (highlight) {
+        highlight.style.display = active ? 'none' : '';
+      }
+      document.querySelectorAll('[data-role="brand-name"], [data-role="brand-tagline"]').forEach(el => {
+        el.style.display = active ? 'none' : '';
+      });
+      if (sidebar) {
+        const desktopLang = sidebar.querySelector('[data-role="language-switcher"]');
+        if (desktopLang) {
+          desktopLang.style.display = active ? 'none' : '';
+        }
+      }
+      const labelText = active ? config.actions.expand[currentLang] : config.actions.collapse[currentLang];
+      miniLabelNodes.forEach(node => {
+        node.textContent = labelText;
+      });
+      miniIconNodes.forEach(icon => {
+        icon.style.transform = active ? 'scaleX(-1)' : '';
+      });
+      if (miniToggle) {
+        miniToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
+        miniToggle.setAttribute('title', labelText);
+      }
+    }
+
+    function setMiniState(state, persist) {
+      miniState = state;
+      if (persist) {
+        try {
+          localStorage.setItem(storageKey, state ? '1' : '0');
+        } catch (error) {
+          // ignore storage errors
+        }
+      }
+      syncMiniPresentation();
+    }
+
+    function createMiniToggle() {
+      if (!sidebar) return null;
+      const headerRow = sidebar.querySelector('.flex.items-start.justify-between.gap-3');
+      const actionsWrap = headerRow ? headerRow.querySelector('.flex.items-center.gap-2') : null;
+      if (!actionsWrap) return null;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'hidden lg:inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20 transition';
+      button.innerHTML = `
+        <span data-role="mini-icon" class="h-8 w-8 rounded-lg flex items-center justify-center bg-white/10 transition-transform duration-300">
+          ${createIcon('layout-sidebar', 'h-4 w-4 text-white')}
+        </span>
+        <span data-role="mini-label" class="mini-label whitespace-nowrap transition-opacity duration-300"></span>
+      `;
+      actionsWrap.appendChild(button);
+      miniLabelNodes = Array.from(button.querySelectorAll('[data-role="mini-label"]'));
+      miniIconNodes = Array.from(button.querySelectorAll('[data-role="mini-icon"]'));
+      button.addEventListener('click', () => {
+        setMiniState(!miniState, true);
+      });
+      return button;
+    }
+
+    function openSidebar() {
+      if (!sidebar) return;
+      sidebar.classList.remove('translate-x-full');
+      sidebar.classList.add('translate-x-0');
+      if (sidebarBackdrop) {
+        sidebarBackdrop.classList.remove('pointer-events-none');
+        sidebarBackdrop.classList.add('opacity-100');
+      }
+    }
+
+    function closeSidebar() {
+      if (!sidebar) return;
+      sidebar.classList.add('translate-x-full');
+      sidebar.classList.remove('translate-x-0');
+      if (sidebarBackdrop) {
+        sidebarBackdrop.classList.add('pointer-events-none');
+        sidebarBackdrop.classList.remove('opacity-100');
+      }
+    }
+
+    sidebarToggle && sidebarToggle.addEventListener('click', openSidebar);
+    sidebarClose && sidebarClose.addEventListener('click', closeSidebar);
+    sidebarBackdrop && sidebarBackdrop.addEventListener('click', closeSidebar);
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeSidebar();
+      }
+    });
+
+    const languageContainers = document.querySelectorAll('[data-role="language-switcher"]');
+    const langButtons = [];
+    languageContainers.forEach(container => {
+      if (!container) return;
+      container.innerHTML = '';
+      ['ar', 'en'].forEach(lang => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.dataset.langButton = lang;
+        button.textContent = lang === 'ar' ? 'ع' : 'En';
+        button.className = 'px-3 py-1 text-xs font-semibold rounded-lg transition border border-white/10 text-slate-200 bg-transparent hover:bg-white/10';
+        button.setAttribute('aria-pressed', 'false');
+        container.appendChild(button);
+        langButtons.push(button);
+      });
+    });
+
+    miniToggle = createMiniToggle();
+
+    langButtons.forEach(btn => {
+      btn.addEventListener('click', () => setLanguage(btn.dataset.langButton));
+    });
+
+    function updateLanguageButtons() {
+      langButtons.forEach(btn => {
+        const active = btn.dataset.langButton === currentLang;
+        btn.classList.toggle('bg-white/10', active);
+        btn.classList.toggle('text-white', active);
+        btn.classList.toggle('border-white/10', true);
+        btn.classList.toggle('opacity-70', !active);
+        btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+
+    function renderBrand(lang) {
+      const badgeElements = document.querySelectorAll('[data-role="brand-badge"], [data-role="mobile-badge"]');
+      badgeElements.forEach(el => {
+        if (!el) return;
+        el.textContent = config.brand.badge || '∞';
+        el.className = `h-12 w-12 rounded-2xl flex items-center justify-center text-xl font-semibold shadow-inner ${theme.badgeBg} ${theme.badgeText}`;
+      });
+
+      const brandNameElements = document.querySelectorAll('[data-role="brand-name"], [data-role="mobile-brand-name"]');
+      brandNameElements.forEach(el => {
+        if (el) {
+          el.textContent = config.brand.name[lang];
+        }
+      });
+
+      const taglineElements = document.querySelectorAll('[data-role="brand-tagline"], [data-role="mobile-brand-tagline"]');
+      taglineElements.forEach(el => {
+        if (el) {
+          el.textContent = config.brand.tagline[lang];
+        }
+      });
+    }
+
+    function renderNav(lang) {
+      const navContainer = document.querySelector('[data-role="sidebar-nav"]');
+      if (!navContainer) return;
+      navContainer.innerHTML = '';
+      navLinks = [];
+      navLabels = [];
+      navBadges = [];
+      (config.nav || []).forEach((item, index) => {
+        const link = document.createElement('a');
+        link.href = `#${item.id}`;
+        link.title = item.label[lang];
+        link.className = `flex items-center justify-between px-4 py-3 rounded-xl border transition ${index === 0 ? 'bg-white/10 border-white/10' : 'border-white/5 hover:bg-white/5'}`;
+        const left = document.createElement('span');
+        left.className = 'flex items-center gap-3 text-sm transition-all duration-300';
+        const iconWrapper = document.createElement('span');
+        iconWrapper.className = 'h-9 w-9 rounded-xl flex items-center justify-center bg-white/5';
+        iconWrapper.innerHTML = createIcon(item.icon, `h-5 w-5 ${theme.accentText}`);
+        const labelSpan = document.createElement('span');
+        labelSpan.className = 'sidebar-label font-medium transition-all duration-300';
+        labelSpan.textContent = item.label[lang];
+        left.appendChild(iconWrapper);
+        left.appendChild(labelSpan);
+        link.appendChild(left);
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'sidebar-badge text-xs text-slate-400 transition-all duration-300';
+        badgeSpan.textContent = item.badge ? item.badge[lang] : '';
+        link.appendChild(badgeSpan);
+        navContainer.appendChild(link);
+        navLinks.push(link);
+        navLabels.push(labelSpan);
+        navBadges.push(badgeSpan);
+      });
+    }
+
+    function renderHighlight(lang) {
+      const highlight = document.querySelector('[data-role="sidebar-highlight"]');
+      if (!highlight || !config.highlight) return;
+      highlight.innerHTML = `
+        <div class="rounded-2xl border ${theme.highlightBg} ${theme.cardShadow} p-5 space-y-3">
+          <p class="text-xs uppercase tracking-wide text-slate-400">${config.highlight.label[lang]}</p>
+          <p class="text-2xl font-semibold">${config.highlight.value}</p>
+          <p class="text-sm text-slate-300">${config.highlight.description[lang]}</p>
+        </div>
+      `;
+      const card = highlight.querySelector('div');
+      if (card) {
+        card.classList.add('dashboard-fade-in');
+        card.style.setProperty('--dashboard-delay', '0.12s');
+      }
+    }
+
+    function renderHeader(lang) {
+      const header = document.querySelector('[data-role="main-header"]');
+      if (!header) return;
+      const primary = config.header.primary ? `<button class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20">${config.header.primary[lang]}</button>` : '';
+      const secondary = config.header.secondary ? `<button class="inline-flex items-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-white/5">${config.header.secondary[lang]}</button>` : '';
+      header.innerHTML = `
+        <div>
+          <h1 class="text-3xl font-bold">${config.header.title[lang]}</h1>
+          <p class="mt-2 text-slate-300">${config.header.subtitle[lang]}</p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          ${secondary}
+          ${primary}
+        </div>
+      `;
+      header.classList.add('dashboard-fade-in');
+      header.style.setProperty('--dashboard-delay', '0.05s');
+    }
+
+    function renderStats(lang) {
+      const statsContainer = document.querySelector('[data-role="stats"]');
+      if (!statsContainer) return;
+      statsContainer.innerHTML = '';
+      (config.stats || []).forEach((stat, index) => {
+        const card = document.createElement('div');
+        card.className = `rounded-2xl border ${theme.cardBorder} ${theme.cardBg} ${theme.cardShadow} p-5 space-y-4`;
+        card.classList.add('dashboard-fade-in');
+        card.style.setProperty('--dashboard-delay', `${0.08 * index + 0.08}s`);
+        card.innerHTML = `
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm text-slate-400">${stat.label[lang]}</p>
+              <p class="mt-3 text-3xl font-semibold">${stat.value}</p>
+            </div>
+            <span class="h-12 w-12 rounded-xl flex items-center justify-center bg-white/5">
+              ${createIcon(stat.icon, `h-6 w-6 ${theme.accentText}`)}
+            </span>
+          </div>
+          <p class="${formatDelta('', stat.trend)}">${stat.delta[lang]}</p>
+        `;
+        statsContainer.appendChild(card);
+      });
+    }
+
+    function renderPanels(lang) {
+      const panelsContainer = document.querySelector('[data-role="panels"]');
+      if (!panelsContainer) return;
+      panelsContainer.innerHTML = '';
+      (config.panels || []).forEach((panel, index) => {
+        const section = document.createElement('section');
+        section.className = `rounded-2xl border ${theme.cardBorder} ${theme.cardBg} ${theme.cardShadow} p-6 space-y-6 ${panel.span || ''}`;
+        if (panel.id) {
+          section.id = panel.id;
+        }
+        section.classList.add('dashboard-fade-in');
+        section.style.setProperty('--dashboard-delay', `${0.1 * index + 0.15}s`);
+        let content = '';
+        if (panel.type === 'chart') {
+          content = `
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 class="text-xl font-semibold">${panel.title[lang]}</h2>
+                <p class="text-sm text-slate-300">${panel.subtitle[lang]}</p>
+              </div>
+              ${panel.action ? `<button class="inline-flex items-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:bg-white/5">${panel.action[lang]}</button>` : ''}
+            </div>
+            <div class="h-56 rounded-2xl border border-dashed border-white/10 bg-gradient-to-br ${theme.accentGradient} opacity-80 flex items-center justify-center text-sm text-white/80">
+              ${panel.placeholder[lang]}
+            </div>
+          `;
+        } else if (panel.type === 'list') {
+          const items = (panel.items || []).map(item => `
+            <div class="flex items-center justify-between rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+              <div class="flex items-center gap-3">
+                <span class="h-10 w-10 rounded-xl flex items-center justify-center bg-white/5">
+                  ${createIcon(item.icon || 'sparkles', `h-5 w-5 ${theme.accentText}`)}
+                </span>
+                <div>
+                  <p class="text-sm font-semibold">${item.title[lang]}</p>
+                  <p class="text-xs text-slate-400">${item.subtitle[lang]}</p>
+                </div>
+              </div>
+              <div class="text-right">
+                <p class="text-base font-semibold">${item.value}</p>
+                <p class="text-xs text-slate-400">${item.delta[lang]}</p>
+              </div>
+            </div>
+          `).join('');
+          content = `
+            <div class="space-y-4">
+              <div class="flex items-center justify-between">
+                <h2 class="text-lg font-semibold">${panel.title[lang]}</h2>
+                ${panel.action ? `<span class="text-xs text-slate-400">${panel.action[lang]}</span>` : ''}
+              </div>
+              ${items}
+            </div>
+          `;
+        } else if (panel.type === 'progress') {
+          const items = (panel.items || []).map(item => `
+            <div class="space-y-2">
+              <div class="flex items-center justify-between text-sm">
+                <span>${item.title[lang]}</span>
+                <span class="text-slate-400">${item.value}</span>
+              </div>
+              <div class="h-2 rounded-full bg-white/5 overflow-hidden">
+                <div class="h-full rounded-full bg-gradient-to-r ${theme.accentGradient}" style="width:${item.percent}"></div>
+              </div>
+              <p class="text-xs text-slate-400">${item.subtitle[lang]}</p>
+            </div>
+          `).join('');
+          content = `
+            <div class="space-y-4">
+              <h2 class="text-lg font-semibold">${panel.title[lang]}</h2>
+              ${items}
+            </div>
+          `;
+        } else if (panel.type === 'table') {
+          const headers = (panel.headers || []).map(header => `<th class="px-4 py-2 text-left text-xs font-semibold text-slate-400">${header[lang]}</th>`).join('');
+          const rows = (panel.rows || []).map(row => `<tr class="border-t border-white/5">
+              <td class="px-4 py-3 text-sm font-medium">${row.name[lang]}</td>
+              <td class="px-4 py-3 text-sm text-slate-300">${row.metric}</td>
+              <td class="px-4 py-3 text-sm ${row.trend === 'negative' ? 'text-rose-400' : 'text-emerald-400'}">${row.delta[lang]}</td>
+            </tr>`).join('');
+          content = `
+            <div class="space-y-4 overflow-hidden">
+              <div class="flex items-center justify-between">
+                <h2 class="text-lg font-semibold">${panel.title[lang]}</h2>
+                ${panel.action ? `<span class="text-xs text-slate-400">${panel.action[lang]}</span>` : ''}
+              </div>
+              <div class="overflow-x-auto">
+                <table class="min-w-full text-left">
+                  <thead class="bg-white/5">
+                    <tr>${headers}</tr>
+                  </thead>
+                  <tbody>${rows}</tbody>
+                </table>
+              </div>
+            </div>
+          `;
+        } else if (panel.type === 'timeline') {
+          const items = (panel.items || []).map(item => `
+            <div class="flex gap-4">
+              <div class="flex flex-col items-center">
+                <span class="h-10 w-10 rounded-xl flex items-center justify-center bg-white/5">${createIcon(item.icon || 'sparkles', `h-5 w-5 ${theme.accentText}`)}</span>
+                <span class="flex-1 w-px bg-white/10"></span>
+              </div>
+              <div class="pb-6">
+                <p class="text-sm font-semibold">${item.title[lang]}</p>
+                <p class="text-xs text-slate-400 mt-1">${item.subtitle[lang]}</p>
+                <span class="inline-flex items-center gap-1 rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300 mt-3">${item.time[lang]}</span>
+              </div>
+            </div>
+          `).join('');
+          content = `
+            <div class="space-y-4">
+              <h2 class="text-lg font-semibold">${panel.title[lang]}</h2>
+              <div class="space-y-4">${items}</div>
+            </div>
+          `;
+        }
+        section.innerHTML = content;
+        panelsContainer.appendChild(section);
+      });
+    }
+
+    function setLanguage(lang) {
+      currentLang = lang;
+      html.setAttribute('lang', lang);
+      html.setAttribute('dir', lang === 'ar' ? 'rtl' : 'ltr');
+      body.classList.toggle('font-english', lang === 'en');
+      updateLanguageButtons();
+      renderBrand(lang);
+      renderNav(lang);
+      renderHighlight(lang);
+      renderHeader(lang);
+      renderStats(lang);
+      renderPanels(lang);
+      const title = document.querySelector('title');
+      if (title && config.meta && config.meta.title) {
+        title.textContent = config.meta.title[lang];
+      }
+      const openLabel = document.querySelector('[data-role="open-label"]');
+      const closeLabel = document.querySelector('[data-role="close-label"]');
+      if (openLabel) openLabel.textContent = config.actions.open[lang];
+      if (closeLabel) closeLabel.textContent = config.actions.close[lang];
+      if (sidebarToggle) sidebarToggle.setAttribute('aria-label', config.actions.open[lang]);
+      if (sidebarClose) sidebarClose.setAttribute('aria-label', config.actions.close[lang]);
+      syncMiniPresentation();
+    }
+
+    setLanguage(currentLang);
+    setMiniState(miniState, false);
+
+    const handleMediaChange = () => {
+      syncMiniPresentation();
+    };
+    if (lgQuery.addEventListener) {
+      lgQuery.addEventListener('change', handleMediaChange);
+    } else if (lgQuery.addListener) {
+      lgQuery.addListener(handleMediaChange);
+    }
+  }
+
+  window.initDashboard = initDashboard;
+})();


### PR DESCRIPTION
## Summary
- overhaul the shared dashboard runtime to inject animated gradients, fade-in motion, and a desktop mini-sidebar toggle with persisted state
- extend every dashboard configuration with collapse/expand translations and rich theming metadata for gradients, glass surfaces, and accent borders
- tag each dashboard shell for runtime targeting so the new styling hooks can be applied consistently across all twenty layouts

## Testing
- not run (static HTML/JS updates)


------
https://chatgpt.com/codex/tasks/task_e_68d7c08a2d84832fb7f6a80c44a69238