### PR TITLE
feat: refresh dashboard shell with dual-mode styling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -872,7 +871,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -890,7 +888,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -901,7 +898,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -911,14 +907,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -929,7 +923,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -943,7 +936,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -953,7 +945,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -967,7 +958,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2906,6 +2896,27 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
@@ -3121,14 +3132,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3139,7 +3150,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3606,7 +3617,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3616,7 +3626,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3632,14 +3641,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3653,7 +3660,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3787,7 +3793,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -3804,7 +3809,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3828,7 +3832,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3944,7 +3947,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4032,7 +4034,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4057,7 +4058,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4116,7 +4116,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4129,7 +4128,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4148,7 +4146,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4177,7 +4174,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4199,7 +4195,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4363,6 +4358,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4509,14 +4515,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -4568,7 +4572,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -4610,7 +4613,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -4988,7 +4990,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5005,7 +5006,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5032,7 +5032,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5061,7 +5060,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5148,7 +5146,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5231,7 +5228,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5311,7 +5307,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5332,7 +5327,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5345,7 +5339,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5355,7 +5348,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5714,7 +5706,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5757,7 +5748,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -5790,7 +5780,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5800,7 +5789,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5810,7 +5798,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5836,7 +5823,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5990,14 +5976,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6013,7 +5997,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -6130,7 +6113,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6143,7 +6125,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -6230,7 +6211,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -6275,7 +6255,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6285,7 +6264,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6343,7 +6321,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6375,7 +6352,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -6387,7 +6363,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6430,7 +6405,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6466,7 +6440,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6587,7 +6560,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -6630,7 +6602,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6640,14 +6611,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -6681,14 +6650,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6701,7 +6668,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6711,7 +6677,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6731,7 +6696,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6760,7 +6724,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6778,7 +6741,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -6798,7 +6760,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6834,7 +6795,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6860,7 +6820,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6888,7 +6847,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6986,7 +6944,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7237,7 +7194,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -7247,7 +7203,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -7340,7 +7295,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -7371,7 +7325,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7430,7 +7383,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7548,7 +7500,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7561,7 +7512,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7654,7 +7604,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7677,7 +7626,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7727,7 +7675,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7746,7 +7693,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7761,14 +7707,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7781,7 +7725,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -7798,7 +7741,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7811,7 +7753,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7870,7 +7811,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -7906,7 +7846,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7936,7 +7875,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -7990,7 +7928,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8004,7 +7941,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -8014,7 +7950,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -8125,7 +8060,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8180,7 +8114,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -8206,7 +8139,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8365,7 +8298,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vaul": {
@@ -9075,7 +9007,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9197,7 +9128,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -9216,7 +9146,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9234,14 +9163,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9256,7 +9183,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9269,7 +9195,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9342,7 +9267,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -14,23 +14,24 @@ const AppShell: React.FC<AppShellProps> = ({ children, title }) => {
   const isRTL = i18n.language === "ar";
 
   return (
-    <div className="flex min-h-screen bg-background" dir={isRTL ? "rtl" : "ltr"}>
-      {/* Sidebar */}
-      <div className="hidden md:block">
-        <Sidebar />
+    <div className="dashboard-shell" dir={isRTL ? "rtl" : "ltr"}>
+      <div className="dashboard-layout">
+        {/* Sidebar */}
+        <div className="hidden md:block">
+          <Sidebar />
+        </div>
+
+        {/* Mobile Drawer trigger */}
+        <MobileDrawer />
+
+        {/* Content */}
+        <div className="dashboard-content">
+          <Header title={title} />
+          <main className="dashboard-scroll">
+            <div className="dashboard-inner">{children}</div>
+          </main>
+        </div>
       </div>
-
-      {/* Mobile Drawer */}
-      <MobileDrawer />
-
-      {/* Content */}
-      <div className="flex flex-1 flex-col min-h-screen transition-all duration-300">
-        <Header title={title} />
-        <main className="flex-1 overflow-y-auto p-6">{children}</main>
-      </div>
-
-      {/* Drawer (Mobile only) */}
-      <MobileDrawer />
     </div>
   );
 };

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Menu, X, UserCircle, Settings, User, LogOut, PanelLeft } from "lucide-react";
+import { Menu, X, UserCircle, Settings, User, LogOut, PanelLeft, SunDim, MoonStar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -15,6 +15,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useSidebar } from "@/contexts/SidebarContext";
 import { cn } from "@/lib/utils";
 import BrandLogo from "../common/BrandLogo";
