### PR TITLE
Add website CMS module

### DIFF
--- a/backend/app/Http/Controllers/Api/Website/AchievementController.php
+++ b/backend/app/Http/Controllers/Api/Website/AchievementController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\AchievementResource;
+use App\Models\Achievement;
+use Illuminate\Http\Request;
+
+class AchievementController extends Controller
+{
+    public function index()
+    {
+        return AchievementResource::collection(Achievement::orderByDesc('number')->get());
+    }
+
+    public function store(Request $request): AchievementResource
+    {
+        $achievement = Achievement::create($this->validateRequest($request));
+
+        return new AchievementResource($achievement);
+    }
+
+    public function show(Achievement $achievement): AchievementResource
+    {
+        return new AchievementResource($achievement);
+    }
+
+    public function update(Request $request, Achievement $achievement): AchievementResource
+    {
+        $achievement->update($this->validateRequest($request, true));
+
+        return new AchievementResource($achievement);
+    }
+
+    public function destroy(Achievement $achievement)
+    {
+        $achievement->delete();
+
+        return response()->noContent();
+    }
+
+    private function validateRequest(Request $request, bool $isUpdate = false): array
+    {
+        $required = $isUpdate ? 'sometimes' : 'required';
+        $optional = $isUpdate ? 'sometimes' : 'nullable';
+
+        return $request->validate([
+            'title_ar' => [$required, 'string', 'max:255'],
+            'title_en' => [$required, 'string', 'max:255'],
+            'number' => [$optional, 'nullable', 'integer', 'min:0'],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/Website/ArticleController.php
+++ b/backend/app/Http/Controllers/Api/Website/ArticleController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ArticleResource;
+use App\Models\Article;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class ArticleController extends Controller
+{
+    public function index()
+    {
+        return ArticleResource::collection(Article::latest()->get());
+    }
+
+    public function store(Request $request): ArticleResource
+    {
+        $article = Article::create($this->validateRequest($request));
+
+        return new ArticleResource($article);
+    }
+
+    public function show(Article $article): ArticleResource
+    {
+        return new ArticleResource($article);
+    }
+
+    public function update(Request $request, Article $article): ArticleResource
+    {
+        $article->update($this->validateRequest($request, $article));
+
+        return new ArticleResource($article);
+    }
+
+    public function destroy(Article $article)
+    {
+        $article->delete();
+
+        return response()->noContent();
+    }
+
+    private function validateRequest(Request $request, ?Article $article = null): array
+    {
+        $required = $article ? 'sometimes' : 'required';
+        $optional = $article ? 'sometimes' : 'nullable';
+
+        return $request->validate([
+            'title_ar' => [$required, 'string', 'max:255'],
+            'title_en' => [$required, 'string', 'max:255'],
+            'body_ar' => [$required, 'string'],
+            'body_en' => [$required, 'string'],
+            'slug' => [$required, 'string', 'max:255', Rule::unique('articles', 'slug')->ignore($article?->id)],
+            'cover_image' => [$optional, 'nullable', 'string', 'max:2048'],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/Website/PageController.php
+++ b/backend/app/Http/Controllers/Api/Website/PageController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\PageResource;
+use App\Models\Page;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class PageController extends Controller
+{
+    public function index(string $slug): PageResource
+    {
+        $page = Page::with('contentBlocks')->where('slug', $slug)->firstOrFail();
+
+        return new PageResource($page);
+    }
+
+    public function update(Request $request, string $slug): PageResource
+    {
+        $validated = $request->validate([
+            'title_ar' => ['nullable', 'string', 'max:255'],
+            'title_en' => ['nullable', 'string', 'max:255'],
+            'content_blocks' => ['sometimes', 'array'],
+            'content_blocks.*.key' => ['required', 'string', 'max:255'],
+            'content_blocks.*.type' => ['nullable', Rule::in('text', 'image', 'link', 'html')],
+            'content_blocks.*.value' => ['required', 'array'],
+            'content_blocks.*.value.ar' => ['nullable'],
+            'content_blocks.*.value.en' => ['nullable'],
+        ]);
+
+        $page = Page::firstOrCreate(['slug' => $slug]);
+
+        $page->fill([
+            'title_ar' => $validated['title_ar'] ?? $page->title_ar,
+            'title_en' => $validated['title_en'] ?? $page->title_en,
+        ]);
+        $page->save();
+
+        if (array_key_exists('content_blocks', $validated)) {
+            $keys = [];
+
+            foreach ($validated['content_blocks'] as $block) {
+                $page->contentBlocks()->updateOrCreate(
+                    ['key' => $block['key']],
+                    [
+                        'type' => $block['type'] ?? 'text',
+                        'value' => [
+                            'ar' => $block['value']['ar'] ?? null,
+                            'en' => $block['value']['en'] ?? null,
+                        ],
+                    ]
+                );
+
+                $keys[] = $block['key'];
+            }
+
+            if ($keys) {
+                $page->contentBlocks()
+                    ->whereNotIn('key', $keys)
+                    ->delete();
+            } else {
+                $page->contentBlocks()->delete();
+            }
+        }
+
+        $page->load('contentBlocks');
+
+        return new PageResource($page);
+    }
+}

--- a/backend/app/Http/Controllers/Api/Website/TeamController.php
+++ b/backend/app/Http/Controllers/Api/Website/TeamController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\TeamMemberResource;
+use App\Models\TeamMember;
+use Illuminate\Http\Request;
+
+class TeamController extends Controller
+{
+    public function index()
+    {
+        return TeamMemberResource::collection(TeamMember::all());
+    }
+
+    public function store(Request $request): TeamMemberResource
+    {
+        $teamMember = TeamMember::create($this->validateRequest($request));
+
+        return new TeamMemberResource($teamMember);
+    }
+
+    public function show(TeamMember $team): TeamMemberResource
+    {
+        return new TeamMemberResource($team);
+    }
+
+    public function update(Request $request, TeamMember $team): TeamMemberResource
+    {
+        $team->update($this->validateRequest($request, true));
+
+        return new TeamMemberResource($team);
+    }
+
+    public function destroy(TeamMember $team)
+    {
+        $team->delete();
+
+        return response()->noContent();
+    }
+
+    private function validateRequest(Request $request, bool $isUpdate = false): array
+    {
+        $required = $isUpdate ? 'sometimes' : 'required';
+        $optional = $isUpdate ? 'sometimes' : 'nullable';
+
+        $rules = [
+            'name_ar' => [$required, 'string', 'max:255'],
+            'name_en' => [$required, 'string', 'max:255'],
+            'position_ar' => [$required, 'string', 'max:255'],
+            'position_en' => [$required, 'string', 'max:255'],
+            'bio_ar' => [$optional, 'nullable', 'string'],
+            'bio_en' => [$optional, 'nullable', 'string'],
+            'image' => [$optional, 'nullable', 'string', 'max:2048'],
+        ];
+
+        return $request->validate($rules);
+    }
+}

--- a/backend/app/Http/Controllers/Api/Website/UploadController.php
+++ b/backend/app/Http/Controllers/Api/Website/UploadController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class UploadController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'file' => ['required_without:image', 'nullable', 'image', 'max:5120'],
+            'image' => ['required_without:file', 'nullable', 'image', 'max:5120'],
+        ]);
+
+        $uploadedFile = $request->file('file') ?? $request->file('image');
+
+        if (!$uploadedFile) {
+            abort(422, __('validation.required', ['attribute' => 'file']));
+        }
+
+        $path = $uploadedFile->store('website', 'public');
+
+        return response()->json([
+            'path' => $path,
+            'url' => Storage::disk('public')->url($path),
+        ]);
+    }
+}

--- a/backend/app/Http/Resources/AchievementResource.php
+++ b/backend/app/Http/Resources/AchievementResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AchievementResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => [
+                'ar' => $this->title_ar,
+                'en' => $this->title_en,
+            ],
+            'number' => $this->number,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/ArticleResource.php
+++ b/backend/app/Http/Resources/ArticleResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ArticleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => [
+                'ar' => $this->title_ar,
+                'en' => $this->title_en,
+            ],
+            'body' => [
+                'ar' => $this->body_ar,
+                'en' => $this->body_en,
+            ],
+            'slug' => $this->slug,
+            'cover_image' => $this->cover_image,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/ContentBlockResource.php
+++ b/backend/app/Http/Resources/ContentBlockResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ContentBlockResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        $value = $this->value ?? [];
+
+        return [
+            'id' => $this->id,
+            'key' => $this->key,
+            'value' => [
+                'ar' => $value['ar'] ?? null,
+                'en' => $value['en'] ?? null,
+            ],
+            'type' => $this->type,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/PageResource.php
+++ b/backend/app/Http/Resources/PageResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PageResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'title' => [
+                'ar' => $this->title_ar,
+                'en' => $this->title_en,
+            ],
+            'content_blocks' => ContentBlockResource::collection(
+                $this->whenLoaded('contentBlocks')
+            ),
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/TeamMemberResource.php
+++ b/backend/app/Http/Resources/TeamMemberResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TeamMemberResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => [
+                'ar' => $this->name_ar,
+                'en' => $this->name_en,
+            ],
+            'position' => [
+                'ar' => $this->position_ar,
+                'en' => $this->position_en,
+            ],
+            'bio' => [
+                'ar' => $this->bio_ar,
+                'en' => $this->bio_en,
+            ],
+            'image' => $this->image,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Models/Achievement.php
+++ b/backend/app/Models/Achievement.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Achievement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title_ar',
+        'title_en',
+        'number',
+    ];
+}

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Article extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title_ar',
+        'title_en',
+        'body_ar',
+        'body_en',
+        'slug',
+        'cover_image',
+    ];
+}

--- a/backend/app/Models/ContentBlock.php
+++ b/backend/app/Models/ContentBlock.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ContentBlock extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'page_id',
+        'key',
+        'value',
+        'type',
+    ];
+
+    protected $casts = [
+        'value' => 'array',
+    ];
+
+    public function page()
+    {
+        return $this->belongsTo(Page::class);
+    }
+}

