### PR TITLE
Add dashboards 21-25 and expand catalog

### DIFF
--- a/dashboards/dashboard-21.html
+++ b/dashboards/dashboard-21.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الذكاء التشغيلي</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">OI</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">OI</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الذكاء التشغيلي',
+          en: 'Operational intelligence cockpit'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        }
+      },
+      brand: {
+        badge: 'OI',
+        name: {
+          ar: 'مركز القيادة الذكي',
+          en: 'Intelligent Operations Center'
+        },
+        tagline: {
+          ar: 'قرارات فورية مدعومة بالذكاء الاصطناعي',
+          en: 'Real-time decisions powered by AI'
+        }
+      },
+      theme: {
+        accentGradient: 'from-emerald-500 via-sky-500 to-teal-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'sparkles',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'بث مباشر', en: 'Live' }
+        },
+        {
+          id: 'alerts',
+          icon: 'megaphone',
+          label: { ar: 'التنبيهات', en: 'Alerts' }
+        },
+        {
+          id: 'throughput',
+          icon: 'chart-bar',
+          label: { ar: 'الإنتاجية', en: 'Throughput' }
+        },
+        {
+          id: 'quality',
+          icon: 'shield',
+          label: { ar: 'الجودة', en: 'Quality' }
+        },
+        {
+          id: 'initiatives',
+          icon: 'cog',
+          label: { ar: 'مبادرات الكفاءة', en: 'Efficiency initiatives' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'تنبيه ذكي', en: 'Intelligent alert' },
+        value: 'انحراف الطاقة في خط الإنتاج 3',
+        description: {
+          ar: 'اكتشف النظام نمط استهلاك غير اعتيادي قد يؤثر على دقة المنتج خلال 25 دقيقة.',
+          en: 'AI detected an abnormal energy pattern that could impact product tolerance within 25 minutes.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة التحكم التشغيلي المباشر',
+          en: 'Live operations control board'
+        },
+        subtitle: {
+          ar: 'راقب التدفقات، جودة الإنتاج، وتأثير المبادرات من منصة واحدة.',
+          en: 'Monitor throughput, quality, and initiative impact from a unified cockpit.'
+        },
+        primary: {
+          ar: 'نشر توصية الذكاء الاصطناعي',
+          en: 'Deploy AI recommendation'
+        },
+        secondary: {
+          ar: 'استعراض تقارير اليوم',
+          en: 'Review daily reports'
+        }
+      },
+      stats: [
+        {
+          icon: 'chart-bar',
+          label: { ar: 'معدل الالتزام بالخطة', en: 'Plan adherence rate' },
+          value: '98.4%',
+          delta: { ar: '+2.1% هذا الأسبوع', en: '+2.1% this week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'وقت معالجة التنبيه', en: 'Alert resolution time' },
+          value: '3.2 م',
+          delta: { ar: '-46 ثانية', en: '-46 seconds' },
+          trend: 'positive'
+        },
+        {
+          icon: 'globe-alt',
+          label: { ar: 'الأصول المتصلة', en: 'Connected assets' },
+          value: '1.8K',
+          delta: { ar: '+120 أجهزة', en: '+120 devices' },
+          trend: 'positive'
+        },
+        {
+          icon: 'shield',
+          label: { ar: 'الحالات الحرجة المفتوحة', en: 'Open critical cases' },
+          value: '4',
+          delta: { ar: '+1 منذ الأمس', en: '+1 since yesterday' },
+          trend: 'negative'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'التدفق مقابل الخطة', en: 'Throughput vs plan' },
+          subtitle: { ar: 'قياس الأداء الحالي مقابل الأهداف الأسبوعية لكل خط إنتاج.', en: 'Track current output against weekly targets across production lines.' },
+          action: { ar: 'تنزيل ملخص الأداء', en: 'Download performance brief' },
+          placeholder: { ar: 'مخطط تراكمي للتدفق المباشر', en: 'Live throughput composite chart' }
+        },
+        {
+          id: 'alerts',
+          type: 'list',
+          title: { ar: 'أبرز تنبيهات الذكاء الاصطناعي', en: 'Top AI alerts' },
+          action: { ar: 'فتح مركز التنبيهات', en: 'Open alert centre' },
+          items: [
+            {
+              icon: 'sparkles',
+              title: { ar: 'انحراف درجة الحرارة | خط التجميع 2', en: 'Temperature deviation | Assembly line 2' },
+              subtitle: { ar: 'حد الانحراف 3.4° فوق المعدل المقبول', en: '3.4° above acceptable threshold' },
+              value: 'أولوية قصوى',
+              delta: { ar: 'موصى بتهدئة فورية', en: 'Recommend immediate cooldown' }
+            },
+            {
+              icon: 'cog',
+              title: { ar: 'تراجع كفاءة المحور الروبوتي', en: 'Robotic cell efficiency dip' },
+              subtitle: { ar: 'الكفاءة عند 91% مقابل هدف 97%', en: 'Running at 91% vs 97% target' },
+              value: 'جارٍ المعالجة',
+              delta: { ar: 'تم تعيين مهندس المناوبة', en: 'Shift engineer assigned' }
+            },
+            {
+              icon: 'shield',
+              title: { ar: 'حساسية جودة المنتج النهائي', en: 'Finished goods tolerance risk' },
+              subtitle: { ar: 'احتمال رفض بنسبة 2.1%', en: '2.1% rejection probability' },
+              value: 'تحذير',
+              delta: { ar: 'طلب اختبار جودة إضافي', en: 'Extra QA sampling requested' }
+            }
+          ]
+        },
+        {
+          id: 'throughput',
+          type: 'progress',
+          title: { ar: 'مبادرات تعزيز الإنتاجية', en: 'Throughput boost initiatives' },
+          items: [
+            {
+              title: { ar: 'تحسين مسارات AGV', en: 'Optimise AGV routing' },
+              subtitle: { ar: 'خوارزمية جديدة لتقليل وقت الانتقال بين المحطات.', en: 'New routing algorithm to cut station travel time.' },
+              value: '72%',
+              percent: '72%'
+            },
+            {
+              title: { ar: 'معايرة تنبؤية للمعدات', en: 'Predictive calibration cycles' },
+              subtitle: { ar: 'جدولة الصيانة الوقائية بناء على التآكل الفعلي.', en: 'Preventive maintenance scheduled by wear models.' },
+              value: '54%',
+              percent: '54%'
+            },
+            {
+              title: { ar: 'لوحات أداء الفرق اللحظية', en: 'Real-time crew scoreboards' },
+              subtitle: { ar: 'تحفيز الفرق عبر عرض الأداء المباشر.', en: 'Motivate crews with live performance visibility.' },
+              value: '38%',
+              percent: '38%'
+            }
+          ]
+        },
+        {
+          id: 'quality',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'مؤشرات الجودة الجوهرية', en: 'Critical quality indicators' },
+          action: { ar: 'تحميل تقرير الجودة', en: 'Download quality report' },
+          headers: [
+            { ar: 'الخط', en: 'Line' },
+            { ar: 'نسبة المطابقة', en: 'Conformance' },
+            { ar: 'الاتجاه', en: 'Trend' }
+          ],
+          rows: [
+            {
+              name: { ar: 'خط التشكيل المتقدم', en: 'Advanced forming line' },
+              metric: '99.2% | آخر 24 ساعة',
+              delta: { ar: '+0.8%', en: '+0.8%' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'خلية الطلاء الدقيقة', en: 'Precision coating cell' },
+              metric: '97.5% | آخر 12 ساعة',
+              delta: { ar: '-0.6%', en: '-0.6%' },
+              trend: 'negative'
+            },
+            {
+              name: { ar: 'التجميع النهائي', en: 'Final assembly' },
+              metric: '98.1% | اليوم',
+              delta: { ar: 'ثابت', en: 'Stable' },
+              trend: 'neutral'
+            }
+          ]
+        },
+        {
+          id: 'initiatives',
+          type: 'timeline',
+          title: { ar: 'جدول مبادرات الكفاءة', en: 'Efficiency initiative timeline' },
+          items: [
+            {
+              icon: 'calendar',
+              title: { ar: 'تجربة خوارزمية الصيانة الذكية', en: 'Pilot smart maintenance algorithm' },
+              subtitle: { ar: 'دمج بيانات الاهتزاز مع مستشعرات الحرارة للتنبؤ بالتوقفات.', en: 'Blend vibration and temperature telemetry to predict downtime.' },
+              time: { ar: '09:30 صباحاً', en: '09:30 AM' }
+            },
+            {
+              icon: 'presentation-chart',
+              title: { ar: 'مراجعة نتائج الكفاءة ربع السنوية', en: 'Quarterly efficiency review' },
+              subtitle: { ar: 'عرض أثر مبادرات الكفاءة على التكلفة وجودة المنتج.', en: 'Showcase cost and quality impact from efficiency programmes.' },
+              time: { ar: '01:00 ظهراً', en: '01:00 PM' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'جلسة تطوير نماذج التنبؤ', en: 'Predictive modelling workshop' },
+              subtitle: { ar: 'تدريب فريق التحليلات على المتغيرات الجديدة.', en: 'Upskill analytics team on new feature sets.' },
+              time: { ar: '04:15 مساءً', en: '04:15 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-22.html
+++ b/dashboards/dashboard-22.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة تخطيط الوسائط المتقدمة</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MP</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">MP</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة تخطيط الوسائط المتقدمة',
+          en: 'Advanced media planning dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        }
+      },
+      brand: {
+        badge: 'MP',
+        name: {
+          ar: 'منصة تخطيط الوسائط',
+          en: 'Media Planning Studio'
+        },
+        tagline: {
+          ar: 'مواءمة الإنفاق والنتائج عبر كل القنوات',
+          en: 'Align spend and outcomes across every channel'
+        }
+      },
+      theme: {
+        accentGradient: 'from-rose-500 via-indigo-500 to-sky-500',
+        accentText: 'text-rose-200',
+        highlightBg: 'bg-rose-500/10 border-rose-400/30',
+        badgeBg: 'bg-rose-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'presentation-chart',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'محدث', en: 'Updated' }
+        },
+        {
+          id: 'budget',
+          icon: 'bank',
+          label: { ar: 'الميزانيات', en: 'Budgets' }
+        },
+        {
+          id: 'channels',
+          icon: 'tv',
+          label: { ar: 'مزيج القنوات', en: 'Channel mix' }
+        },
+        {
+          id: 'creative',
+          icon: 'film',
+          label: { ar: 'الإبداع', en: 'Creative' }
+        },
+        {
+          id: 'operations',
+          icon: 'calendar',
+          label: { ar: 'العمليات', en: 'Operations' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'نافذة حجز حرجة', en: 'Critical booking window' },
+        value: 'مركز البث المباشر | نهائي الموسم',
+        description: {
+          ar: 'تبقى 6 ساعات لتأمين المساحة الإعلانية قبل ارتفاع الأسعار بنسبة 18%.',
+          en: 'Six hours left to lock live broadcast inventory before an 18% rate surge.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة التحكم في الحملات المتكاملة',
+          en: 'Integrated campaign control centre'
+        },
+        subtitle: {
+          ar: 'راقب الإنفاق، الوصول، ومردود الحملات المتعددة القنوات من لوحة واحدة.',
+          en: 'Track spend, reach, and cross-channel ROI from a single orchestrated view.'
+        },
+        primary: {
+          ar: 'إطلاق سيناريو محاكاة',
+          en: 'Launch simulation scenario'
+        },
+        secondary: {
+          ar: 'مراجعة جدول البث',
+          en: 'Review flighting calendar'
+        }
+      },
+      stats: [
+        {
+          icon: 'bank',
+          label: { ar: 'معدل صرف الميزانية', en: 'Budget pacing' },
+          value: '92%',
+          delta: { ar: '+4% عن الهدف', en: '+4% vs target' },
+          trend: 'positive'
+        },
+        {
+          icon: 'tv',
+          label: { ar: 'الوصول الفريد', en: 'Unique reach' },
+          value: '38.6M',
+          delta: { ar: '+1.9M خلال 7 أيام', en: '+1.9M in 7 days' },
+          trend: 'positive'
+        },
+        {
+          icon: 'presentation-chart',
+          label: { ar: 'عائد الاستثمار المتوسط', en: 'Average campaign ROI' },
+          value: '4.2×',
+          delta: { ar: '+0.3× مقارنة بالربع الماضي', en: '+0.3× vs last quarter' },
+          trend: 'positive'
+        },
+        {
+          icon: 'film',
+          label: { ar: 'اختبارات A/B المفتوحة', en: 'Live creative tests' },
+          value: '7',
+          delta: { ar: '-2 بالمقارنة بالأسبوع الماضي', en: '-2 vs last week' },
+          trend: 'negative'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مقارنة الإنفاق مقابل الأداء', en: 'Spend vs performance comparison' },
+          subtitle: { ar: 'تحليل دقيق لارتباط الإنفاق بالأثر عبر التلفزيون، الرقمي، والبودكاست.', en: 'Granular correlation between spend and impact across TV, digital, and podcasts.' },
+          action: { ar: 'تحميل لوحة القياس', en: 'Download measurement board' },
+          placeholder: { ar: 'مخطط متعدد المحاور للإنفاق والعائد', en: 'Multi-axis spend and return chart' }
+        },
+        {
+          id: 'budget',
+          type: 'list',
+          title: { ar: 'أبرز المحافظ الإعلامية', en: 'Top media portfolios' },
+          action: { ar: 'إدارة التخصيص', en: 'Manage allocations' },
+          items: [
+            {
+              icon: 'bank',
+              title: { ar: 'حملة إطلاق المنتج العالمي', en: 'Global product launch' },
+              subtitle: { ar: 'إنفاق 5.4 مليون دولار | 68% من الهدف', en: '$5.4M spent | 68% of plan' },
+              value: 'عائد 4.8×',
+              delta: { ar: '+0.6× أداء متفوق', en: '+0.6× outperforming' }
+            },
+            {
+              icon: 'tv',
+              title: { ar: 'برنامج الرعاية التلفزيونية', en: 'Prime-time sponsorship programme' },
+              subtitle: { ar: 'إنفاق 2.3 مليون دولار | 85% من الهدف', en: '$2.3M spent | 85% of plan' },
+              value: 'عائد 3.2×',
+              delta: { ar: 'متوافق مع التوقعات', en: 'On forecast' }
+            },
+            {
+              icon: 'film',
+              title: { ar: 'حملة الفيديو القصير', en: 'Short-form video blitz' },
+              subtitle: { ar: 'إنفاق 1.1 مليون دولار | 41% من الهدف', en: '$1.1M spent | 41% of plan' },
+              value: 'عائد 2.6×',
+              delta: { ar: '+1.1 مليون مشاهدة جديدة', en: '+1.1M new views' }
+            }
+          ]
+        },
+        {
+          id: 'channels',
+          type: 'progress',
+          title: { ar: 'توزيع مزيج القنوات', en: 'Channel mix distribution' },
+          items: [
+            {
+              title: { ar: 'الفيديو حسب الطلب', en: 'Video on demand' },
+              subtitle: { ar: 'حملات مستهدفة حسب الشرائح السلوكية.', en: 'Behaviourally targeted streaming flights.' },
+              value: '64%',
+              percent: '64%'
+            },
+            {
+              title: { ar: 'البحث المدفوع', en: 'Paid search' },
+              subtitle: { ar: 'مخصص لدعم إطلاق المنتج.', en: 'Dedicated to launch support bursts.' },
+              value: '22%',
+              percent: '22%'
+            },
+            {
+              title: { ar: 'التجارب الميدانية', en: 'Experiential activations' },
+              subtitle: { ar: 'جولات تفاعلية في 8 مدن.', en: 'Interactive roadshow in 8 cities.' },
+              value: '14%',
+              percent: '14%'
+            }
+          ]
+        },
+        {
+          id: 'creative',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'نتائج اختبارات الإعلانات', en: 'Creative testing results' },
+          action: { ar: 'تحميل لوحة الاختبار', en: 'Download test board' },
+          headers: [
+            { ar: 'الإبداع', en: 'Creative' },
+            { ar: 'معدل التفاعل', en: 'Engagement rate' },
+            { ar: 'الاتجاه', en: 'Trend' }
+          ],
+          rows: [
+            {
+              name: { ar: 'نسخة الواقع المعزز', en: 'Augmented reality spot' },
+              metric: '7.9% CTR | +1.4% على المتوسط',
+              delta: { ar: 'ارتفاع مستمر', en: 'Upward momentum' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'سلسلة القصص القصيرة', en: 'Short stories series' },
+              metric: '5.2% CTR | -0.7% مقابل الهدف',
+              delta: { ar: 'يحتاج تحسين', en: 'Needs optimisation' },
+              trend: 'negative'
+            },
+            {
+              name: { ar: 'إعلانات البودكاست الصوتية', en: 'Podcast audio ads' },
+              metric: '4.6% استذكار | ثابت',
+              delta: { ar: 'مستقر', en: 'Stable' },
+              trend: 'neutral'
+            }
+          ]
+        },
+        {
+          id: 'operations',
+          type: 'timeline',
+          title: { ar: 'أحداث التشغيل القادمة', en: 'Upcoming operational events' },
+          items: [
+            {
+              icon: 'calendar',
+              title: { ar: 'إغلاق مخطط الأسبوع المقبل', en: 'Lock next-week flighting' },
+              subtitle: { ar: 'تثبيت الجداول وإرسالها إلى الشركاء الإعلاميين.', en: 'Freeze schedules and submit to media partners.' },
+              time: { ar: '10:00 صباحاً', en: '10:00 AM' }
+            },
+            {
+              icon: 'megaphone',
+              title: { ar: 'إطلاق حملة البث المباشر', en: 'Launch live-stream blitz' },
+              subtitle: { ar: 'تنسيق الرسائل عبر المؤثرين والرعاة.', en: 'Coordinate messaging with influencers and sponsors.' },
+              time: { ar: '01:30 ظهراً', en: '01:30 PM' }
+            },
+            {
+              icon: 'presentation-chart',
+              title: { ar: 'مراجعة أداء منتصف الحملة', en: 'Mid-flight performance review' },
+              subtitle: { ar: 'تحليل مؤشرات الأداء الرئيسية والتعديلات المقترحة.', en: 'Analyse KPIs and propose adjustments.' },
+              time: { ar: '05:00 مساءً', en: '05:00 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-23.html
+++ b/dashboards/dashboard-23.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة شبكة الرعاية الافتراضية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">VC</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">VC</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة شبكة الرعاية الافتراضية',
+          en: 'Virtual care network dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        }
+      },
+      brand: {
+        badge: 'VC',
+        name: {
+          ar: 'شبكة الرعاية المتصلة',
+          en: 'Connected Care Network'
+        },
+        tagline: {
+          ar: 'تنسيق الرعاية عن بعد بجودة موحدة',
+          en: 'Coordinating telehealth care with consistent quality'
+        }
+      },
+      theme: {
+        accentGradient: 'from-sky-500 via-indigo-500 to-cyan-500',
+        accentText: 'text-sky-200',
+        highlightBg: 'bg-sky-500/10 border-sky-400/30',
+        badgeBg: 'bg-sky-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'stethoscope',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'أونلاين', en: 'Online' }
+        },
+        {
+          id: 'capacity',
+          icon: 'users',
+          label: { ar: 'السعة والطاقم', en: 'Capacity & staffing' }
+        },
+        {
+          id: 'experience',
+          icon: 'heart',
+          label: { ar: 'تجربة المرضى', en: 'Patient experience' }
+        },
+        {
+          id: 'compliance',
+          icon: 'shield',
+          label: { ar: 'الامتثال السريري', en: 'Clinical compliance' }
+        },
+        {
+          id: 'operations',
+          icon: 'calendar',
+          label: { ar: 'العمليات اليومية', en: 'Daily operations' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'تنبيه متابعة عاجل', en: 'Urgent follow-up alert' },
+        value: 'حالة رعاية حرجة | المريض 4837',
+        description: {
+          ar: 'تم رصد تدهور في مؤشرات المراقبة المنزلية ويجب جدولة زيارة افتراضية خلال ساعة.',
+          en: 'Home monitoring flagged a decline; schedule a virtual visit within the hour.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة تنسيق الرعاية الافتراضية',
+          en: 'Virtual care coordination board'
+        },
+        subtitle: {
+          ar: 'تابع تدفق الجلسات، توفر الأطباء، ورضا المرضى عبر الشبكة بأكملها.',
+          en: 'Monitor session volumes, provider availability, and patient sentiment network-wide.'
+        },
+        primary: {
+          ar: 'بدء استدعاء الرعاية السريعة',
+          en: 'Initiate rapid care recall'
+        },
+        secondary: {
+          ar: 'عرض تقارير الامتثال',
+          en: 'View compliance reports'
+        }
+      },
+      stats: [
+        {
+          icon: 'stethoscope',
+          label: { ar: 'جلسات اليوم', en: 'Sessions today' },
+          value: '1,264',
+          delta: { ar: '+124 عن المتوسط', en: '+124 vs average' },
+          trend: 'positive'
+        },
+        {
+          icon: 'calendar',
+          label: { ar: 'متوسط وقت الانتظار', en: 'Avg. wait time' },
+          value: '05:42',
+          delta: { ar: '-1:18 دقيقة', en: '-1:18 minutes' },
+          trend: 'positive'
+        },
+        {
+          icon: 'heart',
+          label: { ar: 'مؤشر رضا المرضى', en: 'Patient satisfaction index' },
+          value: '92%',
+          delta: { ar: '+3 نقاط', en: '+3 pts' },
+          trend: 'positive'
+        },
+        {
+          icon: 'shield',
+          label: { ar: 'التزام البروتوكولات', en: 'Protocol adherence' },
+          value: '96%',
+          delta: { ar: '-1% عن الهدف', en: '-1% vs goal' },
+          trend: 'negative'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'توزيع جلسات الرعاية الافتراضية', en: 'Virtual session distribution' },
+          subtitle: { ar: 'رؤية لحجم الطلب حسب الاختصاص والمنطقة في الزمن الحقيقي.', en: 'Real-time demand by specialty and region.' },
+          action: { ar: 'تحميل مخطط السعة', en: 'Download capacity map' },
+          placeholder: { ar: 'مخطط كثافة للجلسات حسب الساعة', en: 'Session density heatmap' }
+        },
+        {
+          id: 'capacity',
+          type: 'list',
+          title: { ar: 'توفر مقدمي الرعاية', en: 'Provider availability' },
+          action: { ar: 'إدارة الجداول', en: 'Manage rosters' },
+          items: [
+            {
+              icon: 'users',
+              title: { ar: 'طب الأسرة | المنطقة الشرقية', en: 'Family medicine | Eastern region' },
+              subtitle: { ar: '24 طبيباً نشطاً | 3 شاغر', en: '24 active clinicians | 3 open slots' },
+              value: 'اكتمل 88%',
+              delta: { ar: '+5 جلسات إضافية', en: '+5 extra sessions' }
+            },
+            {
+              icon: 'stethoscope',
+              title: { ar: 'الصحة النفسية | جلسات الفيديو', en: 'Mental health | Video visits' },
+              subtitle: { ar: '18 معالجاً | 12 قائمة انتظار', en: '18 therapists | 12 waiting list' },
+              value: 'ضغط مرتفع',
+              delta: { ar: 'موصى بفتح نوبة ليلية', en: 'Recommend overnight shift' }
+            },
+            {
+              icon: 'beaker',
+              title: { ar: 'المتابعة المزمنة | مراقبة عن بعد', en: 'Chronic care | Remote monitoring' },
+              subtitle: { ar: '12 فريق تمريض | 4 مقاعد احتياطية', en: '12 nursing pods | 4 buffer slots' },
+              value: 'سعة 94%',
+              delta: { ar: 'ضمن العتبة المثلى', en: 'Within optimal threshold' }
+            }
+          ]
+        },
+        {
+          id: 'experience',
+          type: 'progress',
+          title: { ar: 'برامج تحسين تجربة المرضى', en: 'Patient experience programmes' },
+          items: [
+            {
+              title: { ar: 'استبيان ما بعد الزيارة', en: 'Post-visit survey refresh' },
+              subtitle: { ar: 'تصميم أسئلة قصيرة متعددة اللغات.', en: 'Design short, multilingual question set.' },
+              value: '67%',
+              percent: '67%'
+            },
+            {
+              title: { ar: 'متابعة التوعية الرقمية', en: 'Digital coaching follow-ups' },
+              subtitle: { ar: 'رسائل إرشادية للمصابين بالأمراض المزمنة.', en: 'Guided messaging for chronic conditions.' },
+              value: '58%',
+              percent: '58%'
+            },
+            {
+              title: { ar: 'مجتمع دعم المرضى', en: 'Patient support community' },
+              subtitle: { ar: 'جلسات مباشرة أسبوعية مع اختصاصيين.', en: 'Weekly live circles with specialists.' },
+              value: '34%',
+              percent: '34%'
+            }
+          ]
+        },
+        {
+          id: 'compliance',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'مراجعات الامتثال السريري', en: 'Clinical compliance reviews' },
+          action: { ar: 'تحميل سجل التدقيق', en: 'Download audit log' },
+          headers: [
+            { ar: 'البرنامج', en: 'Programme' },
+            { ar: 'معدل الالتزام', en: 'Adherence' },
+            { ar: 'الاتجاه', en: 'Trend' }
+          ],
+          rows: [
+            {
+              name: { ar: 'بروتوكول الرعاية عن بعد لمرضى السكري', en: 'Remote diabetes protocol' },
+              metric: '97% | الأسبوع الحالي',
+              delta: { ar: '+1%', en: '+1%' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'برنامج ما بعد الجراحة', en: 'Post-operative programme' },
+              metric: '93% | آخر 48 ساعة',
+              delta: { ar: '-2%', en: '-2%' },
+              trend: 'negative'
+            },
+            {
+              name: { ar: 'رعاية الصحة النفسية', en: 'Mental wellness care' },
+              metric: '95% | هذا الشهر',
+              delta: { ar: 'ثابت', en: 'Stable' },
+              trend: 'neutral'
+            }
+          ]
+        },
+        {
+          id: 'operations',
+          type: 'timeline',
+          title: { ar: 'جدول التشغيل اليومي', en: 'Daily operating cadence' },
+          items: [
+            {
+              icon: 'calendar',
+              title: { ar: 'اجتماع مراجعة السعة الصباحية', en: 'Morning capacity huddle' },
+              subtitle: { ar: 'تحليل توقعات الطلب والتغطية لكل منطقة.', en: 'Assess demand forecast and coverage by region.' },
+              time: { ar: '08:15 صباحاً', en: '08:15 AM' }
+            },
+            {
+              icon: 'chat-bubble',
+              title: { ar: 'ورشة تجربة المريض', en: 'Patient experience lab' },
+              subtitle: { ar: 'مراجعة تعليقات المرضى وإطلاق تحسينات الواجهة.', en: 'Review feedback and roll out UX fixes.' },
+              time: { ar: '12:00 ظهراً', en: '12:00 PM' }
+            },
+            {
+              icon: 'stethoscope',
+              title: { ar: 'متابعة الحالات الحرجة', en: 'Critical case follow-up' },
+              subtitle: { ar: 'تحضير خطط الرعاية المخصصة للمرضى ذوي المخاطر العالية.', en: 'Prepare tailored plans for high-risk patients.' },
+              time: { ar: '04:45 مساءً', en: '04:45 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-24.html
+++ b/dashboards/dashboard-24.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الامتثال المالي</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">FC</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">FC</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الامتثال المالي',
+          en: 'Financial compliance monitor'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        }
+      },
+      brand: {
+        badge: 'FC',
+        name: {
+          ar: 'غرفة تحكم الامتثال',
+          en: 'Compliance Command Room'
+        },
+        tagline: {
+          ar: 'مراقبة الضوابط والتنبيهات التنظيمية لحظياً',
+          en: 'Live oversight of controls and regulatory alerts'
+        }
+      },
+      theme: {
+        accentGradient: 'from-amber-500 via-slate-700 to-slate-900',
+        accentText: 'text-amber-200',
+        highlightBg: 'bg-amber-500/10 border-amber-400/30',
+        badgeBg: 'bg-amber-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'scale',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'وضع الامتثال', en: 'Compliance status' }
+        },
+        {
+          id: 'controls',
+          icon: 'shield',
+          label: { ar: 'ضوابط المخاطر', en: 'Risk controls' }
+        },
+        {
+          id: 'kyc',
+          icon: 'folder',
+          label: { ar: 'اختبارات KYC', en: 'KYC testing' }
+        },
+        {
+          id: 'risk',
+          icon: 'chart-bar',
+          label: { ar: 'مراقبة المخاطر', en: 'Risk monitoring' }
+        },
+        {
+          id: 'operations',
+          icon: 'calendar',
+          label: { ar: 'العمليات', en: 'Operations' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'تنبيه تنظيمي جديد', en: 'New regulatory notice' },
+        value: 'مجلس الخدمات المالية | لائحة الامتثال الرقمي',
+        description: {
+          ar: 'دخلت تغييرات الامتثال الرقمي حيز التنفيذ هذا الأسبوع وتتطلب تحديث سجلات الموافقات خلال 48 ساعة.',
+          en: 'Digital compliance amendments became active this week and require approval logs within 48 hours.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'مركز مراقبة الامتثال المالي',
+          en: 'Financial compliance control centre'
+        },
+        subtitle: {
+          ar: 'راقب الامتثال التنظيمي، اختبارات KYC، وإشارات المخاطر في الزمن الحقيقي.',
+          en: 'Track regulatory adherence, KYC testing, and risk signals in real time.'
+        },
+        primary: {
+          ar: 'تسجيل استجابة الامتثال',
+          en: 'Log compliance response'
+        },
+        secondary: {
+          ar: 'مراجعة خطة التدقيق',
+          en: 'Review audit plan'
+        }
+      },
+      stats: [
+        {
+          icon: 'scale',
+          label: { ar: 'مستوى المخاطر', en: 'Risk posture' },
+          value: 'منخفض',
+          delta: { ar: '-12 نقاط أساس', en: '-12 basis pts' },
+          trend: 'positive'
+        },
+        {
+          icon: 'folder',
+          label: { ar: 'اختبارات KYC المنجزة', en: 'Completed KYC checks' },
+          value: '1,482',
+          delta: { ar: '+164 هذا اليوم', en: '+164 today' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'تنبيهات المخاطر المفتوحة', en: 'Open risk alerts' },
+          value: '11',
+          delta: { ar: '-3 هذا الأسبوع', en: '-3 this week' },
+          trend: 'positive'
+        },
+        {
+          icon: 'shield',
+          label: { ar: 'ضوابط تحتاج تحديثاً', en: 'Controls pending update' },
+          value: '5',
+          delta: { ar: '+2 بعد المراجعة', en: '+2 post review' },
+          trend: 'negative'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'لوحة وضع الامتثال', en: 'Compliance posture dashboard' },
+          subtitle: { ar: 'قياس الامتثال عبر المنتجات، المناطق، ومتطلبات التقارير.', en: 'Gauge compliance across products, regions, and reporting obligations.' },
+          action: { ar: 'تحميل بطاقة الامتثال', en: 'Download compliance card' },
+          placeholder: { ar: 'مخطط مؤشر الامتثال متعدد الطبقات', en: 'Layered compliance index chart' }
+        },
+        {
+          id: 'controls',
+          type: 'list',
+          title: { ar: 'أبرز ضوابط المخاطر', en: 'Key risk controls' },
+          action: { ar: 'تحديث حالة الضبط', en: 'Update control status' },
+          items: [
+            {
+              icon: 'shield',
+              title: { ar: 'مراقبة تحويلات المدفوعات الفورية', en: 'Instant payment screening' },
+              subtitle: { ar: 'تغطية 99.3% من المعاملات | آخر تحديث اليوم', en: 'Covers 99.3% of transactions | Updated today' },
+              value: 'سليم',
+              delta: { ar: 'متوافق مع لائحة AML', en: 'Aligned with AML rule' }
+            },
+            {
+              icon: 'bank',
+              title: { ar: 'ضوابط الحسابات المراسلة', en: 'Correspondent banking controls' },
+              subtitle: { ar: 'تمت مراجعة 12 مؤسسة شريكة', en: '12 partner institutions reviewed' },
+              value: 'تحديث مطلوب',
+              delta: { ar: 'نطاق مستندات ناقصة', en: 'Missing documentation range' }
+            },
+            {
+              icon: 'folder',
+              title: { ar: 'لوائح حماية البيانات', en: 'Data protection controls' },
+              subtitle: { ar: 'مراجعة سياسة الوصول في الربع الحالي', en: 'Access policy review in current quarter' },
+              value: 'قيد المراجعة',
+              delta: { ar: 'موعد التسليم خلال 5 أيام', en: 'Due in 5 days' }
+            }
+          ]
+        },
+        {
+          id: 'kyc',
+          type: 'progress',
+          title: { ar: 'تقدم اختبارات KYC', en: 'KYC testing progress' },
+          items: [
+            {
+              title: { ar: 'عملاء المؤسسات', en: 'Institutional clients' },
+              subtitle: { ar: 'إعادة التحقق السنوي للكيانات عالية المخاطر.', en: 'Annual refresh for high-risk entities.' },
+              value: '81%',
+              percent: '81%'
+            },
+            {
+              title: { ar: 'العملاء الأفراد', en: 'Retail customers' },
+              subtitle: { ar: 'التوثيق البيومتري والتوقيع الرقمي.', en: 'Biometric verification and digital signature.' },
+              value: '64%',
+              percent: '64%'
+            },
+            {
+              title: { ar: 'الشركاء الخارجيون', en: 'Third-party partners' },
+              subtitle: { ar: 'مراجعة عقود الامتثال ومراقبة واجهات API.', en: 'Review compliance clauses and API monitoring.' },
+              value: '47%',
+              percent: '47%'
+            }
+          ]
+        },
+        {
+          id: 'risk',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'تقريرات التنبيهات الحرجة', en: 'Critical alert reports' },
+          action: { ar: 'تحميل سجل المخاطر', en: 'Download risk log' },
+          headers: [
+            { ar: 'التنبيه', en: 'Alert' },
+            { ar: 'الحالة', en: 'Status' },
+            { ar: 'الاتجاه', en: 'Trend' }
+          ],
+          rows: [
+            {
+              name: { ar: 'تجاوز حد المعاملات', en: 'Transaction limit breach' },
+              metric: 'جارٍ التحقيق | مهلة 12 ساعة',
+              delta: { ar: 'انخفاض 32%', en: 'Down 32%' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'نشاط حساب نائم', en: 'Dormant account activity' },
+              metric: 'تم التصعيد | قيد المتابعة',
+              delta: { ar: 'ثابت', en: 'Stable' },
+              trend: 'neutral'
+            },
+            {
+              name: { ar: 'طلبات وصول غير مصرح بها', en: 'Unauthorised access attempts' },
+              metric: 'قيد التحليل | 3 مواقع',
+              delta: { ar: '+18% منذ أمس', en: '+18% since yesterday' },
+              trend: 'negative'
+            }
+          ]
+        },
+        {
+          id: 'operations',
+          type: 'timeline',
+          title: { ar: 'جدول عمليات الامتثال', en: 'Compliance operations timeline' },
+          items: [
+            {
+              icon: 'calendar',
+              title: { ar: 'اجتماع مراجعة اللوائح الإقليمية', en: 'Regional regulation review' },
+              subtitle: { ar: 'تقييم تحديثات التشريعات في آسيا وأوروبا.', en: 'Assess regulatory updates across Asia and Europe.' },
+              time: { ar: '09:45 صباحاً', en: '09:45 AM' }
+            },
+            {
+              icon: 'presentation-chart',
+              title: { ar: 'إحاطة مجلس الإدارة', en: 'Board compliance briefing' },
+              subtitle: { ar: 'تلخيص حالات الامتثال عالية المخاطر والتوصيات.', en: 'Summarise high-risk cases and recommendations.' },
+              time: { ar: '02:15 ظهراً', en: '02:15 PM' }
+            },
+            {
+              icon: 'folder',
+              title: { ar: 'تحديث سياسات الوصول', en: 'Access policy update' },
+              subtitle: { ar: 'إصدار الإصدار الجديد لقواعد التحكم في الصلاحيات.', en: 'Publish revised entitlements standard.' },
+              time: { ar: '06:00 مساءً', en: '06:00 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-25.html
+++ b/dashboards/dashboard-25.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>لوحة الاستدامة المناخية</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Cairo', sans-serif; }
+    body.font-english { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    <header class="lg:hidden border-b border-white/5 bg-white/5 backdrop-blur-sm px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div data-role="mobile-badge" class="h-11 w-11 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">CS</div>
+        <div>
+          <p data-role="mobile-brand-name" class="font-semibold"></p>
+          <p data-role="mobile-brand-tagline" class="text-xs text-slate-300"></p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div data-role="language-switcher" class="inline-flex rounded-xl border border-white/10 p-1 bg-white/5"></div>
+        <button id="sidebarToggle" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span data-role="open-label">فتح القائمة</span>
+        </button>
+      </div>
+    </header>
+
+    <div id="sidebarBackdrop" class="fixed inset-0 z-40 bg-black/60 opacity-0 pointer-events-none transition-opacity lg:hidden"></div>
+
+    <aside id="sidebar" class="fixed inset-y-0 right-0 z-50 w-80 max-w-full transform translate-x-full border-l border-white/10 bg-slate-900/95 backdrop-blur-xl px-6 py-8 space-y-8 transition-transform duration-300 lg:static lg:translate-x-0 lg:w-80 lg:border-l-0 lg:bg-slate-900/60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <div data-role="brand-badge" class="h-12 w-12 rounded-2xl bg-white/10 text-white flex items-center justify-center text-lg font-semibold">CS</div>
+          <div>
+            <p data-role="brand-name" class="text-lg font-semibold"></p>
+            <p data-role="brand-tagline" class="text-sm text-slate-300"></p>
+          </div>
+        </div>
+        <div data-role="sidebar-actions" class="flex items-center gap-2">
+          <div data-role="language-switcher" class="hidden lg:inline-flex rounded-xl border border-white/10 bg-white/5 p-1"></div>
+          <button id="sidebarClose" class="lg:hidden inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-slate-200">
+            <span data-role="close-label">إغلاق</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <nav data-role="sidebar-nav" class="space-y-2"></nav>
+      <div data-role="sidebar-highlight"></div>
+    </aside>
+
+    <main class="flex-1 px-4 py-8 lg:px-12 lg:py-10 space-y-10">
+      <div data-role="main-header" class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"></div>
+      <section data-role="stats" class="grid gap-6 md:grid-cols-2 xl:grid-cols-4"></section>
+      <section data-role="panels" class="grid gap-6 xl:grid-cols-3"></section>
+    </main>
+  </div>
+
+  <script src="dashboard-common.js"></script>
+  <script>
+    initDashboard({
+      defaultLang: 'ar',
+      meta: {
+        title: {
+          ar: 'لوحة الاستدامة المناخية',
+          en: 'Climate sustainability dashboard'
+        }
+      },
+      actions: {
+        open: {
+          ar: 'فتح القائمة',
+          en: 'Open menu'
+        },
+        close: {
+          ar: 'إغلاق',
+          en: 'Close'
+        }
+      },
+      brand: {
+        badge: 'CS',
+        name: {
+          ar: 'مركز أثر الاستدامة',
+          en: 'Sustainability Impact Hub'
+        },
+        tagline: {
+          ar: 'تحليل الانبعاثات والتقدم نحو صافي الصفر',
+          en: 'Analysing emissions and net-zero progress'
+        }
+      },
+      theme: {
+        accentGradient: 'from-emerald-500 via-lime-500 to-teal-500',
+        accentText: 'text-emerald-200',
+        highlightBg: 'bg-emerald-500/10 border-emerald-400/30',
+        badgeBg: 'bg-emerald-500/20',
+        badgeText: 'text-white'
+      },
+      nav: [
+        {
+          id: 'overview',
+          icon: 'leaf',
+          label: { ar: 'نظرة عامة', en: 'Overview' },
+          badge: { ar: 'الهدف 2030', en: '2030 goal' }
+        },
+        {
+          id: 'emissions',
+          icon: 'globe-alt',
+          label: { ar: 'الانبعاثات', en: 'Emissions' }
+        },
+        {
+          id: 'projects',
+          icon: 'sparkles',
+          label: { ar: 'المشاريع الخضراء', en: 'Green projects' }
+        },
+        {
+          id: 'impact',
+          icon: 'chart-bar',
+          label: { ar: 'أثر المبادرات', en: 'Impact metrics' }
+        },
+        {
+          id: 'operations',
+          icon: 'calendar',
+          label: { ar: 'العمليات', en: 'Operations' }
+        }
+      ],
+      highlight: {
+        label: { ar: 'نقطة تحول الانبعاثات', en: 'Emission turning point' },
+        value: 'انخفاض انبعاثات النطاق 2 بنسبة 28%',
+        description: {
+          ar: 'حققنا أفضل أداء تاريخي بعد ربط مواقع الإنتاج بعقود الطاقة المتجددة طويلة الأجل.',
+          en: 'Best performance to date after switching production sites to long-term renewable PPAs.'
+        }
+      },
+      header: {
+        title: {
+          ar: 'لوحة مسار صافي الصفر',
+          en: 'Net-zero trajectory board'
+        },
+        subtitle: {
+          ar: 'تابع انبعاثات النطاقات، برامج التعويض، ومؤشرات الأثر البيئي في الوقت الفعلي.',
+          en: 'Track scope emissions, offset programmes, and environmental impact metrics in real time.'
+        },
+        primary: {
+          ar: 'اعتماد خطة خفض جديدة',
+          en: 'Approve new reduction plan'
+        },
+        secondary: {
+          ar: 'عرض تقرير الاستدامة',
+          en: 'View sustainability report'
+        }
+      },
+      stats: [
+        {
+          icon: 'leaf',
+          label: { ar: 'اجمالي الانبعاثات الشهرية', en: 'Monthly emissions total' },
+          value: '18.4 ktCO₂e',
+          delta: { ar: '-3.2 kt منذ الشهر الماضي', en: '-3.2 kt vs last month' },
+          trend: 'positive'
+        },
+        {
+          icon: 'globe-alt',
+          label: { ar: 'تغطية الطاقة المتجددة', en: 'Renewable energy coverage' },
+          value: '72%',
+          delta: { ar: '+12 نقاط مئوية', en: '+12 pts' },
+          trend: 'positive'
+        },
+        {
+          icon: 'sparkles',
+          label: { ar: 'مشاريع التعويض النشطة', en: 'Active offset projects' },
+          value: '14',
+          delta: { ar: '+3 مشاريع', en: '+3 projects' },
+          trend: 'positive'
+        },
+        {
+          icon: 'chart-bar',
+          label: { ar: 'تخفيض الكثافة الكربونية', en: 'Carbon intensity reduction' },
+          value: '38%',
+          delta: { ar: '+5% عن المسار', en: '+5% vs pathway' },
+          trend: 'positive'
+        }
+      ],
+      panels: [
+        {
+          id: 'overview',
+          type: 'chart',
+          span: 'xl:col-span-2',
+          title: { ar: 'مسار الانبعاثات إلى صافي الصفر', en: 'Emissions pathway to net-zero' },
+          subtitle: { ar: 'عرض توقعات الانبعاثات حتى عام 2035 مقارنة بالهدف العلمي.', en: 'Projected emissions vs science-based target through 2035.' },
+          action: { ar: 'تنزيل نموذج التوقع', en: 'Download forecast model' },
+          placeholder: { ar: 'مخطط خطي للتقدم نحو صافي الصفر', en: 'Net-zero progress line chart' }
+        },
+        {
+          id: 'emissions',
+          type: 'list',
+          title: { ar: 'تفصيل الانبعاثات حسب النطاق', en: 'Emissions breakdown by scope' },
+          action: { ar: 'إدارة بيانات الانبعاثات', en: 'Manage emissions data' },
+          items: [
+            {
+              icon: 'leaf',
+              title: { ar: 'النطاق 1 | عمليات التصنيع', en: 'Scope 1 | Manufacturing operations' },
+              subtitle: { ar: '6.1 ktCO₂e | انخفاض 19%', en: '6.1 ktCO₂e | Down 19%' },
+              value: 'على المسار',
+              delta: { ar: 'استخدام وقود بديل', en: 'Alternative fuels adopted' }
+            },
+            {
+              icon: 'globe-alt',
+              title: { ar: 'النطاق 2 | الطاقة المشتراة', en: 'Scope 2 | Purchased energy' },
+              subtitle: { ar: '4.8 ktCO₂e | انخفاض 28%', en: '4.8 ktCO₂e | Down 28%' },
+              value: 'تفوق على الهدف',
+              delta: { ar: 'اتفاقيات طاقة متجددة', en: 'Renewable PPAs active' }
+            },
+            {
+              icon: 'truck',
+              title: { ar: 'النطاق 3 | سلسلة التوريد', en: 'Scope 3 | Supply chain' },
+              subtitle: { ar: '7.5 ktCO₂e | انخفاض 8%', en: '7.5 ktCO₂e | Down 8%' },
+              value: 'يتطلب تسريع',
+              delta: { ar: 'برامج الموردين الخضراء', en: 'Supplier decarbonisation programmes' }
+            }
+          ]
+        },
+        {
+          id: 'projects',
+          type: 'progress',
+          title: { ar: 'مبادرات الاستدامة الجارية', en: 'Ongoing sustainability initiatives' },
+          items: [
+            {
+              title: { ar: 'تركيب الألواح الشمسية في المصانع', en: 'Plant rooftop solar rollout' },
+              subtitle: { ar: 'تغطية 6 مواقع صناعية ضمن المرحلة الحالية.', en: 'Covering six industrial sites this phase.' },
+              value: '63%',
+              percent: '63%'
+            },
+            {
+              title: { ar: 'تحويل أسطول النقل للكهرباء', en: 'Fleet electrification programme' },
+              subtitle: { ar: 'إحلال 120 مركبة ببدائل كهربائية.', en: 'Replacing 120 vehicles with EV alternatives.' },
+              value: '52%',
+              percent: '52%'
+            },
+            {
+              title: { ar: 'زراعة الغابات المجتمعية', en: 'Community forestation projects' },
+              subtitle: { ar: 'غرس 1.5 مليون شجرة في 3 بلدان.', en: 'Planting 1.5M trees across three countries.' },
+              value: '41%',
+              percent: '41%'
+            }
+          ]
+        },
+        {
+          id: 'impact',
+          type: 'table',
+          span: 'xl:col-span-2',
+          title: { ar: 'مؤشرات الأثر البيئي', en: 'Environmental impact indicators' },
+          action: { ar: 'تحميل لوحة الأثر', en: 'Download impact board' },
+          headers: [
+            { ar: 'المؤشر', en: 'Indicator' },
+            { ar: 'القيمة', en: 'Value' },
+            { ar: 'الاتجاه', en: 'Trend' }
+          ],
+          rows: [
+            {
+              name: { ar: 'كفاءة استخدام المياه', en: 'Water efficiency' },
+              metric: '74 لتر/وحدة إنتاج | -9%',
+              delta: { ar: 'تحسن مستمر', en: 'Improving steadily' },
+              trend: 'positive'
+            },
+            {
+              name: { ar: 'معدل النفايات إلى المكبات', en: 'Landfill waste rate' },
+              metric: '12% | -3% هذا الربع',
+              delta: { ar: 'مستقر', en: 'Holding steady' },
+              trend: 'neutral'
+            },
+            {
+              name: { ar: 'كثافة الطاقة', en: 'Energy intensity' },
+              metric: '0.82 ميجاوات ساعة/طن | -5%',
+              delta: { ar: 'بحاجة لتسريع', en: 'Needs acceleration' },
+              trend: 'negative'
+            }
+          ]
+        },
+        {
+          id: 'operations',
+          type: 'timeline',
+          title: { ar: 'أنشطة الاستدامة القادمة', en: 'Upcoming sustainability actions' },
+          items: [
+            {
+              icon: 'calendar',
+              title: { ar: 'مراجعة التقدم ربع السنوية', en: 'Quarterly progress review' },
+              subtitle: { ar: 'تقييم الأهداف والميزانيات مع فرق المناطق.', en: 'Evaluate goals and budgets with regional teams.' },
+              time: { ar: '09:00 صباحاً', en: '09:00 AM' }
+            },
+            {
+              icon: 'leaf',
+              title: { ar: 'ورشة تصميم حلول إزالة الكربون', en: 'Decarbonisation design workshop' },
+              subtitle: { ar: 'مشاريع جديدة لخفض الانبعاثات في سلسلة التوريد.', en: 'New reduction concepts for supply chain.' },
+              time: { ar: '01:00 ظهراً', en: '01:00 PM' }
+            },
+            {
+              icon: 'sparkles',
+              title: { ar: 'إطلاق تقرير الاستدامة التفاعلي', en: 'Launch interactive sustainability report' },
+              subtitle: { ar: 'إشراك المستثمرين عبر لوحة معلومات مباشرة.', en: 'Engage investors with a live data story.' },
+              time: { ar: '05:30 مساءً', en: '05:30 PM' }
+            }
+          ]
+        }
+      ]
+    });
+  </script>
+</body>
+</html>

--- a/dashboards/dashboard-catalog.js
+++ b/dashboards/dashboard-catalog.js
@@ -1,0 +1,579 @@
+(function () {
+  window.dashboardCatalog = [
+        {
+          id: 1,
+          slug: 'dashboard-1',
+          accent: 'from-indigo-500/30 via-purple-500/20 to-slate-900/60',
+          preview: { gradient: 'from-indigo-500 to-purple-500', accentText: 'text-indigo-300' },
+          badge: { ar: 'النمو', en: 'Growth' },
+          category: { ar: 'منتجات SaaS', en: 'SaaS products' },
+          title: { ar: 'لوحة تحليلات النمو', en: 'Growth analytics dashboard' },
+          summary: { ar: 'مراقبة مؤشرات النمو والاكتساب والاحتفاظ لمنتج SaaS ناشئ.', en: 'Track growth, acquisition, and retention signals for a scaling SaaS product.' },
+          description: {
+            ar: 'مراقبة مؤشرات النمو والاكتساب والاحتفاظ لمنتج SaaS ناشئ.',
+            en: 'Track growth, acquisition, and retention signals for a scaling SaaS product.'
+          },
+          features: [
+            { ar: 'مخططات نمو أسبوعية', en: 'Weekly growth curves' },
+            { ar: 'تحليلات قنوات الاكتساب', en: 'Acquisition channel analytics' },
+            { ar: 'جدول أحداث الانطلاق', en: 'Launch milestone timeline' }
+          ],
+          metrics: {
+            label: { ar: 'محتويات جاهزة', en: 'Production-ready sections' },
+            value: { ar: '5 وحدات', en: '5 sections' }
+          }
+        },
+        {
+          id: 2,
+          slug: 'dashboard-2',
+          accent: 'from-cyan-500/30 via-sky-500/20 to-slate-900/60',
+          preview: { gradient: 'from-emerald-500 to-teal-500', accentText: 'text-emerald-300' },
+          badge: { ar: 'المشاريع', en: 'Projects' },
+          category: { ar: 'إدارة المحافظ', en: 'Portfolio management' },
+          title: { ar: 'لوحة إدارة المشاريع', en: 'Project portfolio dashboard' },
+          summary: { ar: 'تنسيق خارطة الطريق، المخاطر، وسعة الفرق عبر مبادرات متعددة.', en: 'Coordinate roadmaps, risks, and team capacity across strategic initiatives.' },
+          description: {
+            ar: 'تنسيق خارطة الطريق، المخاطر، وسعة الفرق عبر مبادرات متعددة.',
+            en: 'Coordinate roadmaps, risks, and team capacity across strategic initiatives.'
+          },
+          features: [
+            { ar: 'منحنى السرعة التراكمية', en: 'Cumulative velocity chart' },
+            { ar: 'لوحة متابعة المخاطر', en: 'Risk tracking board' },
+            { ar: 'قوائم المشاريع ذات الأولوية', en: 'Prioritised project lists' }
+          ],
+          metrics: {
+            label: { ar: 'قوالب جاهزة', en: 'Reusable layouts' },
+            value: { ar: '6 لوحات', en: '6 layouts' }
+          }
+        },
+        {
+          id: 3,
+          slug: 'dashboard-3',
+          accent: 'from-amber-500/35 via-orange-500/20 to-slate-900/60',
+          preview: { gradient: 'from-amber-500 to-orange-500', accentText: 'text-amber-300' },
+          badge: { ar: 'تجارة', en: 'Commerce' },
+          category: { ar: 'متاجر رقمية', en: 'Digital retail' },
+          title: { ar: 'لوحة تجارة إلكترونية', en: 'E-commerce intelligence dashboard' },
+          summary: { ar: 'لوحة مبيعات متكاملة تجمع الإيرادات، القنوات، وتجربة العملاء.', en: 'A commerce control centre blending revenue, channels, and customer experience.' },
+          description: {
+            ar: 'لوحة مبيعات متكاملة تجمع الإيرادات، القنوات، وتجربة العملاء.',
+            en: 'A commerce control centre blending revenue, channels, and customer experience.'
+          },
+          features: [
+            { ar: 'إيرادات يومية مباشرة', en: 'Live daily revenue' },
+            { ar: 'ترتيب القنوات الأعلى أداءً', en: 'Top-performing channel ranking' },
+            { ar: 'متابعة حالة الشحنات', en: 'Fulfilment status tracking' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر الواجهة', en: 'Interface components' },
+            value: { ar: '6 عناصر', en: '6 components' }
+          }
+        },
+        {
+          id: 4,
+          slug: 'dashboard-4',
+          accent: 'from-sky-500/30 via-cyan-500/20 to-slate-900/70',
+          preview: { gradient: 'from-sky-500 to-cyan-500', accentText: 'text-sky-300' },
+          badge: { ar: 'البنية السحابية', en: 'Cloud ops' },
+          category: { ar: 'مركز العمليات', en: 'Operations centre' },
+          title: { ar: 'لوحة مراقبة البنية السحابية', en: 'Cloud infrastructure monitor' },
+          summary: { ar: 'رصد موحد لحمل الموارد، التنبيهات الحية، وتوافر المناطق.', en: 'Unified monitoring for resource load, live alerts, and regional availability.' },
+          description: {
+            ar: 'رصد موحد لحمل الموارد، التنبيهات الحية، وتوافر المناطق.',
+            en: 'Unified monitoring for resource load, live alerts, and regional availability.'
+          },
+          features: [
+            { ar: 'تنبيهات الخدمات الحرجة', en: 'Critical service alerts' },
+            { ar: 'مخططات الأداء الزمني', en: 'Time-series performance panels' },
+            { ar: 'بطاقات توافر المناطق', en: 'Regional availability cards' }
+          ],
+          metrics: {
+            label: { ar: 'شرائح جاهزة', en: 'Drop-in widgets' },
+            value: { ar: '4 أقسام', en: '4 sections' }
+          }
+        },
+        {
+          id: 5,
+          slug: 'dashboard-5',
+          accent: 'from-sky-400/25 via-emerald-400/20 to-slate-900/70',
+          preview: { gradient: 'from-rose-500 to-pink-500', accentText: 'text-rose-300' },
+          badge: { ar: 'الاستمرارية', en: 'Resilience' },
+          category: { ar: 'الاستجابة للحوادث', en: 'Incident response' },
+          title: { ar: 'لوحة مراقبة البنية السحابية', en: 'Cloud reliability war-room' },
+          summary: { ar: 'إدارة الأعطال والسعة مع جداول الحوادث وخطط التوسع.', en: 'Manage outages and capacity with incident logs and scaling readiness.' },
+          description: {
+            ar: 'إدارة الأعطال والسعة مع جداول الحوادث وخطط التوسع.',
+            en: 'Manage outages and capacity with incident logs and scaling readiness.'
+          },
+          features: [
+            { ar: 'قائمة الحوادث المباشرة', en: 'Live incident roster' },
+            { ar: 'مؤشرات حالة الموارد', en: 'Resource health badges' },
+            { ar: 'خيارات توسيع فورية', en: 'On-demand scaling actions' }
+          ],
+          metrics: {
+            label: { ar: 'حزم مدمجة', en: 'Embedded blocks' },
+            value: { ar: '3 لوحات', en: '3 blocks' }
+          }
+        },
+        {
+          id: 6,
+          slug: 'dashboard-6',
+          accent: 'from-fuchsia-500/30 via-pink-500/20 to-slate-900/70',
+          preview: { gradient: 'from-fuchsia-500 to-purple-500', accentText: 'text-fuchsia-300' },
+          badge: { ar: 'العملاء', en: 'CX' },
+          category: { ar: 'نجاح العملاء', en: 'Customer success' },
+          title: { ar: 'لوحة تجربة العملاء', en: 'Customer experience cockpit' },
+          summary: { ar: 'قياس المشاعر، مؤشرات SLA، وتجربة الدعم في الوقت الفعلي.', en: 'Measure sentiment, SLA performance, and support workload in real time.' },
+          description: {
+            ar: 'قياس المشاعر، مؤشرات SLA، وتجربة الدعم في الوقت الفعلي.',
+            en: 'Measure sentiment, SLA performance, and support workload in real time.'
+          },
+          features: [
+            { ar: 'تحليل المشاعر الآلي', en: 'Automated sentiment analysis' },
+            { ar: 'مؤشرات زمن الاستجابة', en: 'Response-time indicators' },
+            { ar: 'لوحات التذاكر المفتوحة', en: 'Open ticket panels' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع محسّنة', en: 'Optimised modules' },
+            value: { ar: '6 عناصر', en: '6 modules' }
+          }
+        },
+        {
+          id: 7,
+          slug: 'dashboard-7',
+          accent: 'from-lime-500/25 via-emerald-500/20 to-slate-900/70',
+          preview: { gradient: 'from-lime-500 to-emerald-500', accentText: 'text-lime-300' },
+          badge: { ar: 'الموظفون', en: 'People' },
+          category: { ar: 'إدارة المواهب', en: 'Talent management' },
+          title: { ar: 'لوحة الموارد البشرية', en: 'People operations dashboard' },
+          summary: { ar: 'تحليلات القوى العاملة، التوظيف، وبرامج التطوير في لوحة واحدة.', en: 'Workforce analytics, hiring pipelines, and development programs in one view.' },
+          description: {
+            ar: 'تحليلات القوى العاملة، التوظيف، وبرامج التطوير في لوحة واحدة.',
+            en: 'Workforce analytics, hiring pipelines, and development programs in one view.'
+          },
+          features: [
+            { ar: 'مؤشرات القوى العاملة', en: 'Workforce KPIs' },
+            { ar: 'جداول الوظائف المفتوحة', en: 'Open role matrices' },
+            { ar: 'لوحة نبض الموظفين', en: 'Employee pulse board' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر تحليلات', en: 'Analytic cards' },
+            value: { ar: '7 بطاقات', en: '7 cards' }
+          }
+        },
+        {
+          id: 8,
+          slug: 'dashboard-8',
+          accent: 'from-blue-500/30 via-sky-400/20 to-slate-900/70',
+          preview: { gradient: 'from-blue-500 to-indigo-500', accentText: 'text-blue-300' },
+          badge: { ar: 'التعليم', en: 'Learning' },
+          category: { ar: 'منصات تعليمية', en: 'Learning platforms' },
+          title: { ar: 'لوحة إدارة التعليم الإلكتروني', en: 'E-learning analytics dashboard' },
+          summary: { ar: 'متابعة المتعلمين، نسب الإكمال، وتفاعل المحتوى للمنصات التعليمية.', en: 'Monitor learners, completion rates, and content engagement for academies.' },
+          description: {
+            ar: 'متابعة المتعلمين، نسب الإكمال، وتفاعل المحتوى للمنصات التعليمية.',
+            en: 'Monitor learners, completion rates, and content engagement for academies.'
+          },
+          features: [
+            { ar: 'مخطط نشاط المتعلمين', en: 'Learner activity curve' },
+            { ar: 'قائمة الدورات المتميزة', en: 'Top-rated courses list' },
+            { ar: 'جدول تقدم المتعلمين', en: 'Learner progress table' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع تعليمية', en: 'Learning widgets' },
+            value: { ar: '6 وحدات', en: '6 widgets' }
+          }
+        },
+        {
+          id: 9,
+          slug: 'dashboard-9',
+          accent: 'from-slate-600/40 via-emerald-500/10 to-slate-900/80',
+          preview: { gradient: 'from-slate-500 to-slate-700', accentText: 'text-slate-300' },
+          badge: { ar: 'الأمن', en: 'Security' },
+          category: { ar: 'مركز الدفاع', en: 'Security centre' },
+          title: { ar: 'لوحة أمن المعلومات', en: 'Cyber security dashboard' },
+          summary: { ar: 'مراقبة التهديدات، الامتثال، ووقت الاستجابة للهجمات الرقمية.', en: 'Monitor threats, compliance posture, and cyber incident response times.' },
+          description: {
+            ar: 'مراقبة التهديدات، الامتثال، ووقت الاستجابة للهجمات الرقمية.',
+            en: 'Monitor threats, compliance posture, and cyber incident response times.'
+          },
+          features: [
+            { ar: 'مستويات الخطر المباشرة', en: 'Live threat levels' },
+            { ar: 'توزيع الحوادث حسب النظام', en: 'Incidents by surface' },
+            { ar: 'مخطط الاستجابة للحوادث', en: 'Incident response chart' }
+          ],
+          metrics: {
+            label: { ar: 'لوحات أمنية', en: 'Security panels' },
+            value: { ar: '5 عروض', en: '5 panels' }
+          }
+        },
+        {
+          id: 10,
+          slug: 'dashboard-10',
+          accent: 'from-violet-500/30 via-indigo-500/20 to-slate-900/70',
+          preview: { gradient: 'from-cyan-500 to-emerald-500', accentText: 'text-cyan-300' },
+          badge: { ar: 'المالية', en: 'Finance' },
+          category: { ar: 'الخدمات المالية', en: 'Financial services' },
+          title: { ar: 'لوحة الخدمات المالية', en: 'Financial services performance' },
+          summary: { ar: 'عرض المحافظ، المخاطر، والأحداث التنظيمية لفرق الاستثمار.', en: 'Visualise portfolios, risk posture, and regulatory events for investment teams.' },
+          description: {
+            ar: 'عرض المحافظ، المخاطر، والأحداث التنظيمية لفرق الاستثمار.',
+            en: 'Visualise portfolios, risk posture, and regulatory events for investment teams.'
+          },
+          features: [
+            { ar: 'مخطط أداء المحافظ', en: 'Portfolio performance graph' },
+            { ar: 'لوحة المخاطر والامتثال', en: 'Risk & compliance board' },
+            { ar: 'خط زمني للأحداث المالية', en: 'Financial events timeline' }
+          ],
+          metrics: {
+            label: { ar: 'مكونات جاهزة', en: 'Ready components' },
+            value: { ar: '6 أقسام', en: '6 sections' }
+          }
+        },
+        {
+          id: 11,
+          slug: 'dashboard-11',
+          accent: 'from-emerald-500/30 via-teal-500/20 to-slate-900/70',
+          preview: { gradient: 'from-teal-500 to-emerald-500', accentText: 'text-teal-300' },
+          badge: { ar: 'الصحة', en: 'Health' },
+          category: { ar: 'العمليات السريرية', en: 'Clinical ops' },
+          title: { ar: 'لوحة عمليات الرعاية الصحية', en: 'Healthcare operations dashboard' },
+          summary: { ar: 'تنسيق تدفق المرضى، تنبيهات سريرية، واستعداد الخدمات للمستشفيات.', en: 'Coordinate patient flow, clinical alerts, and service readiness for hospitals.' },
+          description: {
+            ar: 'تنسيق تدفق المرضى، تنبيهات سريرية، واستعداد الخدمات للمستشفيات.',
+            en: 'Coordinate patient flow, clinical alerts, and service readiness for hospitals.'
+          },
+          features: [
+            { ar: 'مخطط تدفق المرضى', en: 'Patient flow chart' },
+            { ar: 'تنبيهات طبية حرجة', en: 'Critical clinical alerts' },
+            { ar: 'قوائم جاهزية الأقسام', en: 'Service readiness lists' }
+          ],
+          metrics: {
+            label: { ar: 'مقاييس متخصصة', en: 'Specialised metrics' },
+            value: { ar: '5 عناصر', en: '5 items' }
+          }
+        },
+        {
+          id: 12,
+          slug: 'dashboard-12',
+          accent: 'from-rose-500/30 via-fuchsia-500/20 to-slate-900/70',
+          preview: { gradient: 'from-rose-500 to-amber-500', accentText: 'text-rose-300' },
+          badge: { ar: 'التسويق', en: 'Marketing' },
+          category: { ar: 'قنوات متعددة', en: 'Omnichannel' },
+          title: { ar: 'لوحة حملات التسويق', en: 'Marketing campaigns dashboard' },
+          summary: { ar: 'مراقبة الإنفاق، الأداء متعدد القنوات، وأتمتة الحملات.', en: 'Monitor spend, multi-channel performance, and campaign automation.' },
+          description: {
+            ar: 'مراقبة الإنفاق، الأداء متعدد القنوات، وأتمتة الحملات.',
+            en: 'Monitor spend, multi-channel performance, and campaign automation.'
+          },
+          features: [
+            { ar: 'مخطط الأداء متعدد القنوات', en: 'Omnichannel performance chart' },
+            { ar: 'قائمة الحملات البارزة', en: 'Highlighted campaign list' },
+            { ar: 'جدول رحلات الأتمتة', en: 'Automation journey table' }
+          ],
+          metrics: {
+            label: { ar: 'شرائح حملات', en: 'Campaign blocks' },
+            value: { ar: '6 مقاطع', en: '6 blocks' }
+          }
+        },
+        {
+          id: 13,
+          slug: 'dashboard-13',
+          accent: 'from-amber-500/25 via-emerald-500/20 to-slate-900/70',
+          preview: { gradient: 'from-emerald-500 to-amber-500', accentText: 'text-emerald-300' },
+          badge: { ar: 'اللوجستيات', en: 'Logistics' },
+          category: { ar: 'سلسلة الإمداد', en: 'Supply chain' },
+          title: { ar: 'لوحة سلسلة الإمداد', en: 'Supply chain command' },
+          summary: { ar: 'رؤية الشحنات، مخزون المستودعات، وتنبيهات الموردين عالميًا.', en: 'Global view of shipments, warehouse inventory, and supplier alerts.' },
+          description: {
+            ar: 'رؤية الشحنات، مخزون المستودعات، وتنبيهات الموردين عالميًا.',
+            en: 'Global view of shipments, warehouse inventory, and supplier alerts.'
+          },
+          features: [
+            { ar: 'خريطة التقدم اليومي', en: 'Daily shipment tracker' },
+            { ar: 'بطاقات مستويات المخزون', en: 'Inventory health cards' },
+            { ar: 'خط زمني للأحداث اللوجستية', en: 'Logistics updates timeline' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر لوجستية', en: 'Logistics widgets' },
+            value: { ar: '6 عناصر', en: '6 widgets' }
+          }
+        },
+        {
+          id: 14,
+          slug: 'dashboard-14',
+          accent: 'from-emerald-500/25 via-lime-500/20 to-slate-900/70',
+          preview: { gradient: 'from-lime-500 to-emerald-400', accentText: 'text-emerald-400' },
+          badge: { ar: 'العقارات', en: 'Property' },
+          category: { ar: 'استثمار عقاري', en: 'Real estate investing' },
+          title: { ar: 'لوحة إدارة العقارات', en: 'Real estate portfolio dashboard' },
+          summary: { ar: 'مراقبة الإشغال، الإيرادات، وأعمال الصيانة عبر المحافظ.', en: 'Monitor occupancy, cashflow, and maintenance across property portfolios.' },
+          description: {
+            ar: 'مراقبة الإشغال، الإيرادات، وأعمال الصيانة عبر المحافظ.',
+            en: 'Monitor occupancy, cashflow, and maintenance across property portfolios.'
+          },
+          features: [
+            { ar: 'مخطط العوائد الشهرية', en: 'Monthly returns chart' },
+            { ar: 'قائمة العقارات البارزة', en: 'Property spotlight list' },
+            { ar: 'لوحة الصيانة والعمليات', en: 'Operations and upkeep board' }
+          ],
+          metrics: {
+            label: { ar: 'قوالب استثمار', en: 'Investment tiles' },
+            value: { ar: '6 بطاقات', en: '6 tiles' }
+          }
+        },
+        {
+          id: 15,
+          slug: 'dashboard-15',
+          accent: 'from-orange-500/30 via-rose-500/20 to-slate-900/70',
+          preview: { gradient: 'from-orange-500 to-amber-500', accentText: 'text-orange-300' },
+          badge: { ar: 'التصنيع', en: 'Manufacturing' },
+          category: { ar: 'عمليات المصانع', en: 'Factory operations' },
+          title: { ar: 'لوحة العمليات التصنيعية', en: 'Manufacturing operations dashboard' },
+          summary: { ar: 'تحليل الأداء، الجودة، والصيانة على خطوط الإنتاج.', en: 'Analyse performance, quality, and maintenance across production lines.' },
+          description: {
+            ar: 'تحليل الأداء، الجودة، والصيانة على خطوط الإنتاج.',
+            en: 'Analyse performance, quality, and maintenance across production lines.'
+          },
+          features: [
+            { ar: 'مخطط الإنتاج الفعلي', en: 'Actual vs plan production chart' },
+            { ar: 'تنبيهات أعطال حرجة', en: 'Critical downtime alerts' },
+            { ar: 'تقدم مبادرات التحسين', en: 'Improvement program tracker' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع تشغيلية', en: 'Operational blocks' },
+            value: { ar: '6 وحدات', en: '6 units' }
+          }
+        },
+        {
+          id: 16,
+          slug: 'dashboard-16',
+          accent: 'from-purple-500/30 via-indigo-500/20 to-slate-900/70',
+          preview: { gradient: 'from-purple-500 to-indigo-500', accentText: 'text-indigo-300' },
+          badge: { ar: 'البث', en: 'Streaming' },
+          category: { ar: 'منصات المحتوى', en: 'Content platforms' },
+          title: { ar: 'لوحة منصة البث', en: 'Streaming service dashboard' },
+          summary: { ar: 'قياس المشتركين، أداء المحتوى، وصحة الشبكة لخدمة البث.', en: 'Measure subscribers, content performance, and network health for OTT.' },
+          description: {
+            ar: 'قياس المشتركين، أداء المحتوى، وصحة الشبكة لخدمة البث.',
+            en: 'Measure subscribers, content performance, and network health for OTT.'
+          },
+          features: [
+            { ar: 'نمو المشتركين', en: 'Subscriber growth cards' },
+            { ar: 'لوحة أداء العناوين', en: 'Title performance board' },
+            { ar: 'جودة التجربة التقنية', en: 'Experience quality metrics' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع وسائط', en: 'Media widgets' },
+            value: { ar: '6 عناصر', en: '6 widgets' }
+          }
+        },
+        {
+          id: 17,
+          slug: 'dashboard-17',
+          accent: 'from-emerald-500/25 via-cyan-500/20 to-slate-900/70',
+          preview: { gradient: 'from-emerald-500 to-cyan-500', accentText: 'text-emerald-300' },
+          badge: { ar: 'المدن الذكية', en: 'Smart city' },
+          category: { ar: 'البنية الحضرية', en: 'Urban infrastructure' },
+          title: { ar: 'لوحة المدينة الذكية', en: 'Smart city operations' },
+          summary: { ar: 'إدارة التنقل، الطاقة، والاستدامة داخل المدينة الرقمية.', en: 'Manage mobility, energy, and sustainability across a digital city.' },
+          description: {
+            ar: 'إدارة التنقل، الطاقة، والاستدامة داخل المدينة الرقمية.',
+            en: 'Manage mobility, energy, and sustainability across a digital city.'
+          },
+          features: [
+            { ar: 'مؤشرات التنقل اليومي', en: 'Daily mobility indicators' },
+            { ar: 'بطاقات الاستدامة', en: 'Sustainability scorecards' },
+            { ar: 'خط زمني لمشاريع المدينة', en: 'City initiatives timeline' }
+          ],
+          metrics: {
+            label: { ar: 'محاور حضرية', en: 'Urban modules' },
+            value: { ar: '6 محاور', en: '6 modules' }
+          }
+        },
+        {
+          id: 18,
+          slug: 'dashboard-18',
+          accent: 'from-amber-500/25 via-rose-500/20 to-slate-900/70',
+          preview: { gradient: 'from-amber-500 to-rose-500', accentText: 'text-amber-300' },
+          badge: { ar: 'الضيافة', en: 'Hospitality' },
+          category: { ar: 'إدارة الفنادق', en: 'Hotel management' },
+          title: { ar: 'لوحة تجربة الضيافة', en: 'Hospitality experience dashboard' },
+          summary: { ar: 'مؤشرات الإشغال، رضا الضيوف، وجدولة الخدمات عبر ممتلكات الضيافة.', en: 'Occupancy, guest sentiment, and service schedules across hospitality assets.' },
+          description: {
+            ar: 'مؤشرات الإشغال، رضا الضيوف، وجدولة الخدمات عبر ممتلكات الضيافة.',
+            en: 'Occupancy, guest sentiment, and service schedules across hospitality assets.'
+          },
+          features: [
+            { ar: 'مخطط الأداء اليومي', en: 'Daily performance chart' },
+            { ar: 'قائمة الفنادق الأعلى', en: 'Top property spotlight' },
+            { ar: 'جدول مبادرات التجربة', en: 'Guest experience roadmap' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع ضيافة', en: 'Hospitality blocks' },
+            value: { ar: '6 شرائح', en: '6 blocks' }
+          }
+        },
+        {
+          id: 19,
+          slug: 'dashboard-19',
+          accent: 'from-emerald-500/30 via-lime-500/20 to-slate-900/70',
+          preview: { gradient: 'from-emerald-500 to-lime-500', accentText: 'text-emerald-300' },
+          badge: { ar: 'الطاقة', en: 'Energy' },
+          category: { ar: 'الطاقة المتجددة', en: 'Renewables' },
+          title: { ar: 'لوحة الطاقة المتجددة', en: 'Renewable energy operations' },
+          summary: { ar: 'تشغيل محطات الطاقة النظيفة، موازنة الشبكة، ومشاريع الاستدامة.', en: 'Operate clean generation sites, balance the grid, and track sustainability.' },
+          description: {
+            ar: 'تشغيل محطات الطاقة النظيفة، موازنة الشبكة، ومشاريع الاستدامة.',
+            en: 'Operate clean generation sites, balance the grid, and track sustainability.'
+          },
+          features: [
+            { ar: 'مؤشرات توليد الطاقة', en: 'Generation KPI tiles' },
+            { ar: 'مراقبة توازن الشبكة', en: 'Grid balance monitoring' },
+            { ar: 'لوحة المبادرات الخضراء', en: 'Green initiatives board' }
+          ],
+          metrics: {
+            label: { ar: 'عناصر الطاقة', en: 'Energy widgets' },
+            value: { ar: '6 عناصر', en: '6 widgets' }
+          }
+        },
+        {
+          id: 20,
+          slug: 'dashboard-20',
+          accent: 'from-orange-500/25 via-rose-500/20 to-slate-900/70',
+          preview: { gradient: 'from-orange-500 to-rose-500', accentText: 'text-rose-300' },
+          badge: { ar: 'الرياضة', en: 'Sports' },
+          category: { ar: 'أندية محترفة', en: 'Pro clubs' },
+          title: { ar: 'لوحة إدارة الرياضة', en: 'Sports management analytics' },
+          summary: { ar: 'نتائج المباريات، جاهزية اللاعبين، وتفاعل الجماهير طوال الموسم.', en: 'Match outcomes, player readiness, and fan engagement across the season.' },
+          description: {
+            ar: 'نتائج المباريات، جاهزية اللاعبين، وتفاعل الجماهير طوال الموسم.',
+            en: 'Match outcomes, player readiness, and fan engagement across the season.'
+          },
+          features: [
+            { ar: 'تحليلات المباريات', en: 'Match analytics' },
+            { ar: 'لوحة صحة اللاعبين', en: 'Player wellness board' },
+            { ar: 'مؤشرات جماهيرية مباشرة', en: 'Live fan engagement KPIs' }
+          ],
+          metrics: {
+            label: { ar: 'مقاطع رياضية', en: 'Sports modules' },
+            value: { ar: '6 شرائح', en: '6 modules' }
+          }
+        }
+        {
+          id: 21,
+          slug: 'dashboard-21',
+          accent: 'from-emerald-500/30 via-sky-500/20 to-slate-900/70',
+          preview: { gradient: 'from-emerald-500 to-sky-500', accentText: 'text-emerald-300' },
+          badge: { ar: 'الذكاء الاصطناعي', en: 'AI Ops' },
+          category: { ar: 'قيادة العمليات', en: 'Operations leadership' },
+          title: { ar: 'لوحة الذكاء التشغيلي', en: 'Operational intelligence cockpit' },
+          summary: { ar: 'تحليلات تنبؤية لمراقبة الأداء التشغيلي في الوقت الفعلي.', en: 'Predictive analytics to supervise operational performance in real time.' },
+          description: {
+            ar: 'منصة موحدة للجودة، الإنتاجية، وتنبيهات الانحراف المدعومة بالذكاء الاصطناعي.',
+            en: 'A unified hub for quality, productivity, and AI-driven deviation alerts.'
+          },
+          features: [
+            { ar: 'لوحة تنبيهات ذكية', en: 'AI-powered alerting panel' },
+            { ar: 'مخطط الإنتاج مقابل الخطة', en: 'Actual vs plan throughput chart' },
+            { ar: 'متابعة مبادرات الكفاءة', en: 'Efficiency initiative tracker' }
+          ],
+          metrics: {
+            label: { ar: 'وحدات ذكية', en: 'Intelligence widgets' },
+            value: { ar: '6 وحدات', en: '6 widgets' }
+          }
+        },
+        {
+          id: 22,
+          slug: 'dashboard-22',
+          accent: 'from-rose-500/30 via-indigo-500/20 to-slate-900/70',
+          preview: { gradient: 'from-rose-500 to-indigo-500', accentText: 'text-rose-300' },
+          badge: { ar: 'الوسائط', en: 'Media' },
+          category: { ar: 'تخطيط الحملات', en: 'Campaign planning' },
+          title: { ar: 'لوحة تخطيط الوسائط المتقدمة', en: 'Advanced media planning dashboard' },
+          summary: { ar: 'إدارة الميزانيات متعددة المنصات بتنبؤات دقيقة للنتائج.', en: 'Manage cross-platform budgets with accurate outcome forecasts.' },
+          description: {
+            ar: 'تحكم في الإنفاق، تخصيص القنوات، وتأثير الإعلانات الإبداعية عبر منصة واحدة.',
+            en: 'Control spend, channel mix, and creative impact from one orchestrated hub.'
+          },
+          features: [
+            { ar: 'مؤشر كفاءة الميزانية', en: 'Budget efficiency index' },
+            { ar: 'مصفوفة توزيع القنوات', en: 'Channel allocation matrix' },
+            { ar: 'حرارة أداء الإعلانات', en: 'Creative performance heatmap' }
+          ],
+          metrics: {
+            label: { ar: 'تقارير وسائط', en: 'Media reports' },
+            value: { ar: '5 تقارير', en: '5 reports' }
+          }
+        },
+        {
+          id: 23,
+          slug: 'dashboard-23',
+          accent: 'from-sky-500/30 via-indigo-500/20 to-slate-900/70',
+          preview: { gradient: 'from-sky-500 to-indigo-500', accentText: 'text-sky-300' },
+          badge: { ar: 'الرعاية الرقمية', en: 'Telehealth' },
+          category: { ar: 'شبكات طبية', en: 'Healthcare networks' },
+          title: { ar: 'لوحة شبكة الرعاية الافتراضية', en: 'Virtual care network dashboard' },
+          summary: { ar: 'متابعة جلسات الرعاية عن بعد والامتثال السريري وتجربة المرضى.', en: 'Track telehealth sessions, clinical compliance, and patient experience.' },
+          description: {
+            ar: 'لوحة شاملة لجداول الأطباء، رضا المرضى، وإدارة بروتوكولات الرعاية عن بعد.',
+            en: 'A comprehensive board for provider schedules, patient sentiment, and telecare protocols.'
+          },
+          features: [
+            { ar: 'جدول جلسات مباشر', en: 'Live session scheduler' },
+            { ar: 'مؤشرات رضا المرضى', en: 'Patient satisfaction indicators' },
+            { ar: 'لوحة الامتثال السريري', en: 'Clinical compliance board' }
+          ],
+          metrics: {
+            label: { ar: 'مقاييس رعاية', en: 'Care metrics' },
+            value: { ar: '6 عناصر', en: '6 metrics' }
+          }
+        },
+        {
+          id: 24,
+          slug: 'dashboard-24',
+          accent: 'from-amber-500/30 via-slate-700/20 to-slate-900/70',
+          preview: { gradient: 'from-amber-500 to-slate-600', accentText: 'text-amber-300' },
+          badge: { ar: 'الامتثال', en: 'Compliance' },
+          category: { ar: 'الخدمات المالية', en: 'Financial services' },
+          title: { ar: 'لوحة الامتثال المالي', en: 'Financial compliance monitor' },
+          summary: { ar: 'مراقبة الضوابط التنظيمية ومخاطر الامتثال لحظة بلحظة.', en: 'Monitor regulatory controls and compliance risk at a glance.' },
+          description: {
+            ar: 'تتبّع الضوابط، اختبارات KYC، وإنذارات المخاطر عبر فرق الامتثال العالمية.',
+            en: 'Track controls, KYC testing, and risk alerts across global compliance teams.'
+          },
+          features: [
+            { ar: 'لوحة اختبارات KYC', en: 'KYC testing board' },
+            { ar: 'مؤشرات المخاطر الفورية', en: 'Real-time risk indicators' },
+            { ar: 'سجل إجراءات التدقيق', en: 'Audit action log' }
+          ],
+          metrics: {
+            label: { ar: 'ضوابط مراقبة', en: 'Control checks' },
+            value: { ar: '7 ضوابط', en: '7 checks' }
+          }
+        },
+        {
+          id: 25,
+          slug: 'dashboard-25',
+          accent: 'from-emerald-500/25 via-lime-500/20 to-slate-900/70',
+          preview: { gradient: 'from-emerald-500 to-lime-500', accentText: 'text-emerald-300' },
+          badge: { ar: 'الاستدامة', en: 'Sustainability' },
+          category: { ar: 'تحليلات المناخ', en: 'Climate analytics' },
+          title: { ar: 'لوحة الاستدامة المناخية', en: 'Climate sustainability dashboard' },
+          summary: { ar: 'تحليل البصمة الكربونية والتقدم نحو أهداف صافي الصفر.', en: 'Analyse carbon footprint and progress toward net-zero targets.' },
+          description: {
+            ar: 'عرض انبعاثات النطاقات، مشاريع التعويض، وأداء المبادرات الخضراء.',
+            en: 'Visualise scope emissions, offset projects, and green initiative performance.'
+          },
+          features: [
+            { ar: 'مؤشرات الانبعاثات حسب النطاق', en: 'Scope-based emission tiles' },
+            { ar: 'مخطط التقدم نحو صافي الصفر', en: 'Net-zero progress chart' },
+            { ar: 'لوحة مبادرات الاستدامة', en: 'Sustainability initiative board' }
+          ],
+          metrics: {
+            label: { ar: 'تقارير بيئية', en: 'Environmental reports' },
+            value: { ar: '5 تقارير', en: '5 reports' }
+          }
+        }
+      ];
+})();


### PR DESCRIPTION
## Summary
- add localized HTML dashboards 21–25 with theme-aware layouts, navigation, stats, and panel data
- provide the shared dashboard catalog script exposing the 25 dashboard definitions for gallery/home rendering

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8b4f1caa0832f88c37bdf03656b3e