### PR TITLE
Ensure testimonial seed data has Arabic fallbacks

### DIFF
--- a/backend/database/seeders/InitialWebsiteSeeder.php
+++ b/backend/database/seeders/InitialWebsiteSeeder.php
@@ -976,12 +976,15 @@ class InitialWebsiteSeeder extends Seeder
         ];
 
         foreach ($testimonials as $testimonial) {
+            $english = $testimonial['en'] ?? [];
+            $arabic = array_merge($english, $testimonial['ar'] ?? []);
+
             $page->contentBlocks()->create([
                 'key' => sprintf('testimonial_%d', $testimonial['id']),
                 'type' => 'json',
                 'value' => [
-                    'ar' => $testimonial['ar'],
-                    'en' => $testimonial['en'],
+                    'ar' => $arabic,
+                    'en' => $english,
                 ],
             ]);
         }


### PR DESCRIPTION
## Summary
- ensure testimonial seed entries merge English defaults into the Arabic payload so no fields are missing in Arabic responses

## Testing
- php -l database/seeders/InitialWebsiteSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68e08b61c51c832fbee3687ae02416ba