--- a/backend/app/Models/Page.php
+++ b/backend/app/Models/Page.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Page extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'slug',
+        'title_ar',
+        'title_en',
+    ];
+
+    public function contentBlocks()
+    {
+        return $this->hasMany(ContentBlock::class);
+    }
+}

--- a/backend/app/Models/TeamMember.php
+++ b/backend/app/Models/TeamMember.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeamMember extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name_ar',
+        'name_en',
+        'position_ar',
+        'position_en',
+        'bio_ar',
+        'bio_en',
+        'image',
+    ];
+}

--- a/backend/database/migrations/2025_09_09_000000_create_pages_table.php
+++ b/backend/database/migrations/2025_09_09_000000_create_pages_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('title_ar')->nullable();
+            $table->string('title_en')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pages');
+    }
+};

--- a/backend/database/migrations/2025_09_09_000100_create_content_blocks_table.php
+++ b/backend/database/migrations/2025_09_09_000100_create_content_blocks_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('content_blocks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('page_id')->constrained()->cascadeOnDelete();
+            $table->string('key');
+            $table->json('value');
+            $table->enum('type', ['text', 'image', 'link', 'html'])->default('text');
+            $table->timestamps();
+
+            $table->unique(['page_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('content_blocks');
+    }
+};

--- a/backend/database/migrations/2025_09_09_000200_create_team_members_table.php
+++ b/backend/database/migrations/2025_09_09_000200_create_team_members_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('team_members', function (Blueprint $table) {
+            $table->id();
+            $table->string('name_ar');
+            $table->string('name_en');
+            $table->string('position_ar');
+            $table->string('position_en');
+            $table->text('bio_ar')->nullable();
+            $table->text('bio_en')->nullable();
+            $table->string('image')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_members');
+    }
+};

--- a/backend/database/migrations/2025_09_09_000300_create_articles_table.php
+++ b/backend/database/migrations/2025_09_09_000300_create_articles_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->string('title_ar');
+            $table->string('title_en');
+            $table->text('body_ar');
+            $table->text('body_en');
+            $table->string('slug')->unique();
+            $table->string('cover_image')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('articles');
+    }
+};