+import { useTheme } from "@/contexts/ThemeContext";
 
 interface HeaderProps {
   title?: string;
@@ -25,19 +26,25 @@ export const Header: React.FC<HeaderProps> = ({ title, className }) => {
   const { language, setLanguage, t, isRTL } = useLanguage();
   const { user, logout } = useAuth();
   const { isMobileOpen, toggleMobile, isCollapsed, toggleCollapsed } = useSidebar();
+  const { theme } = useTheme();
 
   const toggleLang = () => setLanguage(language === "ar" ? "en" : "ar");
 
   return (
     <header
       className={cn(
-        "header-shell sticky top-0 z-50 h-16 transition-all duration-500",
+        "header-shell sticky top-0 z-50 h-16 transition-all duration-500 backdrop-blur",
         className
       )}
     >
       <div className="relative z-[1] flex h-full items-center justify-between px-4">
         {/* Left side */}
-        <div className={cn("flex items-center gap-3", isRTL ? "flex-row-reverse" : "flex-row")}>
+        <div
+          className={cn(
+            "flex items-center gap-3",
+            isRTL ? "flex-row-reverse" : "flex-row"
+          )}
+        >
           {/* Mobile menu button */}
           <Button
             variant="ghost"
@@ -62,14 +69,32 @@ export const Header: React.FC<HeaderProps> = ({ title, className }) => {
             />
           </Button>
 
-          {/* Page title */}
-          {title && (
-            <h1 className="hidden sm:block text-lg font-semibold text-foreground">{title}</h1>
-          )}
+          <div className="flex items-center gap-3">
+            <BrandLogo variant="icon" className="h-8 w-8 md:hidden" />
+            {/* Page title */}
+            {title && (
+              <h1 className="hidden sm:block text-lg font-semibold text-foreground">
+                {title}
+              </h1>
+            )}
+          </div>
         </div>
 
         {/* Right side */}
         <div className="flex items-center gap-4">
+          <div className="hidden sm:flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            {theme === "dark" ? (
+              <>
+                <MoonStar className="h-3.5 w-3.5" />
+                {language === "ar" ? "وضع ليلي" : "Night Mode"}
+              </>
+            ) : (
+              <>
+                <SunDim className="h-3.5 w-3.5" />
+                {language === "ar" ? "وضع نهاري" : "Day Mode"}
+              </>
+            )}
+          </div>
           <ThemeToggle />
           <Button onClick={toggleLang} variant="outline" size="sm">
             {language === "ar" ? "EN" : "عربي"}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -38,24 +38,23 @@ const Sidebar: React.FC = () => {
       animate={{ width: collapsed ? 64 : 256 }}
       transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
       className={cn(
-        "sidebar-shell hidden h-screen flex-shrink-0 flex-col border-r border-sidebar-border md:sticky md:top-0 md:flex"
+        "sidebar-shell hidden h-screen flex-shrink-0 flex-col md:sticky md:top-0 md:flex"
       )}
       dir={isRTL ? "rtl" : "ltr"}
       data-collapsed={collapsed}
     >
-       {/* Brand Section */}
-<div
-  className={cn(
-    "sidebar-brand flex items-center justify-center gap-3  transition-all duration-300",
-    collapsed ? "px-4 py-2" : "px-6 py-4"
-  )}
->
-  <BrandLogo
-    variant={collapsed ? "icon" : "full"}
-    className={collapsed ? "h-12 w-12 transition-all duration-300" : "h-8 w-auto transition-all duration-300"}
-  />
-</div>
-
+      {/* Brand Section */}
+      <div
+        className={cn(
+          "sidebar-brand flex items-center justify-center gap-3 transition-all duration-300",
+          collapsed ? "px-4 py-3" : "px-6 py-5"
+        )}
+      >
+        <BrandLogo
+          variant={collapsed ? "icon" : "full"}
+          className={collapsed ? "h-10 w-10" : "h-9 w-auto"}
+        />
+      </div>
 
       {/* Navigation Groups */}
       <nav className="flex-1 space-y-6 overflow-y-auto px-3 py-4 sidebar-scroll">
@@ -137,7 +136,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
       )}
       style={{
         background: design.badgeGradient,
-        boxShadow: "var(var(--shadow-luxury))"
+        boxShadow: design.shadow ?? "var(--shadow-premium)"
       }}
     >
       <LegalIcon

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Amiri:wght@400;700&family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap');
 @import './styles/theme-tokens.css';
 @import './styles/radix-vars.css';
+@import './styles/dashboard-shell.css';
 
 @tailwind base;
 @tailwind components;

--- a/frontend/src/pages/dashboard/DashboardHome.tsx
+++ b/frontend/src/pages/dashboard/DashboardHome.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Progress } from '@/components/ui/progress';
-import { Badge } from '@/components/ui/badge';
-import LegalIcon from '@/components/common/LegalIcon';
-import { getIconDesign } from '@/config/iconography';
-import { cn } from '@/lib/utils';
+import React, { useMemo } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import LegalIcon from "@/components/common/LegalIcon";
+import { getIconDesign } from "@/config/iconography";
+import { cn } from "@/lib/utils";
 import {
   BarChart,
   Bar,
@@ -14,138 +14,220 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  LineChart,
-  Line,
   PieChart,
   Pie,
   Cell,
-} from 'recharts';
-import {
-  TrendingUp,
-  AlertCircle,
-  CheckCircle,
-  Clock,
-} from 'lucide-react';
-import { useLanguage } from '@/contexts/LanguageContext';
+  TooltipProps,
+} from "recharts";
+import { TrendingUp, AlertCircle, CheckCircle, Clock } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useTheme } from "@/contexts/ThemeContext";
+import type { ValueType, NameType } from "recharts/types/component/DefaultTooltipContent";
 
 const DashboardHome = () => {
   const { language } = useLanguage();
+  const { theme } = useTheme();
 
-  // Sample data for charts
-  const caseData = [
-    { month: language === 'ar' ? 'يناير' : 'Jan', cases: 65, revenue: 12000 },
-    { month: language === 'ar' ? 'فبراير' : 'Feb', cases: 59, revenue: 15000 },
-    { month: language === 'ar' ? 'مارس' : 'Mar', cases: 80, revenue: 18000 },
-    { month: language === 'ar' ? 'أبريل' : 'Apr', cases: 81, revenue: 22000 },
-    { month: language === 'ar' ? 'مايو' : 'May', cases: 56, revenue: 19000 },
-    { month: language === 'ar' ? 'يونيو' : 'Jun', cases: 95, revenue: 25000 },
-  ];
+  const palette = useMemo(
+    () => ({
+      primary: "hsl(var(--chart-primary))",
+      accent: "hsl(var(--chart-secondary))",
+      tertiary: "hsl(var(--chart-tertiary))",
+      muted: "hsl(var(--chart-muted))",
+    }),
+    []
+  );
 
-  const caseStatusData = [
-    { name: language === 'ar' ? 'نشطة' : 'Active', value: 45, color: 'hsl(var(--primary))' },
-    { name: language === 'ar' ? 'مكتملة' : 'Completed', value: 30, color: 'hsl(var(--success))' },
-    { name: language === 'ar' ? 'معلقة' : 'Pending', value: 15, color: 'hsl(var(--warning))' },
-    { name: language === 'ar' ? 'مؤجلة' : 'On Hold', value: 10, color: 'hsl(var(--muted-foreground))' },
-  ];
+  const revenueFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(language === "ar" ? "ar-EG" : "en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+      }).format(25000),
+    [language]
+  );
+
+  const caseData = useMemo(
+    () =>
+      [
+        { month: language === "ar" ? "يناير" : "Jan", cases: 65 },
+        { month: language === "ar" ? "فبراير" : "Feb", cases: 59 },
+        { month: language === "ar" ? "مارس" : "Mar", cases: 80 },
+        { month: language === "ar" ? "أبريل" : "Apr", cases: 81 },
+        { month: language === "ar" ? "مايو" : "May", cases: 56 },
+        { month: language === "ar" ? "يونيو" : "Jun", cases: 95 },
+      ],
+    [language]
+  );
+
+  const caseStatusData = useMemo(
+    () =>
+      [
+        { name: language === "ar" ? "نشطة" : "Active", value: 45, color: palette.primary },
+        { name: language === "ar" ? "مكتملة" : "Completed", value: 30, color: "hsl(var(--success))" },
+        { name: language === "ar" ? "معلقة" : "Pending", value: 15, color: "hsl(var(--warning))" },
+        { name: language === "ar" ? "مؤجلة" : "On Hold", value: 10, color: palette.muted },
+      ],
+    [language, palette.primary, palette.muted]
+  );
 
   const stats = [
     {
-      title: language === 'ar' ? 'إجمالي القضايا' : 'Total Cases',
-      value: '247',
-      change: '+12%',
-      iconKey: 'cases' as const,
+      title: language === "ar" ? "إجمالي القضايا" : "Total Cases",
+      value: "247",
+      change: "+12%",
+      iconKey: "cases" as const,
     },
     {
-      title: language === 'ar' ? 'العملاء النشطون' : 'Active Clients',
-      value: '89',
-      change: '+8%',
-      iconKey: 'clients' as const,
+      title: language === "ar" ? "العملاء النشطون" : "Active Clients",
+      value: "89",
+      change: "+8%",
+      iconKey: "clients" as const,
     },
     {
-      title: language === 'ar' ? 'الإيرادات الشهرية' : 'Monthly Revenue',
-      value: '$25,000',
-      change: '+15%',
-      iconKey: 'reports' as const,
+      title: language === "ar" ? "الإيرادات الشهرية" : "Monthly Revenue",
+      value: revenueFormatter,
+      change: "+15%",
+      iconKey: "reports" as const,
     },
     {
-      title: language === 'ar' ? 'المواعيد القادمة' : 'Upcoming Appointments',
-      value: '12',
-      change: '+3',
-      iconKey: 'sessions' as const,
+      title: language === "ar" ? "المواعيد القادمة" : "Upcoming Appointments",
+      value: "12",
+      change: "+3",
+      iconKey: "sessions" as const,
     },
   ];
 
   const recentActivities = [
     {
       id: 1,
-      action: language === 'ar' ? 'قضية جديدة مُضافة' : 'New case added',
-      client: language === 'ar' ? 'شركة الخليج' : 'Gulf Corporation',
-      time: language === 'ar' ? 'منذ 2 ساعة' : '2 hours ago',
-      status: 'new',
+      action: language === "ar" ? "قضية جديدة مُضافة" : "New case added",
+      client: language === "ar" ? "شركة الخليج" : "Gulf Corporation",
+      time: language === "ar" ? "منذ 2 ساعة" : "2 hours ago",
+      status: "new" as const,
     },
     {
       id: 2,
-      action: language === 'ar' ? 'تم إكمال المستند' : 'Document completed',
-      client: language === 'ar' ? 'أحمد المحمدي' : 'Ahmed Al-Mohammadi',
-      time: language === 'ar' ? 'منذ 4 ساعات' : '4 hours ago',
-      status: 'completed',
+      action: language === "ar" ? "تم إكمال المستند" : "Document completed",
+      client: language === "ar" ? "أحمد المحمدي" : "Ahmed Al-Mohammadi",
+      time: language === "ar" ? "منذ 4 ساعات" : "4 hours ago",
+      status: "completed" as const,
     },
     {
       id: 3,
-      action: language === 'ar' ? 'موعد مجدول' : 'Appointment scheduled',
-      client: language === 'ar' ? 'شركة النور' : 'Al-Noor Company',
-      time: language === 'ar' ? 'منذ 6 ساعات' : '6 hours ago',
-      status: 'scheduled',
+      action: language === "ar" ? "موعد مجدول" : "Appointment scheduled",
+      client: language === "ar" ? "شركة النور" : "Al-Noor Company",
+      time: language === "ar" ? "منذ 6 ساعات" : "6 hours ago",
+      status: "scheduled" as const,
     },
   ];
- 
-  return (
-    <div className="space-y-6" dir={language === 'ar' ? 'rtl' : 'ltr'}>
-      {/* Welcome Section */}
-      <div className="rounded-xl bg-gradient-to-r from-primary to-primary-light p-4 text-primary-foreground sm:p-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-display font-bold mb-2">
-              {language === 'ar' ? 'مرحباً بك في لوحة التحكم' : 'Welcome to Your Dashboard'}
-            </h1>
-            <p className="text-primary-foreground/80">
-              {language === 'ar' 
-                ? 'إليك نظرة عامة على أداءك القانوني اليوم' 
-                : 'Here\'s an overview of your legal practice today'
-              }
-            </p>
+
+  const renderTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+    if (!active || !payload?.length) return null;
+
+    return (
+      <div className="rounded-lg border border-border/60 bg-card/95 px-3 py-2 shadow-lg backdrop-blur">
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        {payload.map((entry, index) => (
+          <div key={index} className="flex items-center gap-2 text-sm text-foreground">
+            <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: entry.color as string }} />
+            <span className="font-semibold">{entry.value}</span>
           </div>
-          <LegalIcon iconKey="dashboard" width={48} height={48} />
-        </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6" dir={language === "ar" ? "rtl" : "ltr"}>
+      <div className="grid gap-6 lg:grid-cols-[2.2fr_1fr]">
+        <Card className="card-premium">
+          <CardContent className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-3">
+              <Badge className="w-fit rounded-full border border-border/40 bg-background/40 px-4 py-1 text-xs uppercase tracking-[0.3em] text-muted-foreground" variant="outline">
+                {theme === "dark"
+                  ? language === "ar" ? "أداء ليلي" : "Night Insight"
+                  : language === "ar" ? "أداء نهاري" : "Daylight Insight"}
+              </Badge>
+              <div className="space-y-1">
+                <h1 className="text-2xl font-display font-bold tracking-tight sm:text-3xl">
+                  {language === "ar" ? "مرحباً بك في لوحة التحكم" : "Welcome to Your Dashboard"}
+                </h1>
+                <p className="max-w-xl text-sm text-muted-foreground">
+                  {language === "ar"
+                    ? "نقدّم لك لمحة محدثة عن القضايا، العملاء والأداء المالي"
+                    : "Get an updated snapshot of your cases, clients, and revenue streams."}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                <div className="flex items-center gap-2 rounded-full bg-background/60 px-3 py-1">
+                  <span className="h-2 w-2 rounded-full bg-[hsl(var(--chart-primary))]" />
+                  {language === "ar" ? "القضايا النشطة" : "Active Cases"}
+                </div>
+                <div className="flex items-center gap-2 rounded-full bg-background/60 px-3 py-1">
+                  <span className="h-2 w-2 rounded-full bg-[hsl(var(--chart-secondary))]" />
+                  {language === "ar" ? "قضايا مكتملة" : "Completed"}
+                </div>
+              </div>
+            </div>
+            <div className="relative flex h-full min-h-[160px] w-full items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-[hsl(var(--primary)/0.08)] to-[hsl(var(--accent)/0.1)] sm:w-[220px]">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,hsl(var(--primary)/0.2),transparent_60%)]" />
+              <LegalIcon iconKey="dashboard" width={72} height={72} className="relative text-primary" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="card-premium flex flex-col justify-between">
+          <CardHeader className="pb-2">
+            <CardTitle className="dashboard-section-title flex items-center gap-2 text-base">
+              <AlertCircle className="h-5 w-5 text-[hsl(var(--chart-secondary))]" />
+              {language === "ar" ? "نظرة سريعة" : "Quick Glance"}
+            </CardTitle>
+            <CardDescription>
+              {language === "ar" ? "أرقام اليوم المميزة" : "Today's highlights"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            {[
+              { label: language === "ar" ? "جلسات اليوم" : "Sessions Today", value: "5" },
+              { label: language === "ar" ? "وثائق قيد المراجعة" : "Docs in Review", value: "14" },
+              { label: language === "ar" ? "نسبة الالتزام" : "Compliance", value: "92%" },
+            ].map((item) => (
+              <div
+                key={item.label}
+                className="flex items-center justify-between rounded-2xl bg-background/60 px-4 py-3 text-sm font-medium text-muted-foreground"
+              >
+                <span>{item.label}</span>
+                <span className="text-foreground">{item.value}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
       </div>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+      <div className="dashboard-bento">
         {stats.map((stat, index) => {
           const design = getIconDesign(stat.iconKey);
           return (
             <Card key={index} className="card-premium">
               <CardContent className="p-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground">
-                      {stat.title}
-                    </p>
-                    <p className="text-2xl font-bold text-text-strong">
-                      {stat.value}
-                    </p>
-                    <Badge variant="secondary" className="mt-1">
+                <div className="flex items-start justify-between">
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-muted-foreground">{stat.title}</p>
+                    <p className="text-3xl font-bold tracking-tight text-text-strong">{stat.value}</p>
+                    <Badge variant="secondary" className="mt-1 w-fit rounded-full px-3">
                       {stat.change}
                     </Badge>
                   </div>
                   <div
                     className={cn(
                       "flex h-12 w-12 items-center justify-center rounded-2xl",
-                      design.badgeClass ?? "text-white",
+                      design.badgeClass ?? "text-white"
                     )}
                     style={{
                       background: design.badgeGradient,
-                      boxShadow: design.shadow,
+                      boxShadow: design.shadow ?? "var(--shadow-premium)",
                     }}
                   >
                     <LegalIcon iconKey={stat.iconKey} width={28} height={28} />
@@ -157,86 +239,61 @@ const DashboardHome = () => {
         })}
       </div>
 
-      {/* Charts Row */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Cases & Revenue Chart */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.6fr_1fr]">
         <Card className="card-premium">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <TrendingUp className="h-5 w-5" />
-              {language === 'ar' ? 'القضايا والإيرادات' : 'Cases & Revenue'}
+              {language === "ar" ? "القضايا والإيرادات" : "Cases & Revenue"}
             </CardTitle>
             <CardDescription>
-              {language === 'ar' 
-                ? 'نظرة عامة على الأداء الشهري' 
-                : 'Monthly performance overview'
-              }
+              {language === "ar" ? "نظرة عامة على الأداء الشهري" : "Monthly performance overview"}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={caseData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis dataKey="month" stroke="hsl(var(--muted-foreground))" />
-                <YAxis stroke="hsl(var(--muted-foreground))" />
-                <Tooltip 
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
-                />
-                <Bar dataKey="cases" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                <defs>
+                  <linearGradient id="casesGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={palette.primary} stopOpacity={0.95} />
+                    <stop offset="100%" stopColor={palette.primary} stopOpacity={0.25} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border) / 0.6)" />
+                <XAxis dataKey="month" stroke="hsl(var(--muted-foreground))" tickLine={false} axisLine={false} />
+                <YAxis stroke="hsl(var(--muted-foreground))" tickLine={false} axisLine={false} />
+                <Tooltip content={renderTooltip} cursor={{ fill: "hsl(var(--muted) / 0.3)" }} />
+                <Bar dataKey="cases" fill="url(#casesGradient)" radius={[12, 12, 12, 12]} barSize={26} />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>
         </Card>
 
-        {/* Case Status Distribution */}
         <Card className="card-premium">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <LegalIcon iconKey="cases" width={20} height={20} />
-              {language === 'ar' ? 'توزيع حالة القضايا' : 'Case Status Distribution'}
+              {language === "ar" ? "توزيع حالة القضايا" : "Case Status Distribution"}
             </CardTitle>
             <CardDescription>
-              {language === 'ar' 
-                ? 'التوزيع الحالي للقضايا حسب الحالة' 
-                : 'Current distribution of cases by status'
-              }
+              {language === "ar" ? "التوزيع الحالي للقضايا حسب الحالة" : "Current distribution of cases by status"}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={300}>
               <PieChart>
-                <Pie
-                  data={caseStatusData}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={60}
-                  outerRadius={100}
-                  dataKey="value"
-                >
+                <Pie data={caseStatusData} cx="50%" cy="50%" innerRadius={60} outerRadius={110} dataKey="value">
                   {caseStatusData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={entry.color} />
                   ))}
                 </Pie>
-                <Tooltip 
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
-                />
+                <Tooltip content={renderTooltip} />
               </PieChart>
             </ResponsiveContainer>
-            <div className="grid grid-cols-2 gap-4 mt-4">
+            <div className="mt-4 grid grid-cols-2 gap-4">
               {caseStatusData.map((item, index) => (
                 <div key={index} className="flex items-center gap-2">
-                  <div 
-                    className="w-3 h-3 rounded-full" 
-                    style={{ backgroundColor: item.color }}
-                  />
+                  <div className="h-3 w-3 rounded-full" style={{ backgroundColor: item.color }} />
                   <span className="text-sm text-muted-foreground">{item.name}</span>
                   <Badge variant="outline">{item.value}</Badge>
                 </div>
@@ -246,28 +303,39 @@ const DashboardHome = () => {
         </Card>
       </div>
 
-      {/* Recent Activities & Quick Actions */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Recent Activities */}
-        <Card className="lg:col-span-2 card-premium">
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.7fr_1fr]">
+        <Card className="card-premium">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Clock className="h-5 w-5" />
-              {language === 'ar' ? 'الأنشطة الأخيرة' : 'Recent Activities'}
+              {language === "ar" ? "الأنشطة الأخيرة" : "Recent Activities"}
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
               {recentActivities.map((activity) => (
-                <div key={activity.id} className="flex items-center justify-between p-3 bg-surface-muted rounded-lg">
+                <div
+                  key={activity.id}
+                  className="flex items-center justify-between gap-3 rounded-2xl border border-border/50 bg-background/60 px-4 py-3 shadow-sm"
+                >
                   <div className="flex items-center gap-3">
-                    <div className={`w-2 h-2 rounded-full ${
-                      activity.status === 'new' ? 'bg-primary' :
-                      activity.status === 'completed' ? 'bg-success' : 'bg-warning'
-                    }`} />
+                    <span
+                      className={cn(
+                        "inline-flex h-8 w-8 items-center justify-center rounded-full",
+                        activity.status === "new"
+                          ? "bg-[hsl(var(--chart-primary))]/15 text-[hsl(var(--chart-primary))]"
+                          : activity.status === "completed"
+                          ? "bg-success/15 text-success"
+                          : "bg-warning/15 text-warning"
+                      )}
+                    >
+                      {activity.status === "new" && <AlertCircle className="h-4 w-4" />}
+                      {activity.status === "completed" && <CheckCircle className="h-4 w-4" />}
+                      {activity.status === "scheduled" && <Clock className="h-4 w-4" />}
+                    </span>
                     <div>
                       <p className="font-medium text-text-strong">{activity.action}</p>
-                      <p className="text-sm text-muted-foreground">{activity.client}</p>
+                      <p className="text-xs text-muted-foreground">{activity.client}</p>
                     </div>
                   </div>
                   <span className="text-xs text-muted-foreground">{activity.time}</span>
@@ -277,77 +345,58 @@ const DashboardHome = () => {
           </CardContent>
         </Card>
 
-        {/* Quick Actions */}
         <Card className="card-premium">
           <CardHeader>
-            <CardTitle>
-              {language === 'ar' ? 'إجراءات سريعة' : 'Quick Actions'}
-            </CardTitle>
+            <CardTitle>{language === "ar" ? "إجراءات سريعة" : "Quick Actions"}</CardTitle>
           </CardHeader>
-         <CardContent className="space-y-3">
-            <Button className="w-full justify-start gap-2 btn-premium">
+          <CardContent className="space-y-3">
+            <Button className="btn-premium w-full justify-start gap-3">
               <LegalIcon iconKey="cases" width={20} height={20} />
-              {language === 'ar' ? 'قضية جديدة' : 'New Case'}
+              {language === "ar" ? "قضية جديدة" : "New Case"}
             </Button>
-            <Button variant="outline" className="w-full justify-start gap-2">
+            <Button variant="outline" className="w-full justify-start gap-3 rounded-2xl border-border/60 bg-background/70">
               <LegalIcon iconKey="clients" width={20} height={20} />
-              {language === 'ar' ? 'إضافة عميل' : 'Add Client'}
+              {language === "ar" ? "إضافة عميل" : "Add Client"}
             </Button>
-            <Button variant="outline" className="w-full justify-start gap-2">
+            <Button variant="outline" className="w-full justify-start gap-3 rounded-2xl border-border/60 bg-background/70">
               <LegalIcon iconKey="sessions" width={20} height={20} />
-              {language === 'ar' ? 'جدولة موعد' : 'Schedule Meeting'}
+              {language === "ar" ? "جدولة موعد" : "Schedule Meeting"}
             </Button>
-            <Button variant="outline" className="w-full justify-start gap-2">
+            <Button variant="outline" className="w-full justify-start gap-3 rounded-2xl border-border/60 bg-background/70">
               <LegalIcon iconKey="documents" width={20} height={20} />
-              {language === 'ar' ? 'إنشاء مستند' : 'Create Document'}
+              {language === "ar" ? "إنشاء مستند" : "Create Document"}
             </Button>
           </CardContent>
         </Card>
       </div>
 
-      {/* Task Progress */}
       <Card className="card-premium">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <CheckCircle className="h-5 w-5" />
-            {language === 'ar' ? 'تقدم المهام' : 'Task Progress'}
+            {language === "ar" ? "تقدم المهام" : "Task Progress"}
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <div>
-              <div className="flex justify-between items-center mb-2">
-                <span className="text-sm font-medium">
-                  {language === 'ar' ? 'مراجعة الوثائق' : 'Document Review'}
-                </span>
-                <span className="text-sm text-muted-foreground">75%</span>
+            {[
+              { label: language === "ar" ? "مراجعة الوثائق" : "Document Review", value: 75 },
+              { label: language === "ar" ? "متابعة العملاء" : "Client Follow-up", value: 60 },
+              { label: language === "ar" ? "إعداد التقارير" : "Report Preparation", value: 90 },
+            ].map((task) => (
+              <div key={task.label}>
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-sm font-medium">{task.label}</span>
+                  <span className="text-sm text-muted-foreground">{task.value}%</span>
+                </div>
+                <Progress value={task.value} className="h-2" />
               </div>
-              <Progress value={75} className="h-2" />
-            </div>
-            <div>
-              <div className="flex justify-between items-center mb-2">
-                <span className="text-sm font-medium">
-                  {language === 'ar' ? 'متابعة العملاء' : 'Client Follow-up'}
-                </span>
-                <span className="text-sm text-muted-foreground">60%</span>
-              </div>
-              <Progress value={60} className="h-2" />
-            </div>
-            <div>
-              <div className="flex justify-between items-center mb-2">
-                <span className="text-sm font-medium">
-                  {language === 'ar' ? 'إعداد التقارير' : 'Report Preparation'}
-                </span>
-                <span className="text-sm text-muted-foreground">90%</span>
-              </div>
-              <Progress value={90} className="h-2" />
-            </div>
+            ))}
           </div>
         </CardContent>
       </Card>
     </div>
   );
-
 };
 
 export default DashboardHome;

--- a/frontend/src/styles/dashboard-shell.css
+++ b/frontend/src/styles/dashboard-shell.css
@@ -1,0 +1,274 @@
+@layer base {
+  :root {
+    --shell-day-gradient: linear-gradient(135deg, hsl(var(--background) / 0.95), hsl(var(--card-elevated)) 60%, hsl(var(--muted) / 0.85));
+    --shell-day-overlay: radial-gradient(120% 120% at 10% 10%, hsl(var(--primary) / 0.12), transparent 60%),
+      radial-gradient(140% 140% at 90% 30%, hsl(var(--accent) / 0.12), transparent 70%);
+    --shell-night-gradient: linear-gradient(135deg, hsl(220 60% 6% / 0.98), hsl(215 60% 10% / 0.92) 45%, hsl(230 60% 4% / 0.92));
+    --shell-night-overlay: radial-gradient(120% 120% at 10% 10%, hsl(var(--primary) / 0.22), transparent 65%),
+      radial-gradient(150% 150% at 90% 30%, hsl(var(--accent) / 0.18), transparent 70%);
+
+    --chart-primary: var(--primary);
+    --chart-secondary: var(--accent);
+    --chart-tertiary: 180 60% 45%;
+    --chart-muted: var(--muted-foreground);
+
+    --sidebar-glass-background: color-mix(in srgb, hsl(var(--sidebar-background)) 88%, transparent);
+    --sidebar-glass-border: 1px solid hsl(var(--sidebar-border));
+    --sidebar-glass-shadow: var(--sidebar-shell-shadow);
+
+    --header-glass-background: color-mix(in srgb, hsl(var(--popover)) 92%, transparent);
+    --header-glass-border: var(--header-shell-border);
+    --header-glass-shadow: var(--header-shell-shadow);
+  }
+
+  .dark {
+    --chart-tertiary: 200 70% 55%;
+    --shell-background: var(--shell-night-gradient);
+    --shell-overlay: var(--shell-night-overlay);
+  }
+
+  :root {
+    --shell-background: var(--shell-day-gradient);
+    --shell-overlay: var(--shell-day-overlay);
+  }
+}
+
+@layer components {
+  .dashboard-shell {
+    position: relative;
+    min-height: 100vh;
+    background: var(--shell-background);
+    color: hsl(var(--foreground));
+    transition: var(--transition-theme);
+    overflow: hidden;
+  }
+
+  .dashboard-shell::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: var(--shell-overlay);
+    opacity: 1;
+    pointer-events: none;
+    mix-blend-mode: screen;
+    transition: var(--transition-theme);
+  }
+
+  .dashboard-layout {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    min-height: 100vh;
+    backdrop-filter: blur(4px);
+  }
+
+  .dashboard-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 100vh;
+    transition: var(--transition-smooth);
+  }
+
+  .dashboard-scroll {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+    display: flex;
+    justify-content: center;
+  }
+
+  .dashboard-inner {
+    width: min(1200px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 1.8vw, 2.5rem);
+  }
+
+  .header-shell {
+    background: var(--header-surface-gradient);
+    backdrop-filter: var(--header-shell-blur);
+    box-shadow: var(--header-shell-shadow);
+    border-bottom: var(--header-glass-border);
+    border-bottom-left-radius: clamp(0.75rem, 1vw, 1.25rem);
+    border-bottom-right-radius: clamp(0.75rem, 1vw, 1.25rem);
+  }
+
+  .header-shell::after {
+    content: "";
+    position: absolute;
+    inset-inline: 1.5rem;
+    bottom: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, hsl(var(--accent) / 0.4), transparent);
+  }
+
+  .sidebar-shell {
+    background: var(--sidebar-surface-gradient);
+    backdrop-filter: var(--sidebar-shell-blur);
+    box-shadow: var(--sidebar-glass-shadow);
+    border-inline-end: var(--sidebar-glass-border);
+  }
+
+  .sidebar-brand {
+    position: relative;
+    border-bottom: 1px solid hsl(var(--sidebar-border) / 0.6);
+  }
+
+  .sidebar-brand::after {
+    content: "";
+    position: absolute;
+    inset-inline: clamp(1.25rem, 1.8vw, 2.5rem);
+    bottom: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, hsl(var(--sidebar-primary) / 0.35), transparent);
+  }
+
+  .sidebar-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--sidebar-hover-highlight)) transparent;
+  }
+
+  .sidebar-scroll::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .sidebar-scroll::-webkit-scrollbar-thumb {
+    background: hsl(var(--sidebar-hover-highlight));
+    border-radius: 999px;
+  }
+
+  .sidebar-nav-item {
+    border-radius: clamp(1rem, 1.6vw, 1.25rem);
+    background: transparent;
+    position: relative;
+  }
+
+  .sidebar-group-label {
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: hsl(var(--sidebar-text-muted) / 0.7);
+  }
+
+  .sidebar-nav-item[data-active="true"]::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--sidebar-item-active-bg);
+    box-shadow: var(--sidebar-item-active-shadow);
+    border: 1px solid hsl(var(--sidebar-primary) / 0.2);
+    opacity: 1;
+  }
+
+  .sidebar-nav-item[data-active="true"] .sidebar-nav-link {
+    color: hsl(var(--sidebar-primary));
+  }
+
+  .sidebar-nav-link {
+    position: relative;
+    z-index: 1;
+    transition: var(--transition-smooth);
+    font-weight: 600;
+    color: hsl(var(--sidebar-text-muted));
+  }
+
+  .sidebar-nav-link:hover {
+    background: hsl(var(--sidebar-item-hover-bg));
+    color: hsl(var(--sidebar-hover-foreground));
+    box-shadow: 0 12px 24px -12px hsl(var(--sidebar-primary) / 0.25);
+  }
+
+  .sidebar-subitem {
+    position: relative;
+    border-radius: 0.75rem;
+    transition: var(--transition-smooth);
+    color: hsl(var(--sidebar-text-muted));
+  }
+
+  .sidebar-subitem.is-active {
+    background: hsl(var(--sidebar-subitem-active-bg));
+    box-shadow: var(--sidebar-subitem-shadow);
+    color: hsl(var(--sidebar-primary));
+  }
+
+  .sidebar-subitem:hover {
+    background: hsl(var(--sidebar-subitem-hover-bg));
+    color: hsl(var(--sidebar-hover-foreground));
+  }
+
+  .sidebar-footer {
+    background: color-mix(in srgb, hsl(var(--sidebar-background)) 75%, transparent);
+    border-top: 1px solid hsl(var(--sidebar-border));
+  }
+
+  .card-premium {
+    position: relative;
+    overflow: hidden;
+    border-radius: clamp(1rem, 1.4vw, 1.5rem);
+    border: 1px solid hsl(var(--border));
+    background: linear-gradient(160deg, hsl(var(--card)) 10%, hsl(var(--card-elevated)) 90%);
+    box-shadow: var(--shadow-elevated);
+    transition: var(--transition-smooth);
+  }
+
+  .dark .card-premium {
+    background: linear-gradient(160deg, hsl(var(--card) / 0.98) 0%, hsl(var(--card-elevated) / 0.8) 100%);
+    border-color: hsl(var(--border) / 0.4);
+    box-shadow: var(--shadow-ambient);
+  }
+
+  .card-premium::after {
+    content: "";
+    position: absolute;
+    inset-inline: -50%;
+    top: -40%;
+    height: 60%;
+    background: radial-gradient(ellipse at center, hsl(var(--accent) / 0.15), transparent 70%);
+    transform: rotate(6deg);
+    pointer-events: none;
+  }
+
+  .card-premium:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-premium);
+  }
+
+  .btn-premium {
+    background: var(--gradient-primary);
+    color: hsl(var(--primary-foreground));
+    box-shadow: var(--shadow-premium);
+    border-radius: 1rem;
+    transition: var(--transition-premium);
+  }
+
+  .btn-premium:hover {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: var(--shadow-glow);
+  }
+
+  .dashboard-bento {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(1rem, 1.4vw, 1.75rem);
+  }
+
+  .dashboard-section-title {
+    font-size: clamp(1.25rem, 1.5vw, 1.5rem);
+    font-weight: 700;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-shell {
+    border-radius: 0;
+  }
+
+  .dashboard-scroll {
+    padding: 1.5rem;
+  }
+
+  .dashboard-inner {
+    gap: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dashboard shell stylesheet with day/night gradients, sidebar polish, and premium card treatments
- update AppShell, Header, and Sidebar to leverage the new shell structure and highlight the active theme
- reshape the dashboard home into a bento layout with reusable color tokens and refreshed chart/quick action blocks

## Testing
- npm run lint *(fails: existing lint issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e072d979f0832f89de93796a60a9d5