### PR TITLE
Scope dashboard showcase styling

### DIFF
--- a/frontend/src/pages/DashboardShowcase/GalleryPage.tsx
+++ b/frontend/src/pages/DashboardShowcase/GalleryPage.tsx
@@ -73,7 +73,7 @@ const DashboardGalleryPage = () => {
   }, [activeCategory, language, query]);
 
   return (
-    <div className="gallery-shell" dir={direction}>
+    <div className="gallery-shell" data-gallery-root dir={direction}>
       <div className="gallery-content">
         <header className="gallery-header">
           <Link to="/" className="inline-flex items-center gap-3">
@@ -225,6 +225,10 @@ const GalleryCard = ({ dashboard, language, ctaLabel }: GalleryCardProps) => {
 
   return (
     <Card className="gallery-card">
+      <span
+        aria-hidden
+        className={cn('gallery-card__accent bg-gradient-to-br', dashboard.accent)}
+      />
       <div className="gallery-card__preview">
         <div className={cn('gallery-card__previewGradient bg-gradient-to-br', dashboard.preview.gradient)} />
         <div className="gallery-card__previewOverlay" />

--- a/frontend/src/pages/DashboardShowcase/gallery.css
+++ b/frontend/src/pages/DashboardShowcase/gallery.css
@@ -1,153 +1,184 @@
 @layer components {
-  .gallery-shell {
+  [data-gallery-root] {
     @apply relative min-h-screen overflow-hidden text-slate-100;
     background: radial-gradient(circle at top, hsl(var(--primary) / 0.18), transparent 65%);
   }
 
-  .gallery-content {
+  [data-gallery-root] .gallery-content {
     @apply relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-4 pb-24 pt-12 sm:px-6 lg:px-8;
   }
 
-  .gallery-header {
+  [data-gallery-root] .gallery-header {
     @apply flex flex-wrap items-center justify-between gap-4;
   }
 
-  .gallery-actions {
+  [data-gallery-root] .gallery-actions {
     @apply flex items-center gap-2;
   }
 
-  .gallery-hero {
+  [data-gallery-root] .gallery-hero {
     @apply mt-12 grid gap-10 lg:grid-cols-[1.1fr_0.9fr];
   }
 
-  .gallery-hero-card {
+  [data-gallery-root] .gallery-hero-card {
     @apply rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl backdrop-blur;
   }
 
-  .gallery-stats-grid {
+  [data-gallery-root] .gallery-stats-grid {
     @apply grid gap-6 sm:grid-cols-2;
   }
 
-  .gallery-stat {
+  [data-gallery-root] .gallery-stat {
     @apply space-y-2 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-sm text-slate-200 shadow-lg;
   }
 
-  .gallery-search {
+  [data-gallery-root] .gallery-search {
     @apply flex w-full max-w-xl items-center gap-3 rounded-full border border-white/10 bg-white/5 px-5 py-2 backdrop-blur;
   }
 
-  .gallery-search__input {
+  [data-gallery-root] .gallery-search__input {
     @apply border-0 bg-transparent text-sm text-white placeholder:text-slate-400 focus-visible:ring-0;
   }
 
-  .gallery-filters {
+  [data-gallery-root] .gallery-filters {
     @apply flex flex-wrap gap-2;
   }
 
-  .gallery-grid {
+  [data-gallery-root] .gallery-grid {
     @apply grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3;
   }
 
-  .gallery-empty {
+  [data-gallery-root] .gallery-empty {
     @apply col-span-full flex flex-col items-center justify-center rounded-3xl border border-white/10 bg-white/5 p-12 text-center text-slate-300;
   }
 
-  .gallery-card {
-    @apply group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 text-white shadow-xl transition-all duration-500;
+  [data-gallery-root] .gallery-card {
+    @apply isolate relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 text-white shadow-xl transition-all duration-500;
   }
 
-  .gallery-card__preview {
+  [data-gallery-root] .gallery-card__accent {
+    @apply pointer-events-none absolute inset-0 -z-10 opacity-70 transition duration-700 ease-out;
+    border-radius: inherit;
+  }
+
+  [data-gallery-root] .gallery-card__preview {
     @apply relative aspect-[16/9] overflow-hidden;
   }
 
-  .gallery-card__previewGradient {
+  [data-gallery-root] .gallery-card__previewGradient {
     @apply absolute inset-0 transition-opacity duration-500;
   }
 
-  .gallery-card__previewOverlay {
+  [data-gallery-root] .gallery-card__previewOverlay {
     @apply absolute inset-0 bg-white/10 opacity-0 transition-opacity duration-500;
   }
 
-  .gallery-card__previewContent {
+  [data-gallery-root] .gallery-card__previewContent {
     @apply relative z-10 flex h-full flex-col justify-between p-6;
   }
 
-  .gallery-card__previewBadge {
+  [data-gallery-root] .gallery-card__previewBadge {
     @apply inline-flex w-fit items-center gap-2 rounded-full border border-white/20 bg-black/30 px-4 py-1 text-xs font-semibold uppercase tracking-[0.25em];
   }
 
-  .gallery-card__previewCategory {
+  [data-gallery-root] .gallery-card__previewCategory {
     @apply text-sm font-medium text-slate-200;
   }
 
-  .gallery-card__header {
+  [data-gallery-root] .gallery-card__header {
     @apply space-y-3 px-6 pt-6;
   }
 
-  .gallery-card__title {
+  [data-gallery-root] .gallery-card__title {
     @apply text-2xl font-semibold text-white;
   }
 
-  .gallery-card__summary {
+  [data-gallery-root] .gallery-card__summary {
     @apply text-sm text-slate-200;
   }
 
-  .gallery-card__content {
+  [data-gallery-root] .gallery-card__content {
     @apply space-y-6 px-6 pb-6;
   }
 
-  .gallery-card__features {
+  [data-gallery-root] .gallery-card__features {
     @apply space-y-3 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-slate-200;
   }
 
-  .gallery-card__metrics {
+  [data-gallery-root] .gallery-card__metrics {
     @apply flex items-center justify-between rounded-2xl border border-indigo-300/30 bg-indigo-500/10 px-5 py-3 text-sm text-indigo-100;
   }
 
-  .gallery-card__cta {
+  [data-gallery-root] .gallery-card__cta {
     @apply w-full rounded-full;
+  }
+
+  [data-gallery-root] .gallery-card__feature {
+    @apply flex items-start gap-3;
+  }
+
+  [data-gallery-root] .gallery-stat h3 {
+    @apply text-xs font-semibold uppercase tracking-[0.4em] text-indigo-200;
+  }
+
+  [data-gallery-root] .gallery-stat p {
+    @apply text-slate-300;
+  }
+
+  [data-gallery-root] .gallery-stat strong {
+    @apply text-4xl font-bold text-white;
   }
 }
 
-.gallery-shell::before,
-.gallery-shell::after {
+[data-gallery-root]::before,
+[data-gallery-root]::after {
   content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;
 }
 
-.gallery-shell::before {
+[data-gallery-root]::before {
   background: linear-gradient(130deg, hsl(var(--background)) 15%, hsl(var(--secondary)) 100%);
   opacity: 0.35;
 }
 
-.gallery-shell::after {
+[data-gallery-root]::after {
   background: var(--gradient-aurora);
   opacity: 0.2;
 }
 
-.gallery-card:hover {
+[data-gallery-root] .gallery-card > *:not(.gallery-card__accent) {
+  position: relative;
+  z-index: 1;
+}
+
+[data-gallery-root] .gallery-card:hover {
   transform: translateY(-0.25rem);
   box-shadow: 0 28px 60px -18px rgba(14, 116, 144, 0.35);
   border-color: rgba(99, 102, 241, 0.45);
 }
 
-.gallery-card:hover .gallery-card__previewGradient {
+[data-gallery-root] .gallery-card:hover .gallery-card__accent {
+  opacity: 0.9;
+  transform: scale(1.03);
+  filter: saturate(1.15);
+}
+
+[data-gallery-root] .gallery-card:hover .gallery-card__previewGradient {
   opacity: 0.65;
 }
 
-.gallery-card:hover .gallery-card__previewOverlay {
+[data-gallery-root] .gallery-card:hover .gallery-card__previewOverlay {
   opacity: 0.35;
 }
 
-.gallery-card__feature {
-  display: flex;
-  align-items: flex-start;
-  column-gap: 0.75rem;
+[data-gallery-root] .gallery-card__accent {
+  transform: scale(1);
+  filter: saturate(0.95);
 }
 
-.gallery-card__feature::before {
+[data-gallery-root] .gallery-card__feature::before {
   content: "";
   flex-shrink: 0;
   margin-top: 0.35rem;
@@ -157,18 +188,6 @@
   background: hsl(225 100% 85% / 0.85);
 }
 
-.gallery-card__feature--more::before {
+[data-gallery-root] .gallery-card__feature--more::before {
   display: none;
-}
-
-.gallery-stat h3 {
-  @apply text-xs font-semibold uppercase tracking-[0.4em] text-indigo-200;
-}
-
-.gallery-stat p {
-  @apply text-slate-300;
-}
-
-.gallery-stat strong {
-  @apply text-4xl font-bold text-white;
 }


### PR DESCRIPTION
## Summary
- scope the dashboard showcase stylesheet to the gallery container to prevent leakage into the rest of the app
- add a gradient accent layer to each gallery card so dashboards feel more distinct while keeping existing content intact

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc3cc978c832f969f7e0cc0881514