--- a/backend/database/migrations/2025_09_09_000400_create_achievements_table.php
+++ b/backend/database/migrations/2025_09_09_000400_create_achievements_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('achievements', function (Blueprint $table) {
+            $table->id();
+            $table->string('title_ar');
+            $table->string('title_en');
+            $table->integer('number')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('achievements');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         ]);
         $this->call(UsersTableSeeder::class);
         $this->call(ClientsTableSeeder::class);
+        $this->call(PageSeeder::class);
         $this->call(LawyerSeeder::class);
         $this->call(CourtTypesTableSeeder::class);
         $this->call(CourtLevelsTableSeeder::class);

--- a/backend/database/seeders/PageSeeder.php
+++ b/backend/database/seeders/PageSeeder.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ContentBlock;
+use App\Models\Page;
+use Illuminate\Database\Seeder;
+
+class PageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $pages = [
+            'hero' => [
+                'title_ar' => 'الصفحة الرئيسية',
+                'title_en' => 'Landing Page',
+                'blocks' => [
+                    [
+                        'key' => 'hero_title',
+                        'type' => 'text',
+                        'value' => [
+                            'ar' => 'مرحبا بكم في مكتب أفوكات',
+                            'en' => 'Welcome to Avocat Law Firm',
+                        ],
+                    ],
+                    [
+                        'key' => 'hero_subtitle',
+                        'type' => 'text',
+                        'value' => [
+                            'ar' => 'نقدم خدمات قانونية متكاملة',
+                            'en' => 'We provide comprehensive legal services',
+                        ],
+                    ],
+                ],
+            ],
+            'about' => [
+                'title_ar' => 'من نحن',
+                'title_en' => 'About Us',
+                'blocks' => [
+                    [
+                        'key' => 'about_description',
+                        'type' => 'html',
+                        'value' => [
+                            'ar' => 'خبرة قانونية عميقة وشاملة.',
+                            'en' => 'Extensive and in-depth legal expertise.',
+                        ],
+                    ],
+                ],
+            ],
+            'services' => [
+                'title_ar' => 'خدماتنا',
+                'title_en' => 'Our Services',
+                'blocks' => [
+                    [
+                        'key' => 'services_intro',
+                        'type' => 'text',
+                        'value' => [
+                            'ar' => 'خدمات قانونية مصممة خصيصًا لعملائنا.',
+                            'en' => 'Legal services tailored for our clients.',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        foreach ($pages as $slug => $data) {
+            $page = Page::updateOrCreate(
+                ['slug' => $slug],
+                [
+                    'title_ar' => $data['title_ar'],
+                    'title_en' => $data['title_en'],
+                ]
+            );
+
+            foreach ($data['blocks'] as $block) {
+                ContentBlock::updateOrCreate(
+                    [
+                        'page_id' => $page->id,
+                        'key' => $block['key'],
+                    ],
+                    [
+                        'type' => $block['type'],
+                        'value' => $block['value'],
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,10 @@
 <?php
 
+use App\Http\Controllers\Api\Website\AchievementController;
+use App\Http\Controllers\Api\Website\ArticleController;
+use App\Http\Controllers\Api\Website\PageController;
+use App\Http\Controllers\Api\Website\TeamController;
+use App\Http\Controllers\Api\Website\UploadController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\CaseStatusController;
 use App\Http\Controllers\CaseSubTypeController;
@@ -169,3 +174,14 @@ Route::post('notifications/{notificationId}/read', [NotificationController::clas
         Route::post('notification', [NotificationController::class,'store']);
         Route::post('event', [EventController::class,'store']);
         Route::get('/events', [EventController::class,'index']);
+
+Route::prefix('website')->middleware(['auth:sanctum', 'role:admin'])->group(function () {
+    Route::get('/pages/{slug}', [PageController::class, 'index']);
+    Route::post('/pages/{slug}', [PageController::class, 'update']);
+
+    Route::apiResource('team', TeamController::class);
+    Route::apiResource('articles', ArticleController::class);
+    Route::apiResource('achievements', AchievementController::class);
+
+    Route::post('/upload', [UploadController::class, 'store']);
+});


### PR DESCRIPTION
## Summary
- add migrations, models, and seed data for pages, content blocks, team members, articles, and achievements
- implement bilingual API resources and controllers for website content management with admin-only routing
- support media uploads for CMS content from the dashboard

## Testing
- composer dump-autoload *(fails: Class Illuminate\\Foundation\\Application not found during package discovery)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9eb5c348832f95c6a7ccd7077526