### PR TITLE
feat: upgrade website management dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import ServicesPage from '@/pages/ServicesPage';
 import OfficeSettingsPage from '@/pages/OfficeSettingsPage';
 import NotFound from '@/pages/NotFound'; 
 import AdminWebsitePage from '@/pages/admin/Website/AdminWebsitePage';
+import WebsiteReportPage from '@/pages/admin/Website/WebsiteReportPage';
 
 // 🌀 نوع الأقسام المستقبلية
 type DashboardSectionKey =
@@ -84,6 +85,7 @@ const App = () => {
           {/* 🌐 Website Management */}
           <Route path="website">
             <Route index element={<Navigate to="pages" replace />} />
+            <Route path="report" element={<WebsiteReportPage />} />
             <Route path=":section" element={<AdminWebsitePage />} />
           </Route>
 

--- a/frontend/src/api/websiteAdmin.service.ts
+++ b/frontend/src/api/websiteAdmin.service.ts
@@ -1,5 +1,15 @@
 import api from '@/api/axiosConfig';
-import type { PageContent, TeamMemberApi, AchievementApi, Localized } from '@/types/website';
+import type {
+  AchievementApi,
+  ArticleApi,
+  Localized,
+  PageContent,
+  PageHistoryEntry,
+  PageStatus,
+  TeamMemberApi,
+  TestimonialApi,
+  WebsiteReportSummary,
+} from '@/types/website';
 
 const unwrap = <T>(payload: unknown): T => {
   if (payload && typeof payload === 'object' && 'data' in (payload as Record<string, unknown>)) {
@@ -28,6 +38,7 @@ export interface PageUpdatePayload {
   title_en?: string | null;
   title_ar?: string | null;
   content_blocks?: AdminContentBlockPayload[];
+  status?: PageStatus | null;
 }
 
 export const listWebsitePages = async (): Promise<PageContent[]> => {
@@ -43,6 +54,48 @@ export const getWebsitePage = async (slug: string): Promise<PageContent> => {
 export const updateWebsitePage = async (slug: string, payload: PageUpdatePayload): Promise<PageContent> => {
   const { data } = await api.put(`/api/admin/website/pages/${slug}`, payload);
   return unwrap<PageContent>(data);
+};
+
+export const previewWebsitePage = async (slug: string, payload?: PageUpdatePayload): Promise<PageContent> => {
+  const { data } = await api.post(`/api/admin/website/pages/${slug}/preview`, payload ?? {});
+  return unwrap<PageContent>(data);
+};
+
+export const publishWebsitePage = async (slug: string): Promise<PageContent> => {
+  const { data } = await api.post(`/api/admin/website/pages/${slug}/publish`);
+  return unwrap<PageContent>(data);
+};
+
+export const publishAllWebsitePages = async (): Promise<void> => {
+  await api.post('/api/admin/website/pages/publish-all');
+};
+
+export const getWebsitePageHistory = async (slug: string): Promise<PageHistoryEntry[]> => {
+  const { data } = await api.get(`/api/admin/website/pages/${slug}/history`);
+  return unwrapCollection<PageHistoryEntry>(data);
+};
+
+export interface UploadMediaResult {
+  url: string;
+  size: number;
+  filename?: string;
+  mime_type?: string;
+}
+
+export const uploadWebsiteMedia = async (file: File): Promise<UploadMediaResult> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const { data } = await api.post('/api/website/upload', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+
+  return unwrap<UploadMediaResult>(data);
+};
+
+export const getWebsiteReport = async (): Promise<WebsiteReportSummary> => {
+  const { data } = await api.get('/api/admin/website/report');
+  return unwrap<WebsiteReportSummary>(data);
 };
 
 export const getWebsiteSettings = async (): Promise<PageContent> => getWebsitePage('settings');
@@ -101,4 +154,64 @@ export const updateAchievement = async (id: number, payload: AchievementInput): 
 
 export const deleteAchievement = async (id: number): Promise<void> => {
   await api.delete(`/api/website/achievements/${id}`);
+};
+
+export interface ArticleInput {
+  title_en: string;
+  title_ar: string;
+  summary_en?: string | null;
+  summary_ar?: string | null;
+  body_en: string;
+  body_ar: string;
+  tag_en?: string | null;
+  tag_ar?: string | null;
+  cover_image?: string | null;
+}
+
+export const listArticles = async (): Promise<ArticleApi[]> => {
+  const { data } = await api.get('/api/admin/website/articles');
+  return unwrapCollection<ArticleApi>(data);
+};
+
+export const createArticle = async (payload: ArticleInput): Promise<ArticleApi> => {
+  const { data } = await api.post('/api/admin/website/articles', payload);
+  return unwrap<ArticleApi>(data);
+};
+
+export const updateArticle = async (id: number, payload: ArticleInput): Promise<ArticleApi> => {
+  const { data } = await api.put(`/api/admin/website/articles/${id}`, payload);
+  return unwrap<ArticleApi>(data);
+};
+
+export const deleteArticle = async (id: number): Promise<void> => {
+  await api.delete(`/api/admin/website/articles/${id}`);
+};
+
+export interface TestimonialInput {
+  name_en: string;
+  name_ar: string;
+  quote_en: string;
+  quote_ar: string;
+  position_en?: string | null;
+  position_ar?: string | null;
+  avatar?: string | null;
+}
+
+export const listTestimonials = async (): Promise<TestimonialApi[]> => {
+  const { data } = await api.get('/api/admin/website/testimonials');
+  return unwrapCollection<TestimonialApi>(data);
+};
+
+export const createTestimonial = async (payload: TestimonialInput): Promise<TestimonialApi> => {
+  const { data } = await api.post('/api/admin/website/testimonials', payload);
+  return unwrap<TestimonialApi>(data);
+};
+
+export const updateTestimonial = async (id: number, payload: TestimonialInput): Promise<TestimonialApi> => {
+  const { data } = await api.put(`/api/admin/website/testimonials/${id}`, payload);
+  return unwrap<TestimonialApi>(data);
+};
+
+export const deleteTestimonial = async (id: number): Promise<void> => {
+  await api.delete(`/api/admin/website/testimonials/${id}`);
 };

--- a/frontend/src/hooks/usePageManager.ts
+++ b/frontend/src/hooks/usePageManager.ts
@@ -1,0 +1,182 @@
+import { useCallback, useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  getWebsitePage,
+  getWebsitePageHistory,
+  previewWebsitePage,
+  publishWebsitePage,
+  updateWebsitePage,
+  type PageUpdatePayload,
+} from '@/api/websiteAdmin.service';
+import type { PageContent, PageHistoryEntry, PageStatus } from '@/types/website';
+
+interface UsePageManagerOptions {
+  enabled?: boolean;
+}
+
+interface SaveDraftOptions {
+  silent?: boolean;
+  status?: PageStatus;
+}
+
+interface UsePageManagerResult {
+  page: PageContent | undefined;
+  status: PageStatus;
+  history: PageHistoryEntry[];
+  isLoading: boolean;
+  isHistoryLoading: boolean;
+  isSaving: boolean;
+  isPublishing: boolean;
+  isPreviewing: boolean;
+  saveDraft: (payload: PageUpdatePayload, options?: SaveDraftOptions) => Promise<PageContent | undefined>;
+  publish: () => Promise<PageContent | undefined>;
+  requestPreview: (payload?: PageUpdatePayload) => Promise<PageContent | undefined>;
+  refresh: () => void;
+  error: unknown;
+}
+
+const deriveStatus = (page: PageContent | undefined): PageStatus => {
+  if (!page?.status) {
+    return 'draft';
+  }
+
+  return page.status;
+};
+
+export const usePageManager = (
+  slug: string,
+  options: UsePageManagerOptions = {},
+): UsePageManagerResult => {
+  const { enabled = true } = options;
+  const queryClient = useQueryClient();
+
+  const pageQuery = useQuery({
+    queryKey: ['admin-website-page', slug],
+    queryFn: () => getWebsitePage(slug),
+    enabled: Boolean(slug) && enabled,
+  });
+
+  const historyQuery = useQuery({
+    queryKey: ['admin-website-page-history', slug],
+    queryFn: () => getWebsitePageHistory(slug),
+    enabled: Boolean(slug) && enabled,
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: PageUpdatePayload) => updateWebsitePage(slug, payload),
+    onMutate: async (payload) => {
+      await queryClient.cancelQueries({ queryKey: ['admin-website-page', slug] });
+
+      const previousPage = queryClient.getQueryData<PageContent>(['admin-website-page', slug]);
+
+      const nextPage: PageContent | undefined = previousPage
+        ? {
+            ...previousPage,
+            title: {
+              en: payload.title_en ?? previousPage.title?.en ?? null,
+              ar: payload.title_ar ?? previousPage.title?.ar ?? null,
+            },
+            content_blocks: payload.content_blocks ?? previousPage.content_blocks ?? [],
+            status: payload.status ?? previousPage.status ?? 'draft',
+            updated_at: new Date().toISOString(),
+          }
+        : previousPage;
+
+      if (nextPage) {
+        queryClient.setQueryData(['admin-website-page', slug], nextPage);
+      }
+
+      return { previousPage };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousPage) {
+        queryClient.setQueryData(['admin-website-page', slug], context.previousPage);
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['admin-website-page', slug], data);
+      queryClient.invalidateQueries({ queryKey: ['admin-website-pages'] });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-page-history', slug] });
+    },
+  });
+
+  const publishMutation = useMutation({
+    mutationFn: () => publishWebsitePage(slug),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['admin-website-page', slug], data);
+      queryClient.invalidateQueries({ queryKey: ['admin-website-pages'] });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-page-history', slug] });
+    },
+  });
+
+  const previewMutation = useMutation({
+    mutationFn: (payload: PageUpdatePayload | undefined) => previewWebsitePage(slug, payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['admin-website-page', slug], data);
+      queryClient.invalidateQueries({ queryKey: ['admin-website-page-history', slug] });
+    },
+  });
+
+  const saveDraft = useCallback(
+    async (payload: PageUpdatePayload, saveOptions?: SaveDraftOptions) => {
+      const status = saveOptions?.status ?? payload.status ?? 'draft';
+      const mergedPayload: PageUpdatePayload = {
+        ...payload,
+        status,
+      };
+
+      try {
+        const data = await saveMutation.mutateAsync(mergedPayload);
+        if (!saveOptions?.silent) {
+          return data;
+        }
+        return data;
+      } catch (error) {
+        if (saveOptions?.silent) {
+          throw error;
+        }
+        throw error;
+      }
+    },
+    [saveMutation],
+  );
+
+  const publish = useCallback(async () => {
+    const data = await publishMutation.mutateAsync();
+    return data;
+  }, [publishMutation]);
+
+  const requestPreview = useCallback(
+    async (payload?: PageUpdatePayload) => {
+      const data = await previewMutation.mutateAsync(payload);
+      return data;
+    },
+    [previewMutation],
+  );
+
+  const refresh = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['admin-website-page', slug] });
+    queryClient.invalidateQueries({ queryKey: ['admin-website-page-history', slug] });
+  }, [queryClient, slug]);
+
+  const status = useMemo(() => deriveStatus(pageQuery.data), [pageQuery.data]);
+
+  return {
+    page: pageQuery.data,
+    status,
+    history: historyQuery.data ?? [],
+    isLoading: pageQuery.isLoading || pageQuery.isFetching,
+    isHistoryLoading: historyQuery.isLoading,
+    isSaving: saveMutation.isPending,
+    isPublishing: publishMutation.isPending,
+    isPreviewing: previewMutation.isPending,
+    saveDraft,
+    publish,
+    requestPreview,
+    refresh,
+    error: pageQuery.error,
+  };
+};
+
+export default usePageManager;

--- a/frontend/src/hooks/useWebsiteContent.ts
+++ b/frontend/src/hooks/useWebsiteContent.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
 import api from '@/api/axiosConfig';
 import type { ContentBlock, Localized, Locale, PageContent } from '@/types/website';
 
@@ -16,40 +18,16 @@ export interface UseWebsiteContentResult {
 }
 
 export function useWebsiteContent(slug: string): UseWebsiteContentResult {
-  const [data, setData] = useState<PageContent | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<Error | null>(null);
+  const query = useQuery({
+    queryKey: ['website-content', slug],
+    queryFn: async () => {
+      const response = await api.get(`/api/website/pages/${slug}`);
+      const payload = (response.data?.data ?? response.data) as PageContent | null;
+      return payload;
+    },
+  });
 
-  useEffect(() => {
-    let isCancelled = false;
-
-    setLoading(true);
-    setError(null);
-
-    api
-      .get(`/api/website/pages/${slug}`)
-      .then((response) => {
-        if (!isCancelled) {
-          const payload = (response.data?.data ?? response.data) as PageContent | null;
-          setData(payload);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!isCancelled) {
-          const normalized = err instanceof Error ? err : new Error('Failed to load content');
-          setError(normalized);
-        }
-      })
-      .finally(() => {
-        if (!isCancelled) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [slug]);
+  const data = query.data ?? null;
 
   const contentBlocks = useMemo<ContentBlock[]>(
     () => data?.content_blocks ?? data?.content ?? [],
@@ -86,8 +64,8 @@ export function useWebsiteContent(slug: string): UseWebsiteContentResult {
 
   return {
     data,
-    loading,
-    error,
+    loading: query.isLoading,
+    error: (query.error as Error | null) ?? null,
     contentBlocks,
     getLocalizedValue,
     getValueForLocale,

--- a/frontend/src/pages/admin/Website/AdminWebsitePage.tsx
+++ b/frontend/src/pages/admin/Website/AdminWebsitePage.tsx
@@ -7,6 +7,8 @@ import PagesManager from './components/PagesManager';
 import TeamManager from './components/TeamManager';
 import AchievementsManager from './components/AchievementsManager';
 import SettingsManager from './components/SettingsManager';
+import ArticlesManager from './components/ArticlesManager';
+import TestimonialsManager from './components/TestimonialsManager';
 
 const TABS = ['pages', 'team', 'achievements', 'settings'] as const;
 type TabValue = (typeof TABS)[number];
@@ -47,6 +49,8 @@ const AdminWebsitePage: React.FC = () => {
 
         <TabsContent value="pages" className="space-y-6">
           <PagesManager />
+          <ArticlesManager />
+          <TestimonialsManager />
         </TabsContent>
 
         <TabsContent value="team" className="space-y-6">

--- a/frontend/src/pages/admin/Website/WebsiteReportPage.tsx
+++ b/frontend/src/pages/admin/Website/WebsiteReportPage.tsx
@@ -1,0 +1,18 @@
+import PageHeader from '@/components/common/PageHeader';
+import ReportWidget from './components/ReportWidget';
+
+const WebsiteReportPage: React.FC = () => {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        iconKey="chart"
+        title="Website content report"
+        subtitle="Monitor publishing progress, outstanding drafts, and API connectivity for the marketing site."
+      />
+
+      <ReportWidget />
+    </div>
+  );
+};
+
+export default WebsiteReportPage;

--- a/frontend/src/pages/admin/Website/components/ArticlesManager.tsx
+++ b/frontend/src/pages/admin/Website/components/ArticlesManager.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+
+import {
+  createArticle,
+  deleteArticle,
+  listArticles,
+  updateArticle,
+  type ArticleInput,
+} from '@/api/websiteAdmin.service';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/use-toast';
+import type { ArticleApi } from '@/types/website';
+import UploadMedia from './UploadMedia';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+
+interface ArticleFormValues {
+  title_en: string;
+  title_ar: string;
+  summary_en: string;
+  summary_ar: string;
+  body_en: string;
+  body_ar: string;
+  tag_en: string;
+  tag_ar: string;
+  cover_image: string;
+}
+
+const emptyArticle: ArticleFormValues = {
+  title_en: '',
+  title_ar: '',
+  summary_en: '',
+  summary_ar: '',
+  body_en: '',
+  body_ar: '',
+  tag_en: '',
+  tag_ar: '',
+  cover_image: '',
+};
+
+const toPayload = (values: ArticleFormValues): ArticleInput => ({
+  title_en: values.title_en.trim(),
+  title_ar: values.title_ar.trim(),
+  summary_en: values.summary_en.trim() || null,
+  summary_ar: values.summary_ar.trim() || null,
+  body_en: values.body_en.trim(),
+  body_ar: values.body_ar.trim(),
+  tag_en: values.tag_en.trim() || null,
+  tag_ar: values.tag_ar.trim() || null,
+  cover_image: values.cover_image.trim() || null,
+});
+
+const toFormValues = (article: ArticleApi | null): ArticleFormValues => {
+  if (!article) {
+    return emptyArticle;
+  }
+
+  return {
+    title_en: article.title.en ?? '',
+    title_ar: article.title.ar ?? '',
+    summary_en: article.summary.en ?? '',
+    summary_ar: article.summary.ar ?? '',
+    body_en: article.body.en ?? '',
+    body_ar: article.body.ar ?? '',
+    tag_en: article.tag.en ?? '',
+    tag_ar: article.tag.ar ?? '',
+    cover_image: article.cover_image ?? '',
+  };
+};
+
+const ArticlesManager: React.FC = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const articlesQuery = useQuery({
+    queryKey: ['admin-website-articles'],
+    queryFn: listArticles,
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingArticle, setEditingArticle] = useState<ArticleApi | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<ArticleApi | null>(null);
+
+  const form = useForm<ArticleFormValues>({
+    defaultValues: emptyArticle,
+  });
+
+  useEffect(() => {
+    form.reset(toFormValues(editingArticle));
+  }, [editingArticle, form]);
+
+  const saveMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id?: number; payload: ArticleInput }) => {
+      if (id) {
+        return updateArticle(id, payload);
+      }
+      return createArticle(payload);
+    },
+    onSuccess: () => {
+      toast({ title: 'Article saved' });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-articles'] });
+      setDialogOpen(false);
+      setEditingArticle(null);
+    },
+    onError: () => {
+      toast({ title: 'Failed to save article', variant: 'destructive' });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteArticle(id),
+    onSuccess: () => {
+      toast({ title: 'Article removed' });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-articles'] });
+    },
+    onError: () => {
+      toast({ title: 'Unable to delete article', variant: 'destructive' });
+    },
+    onSettled: () => setPendingDelete(null),
+  });
+
+  const handleSubmit = (values: ArticleFormValues) => {
+    const payload = toPayload(values);
+    if (!payload.title_en || !payload.title_ar || !payload.body_en || !payload.body_ar) {
+      toast({ title: 'Title and body are required in both languages', variant: 'destructive' });
+      return;
+    }
+
+    const id = editingArticle?.id;
+    saveMutation.mutate({ id, payload });
+  };
+
+  const handleOpenDialog = (article: ArticleApi | null = null) => {
+    setEditingArticle(article);
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setEditingArticle(null);
+  };
+
+  const articles = useMemo(() => articlesQuery.data ?? [], [articlesQuery.data]);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle className="text-xl font-semibold">Articles</CardTitle>
+          <CardDescription>Manage insights and blog entries published on the marketing site.</CardDescription>
+        </div>
+        <Button type="button" onClick={() => handleOpenDialog(null)}>
+          <Plus className="mr-2 h-4 w-4" /> New article
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {articlesQuery.isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        ) : articles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No articles found.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title (EN)</TableHead>
+                  <TableHead>العنوان (AR)</TableHead>
+                  <TableHead>Tag</TableHead>
+                  <TableHead className="w-32 text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {articles.map((article) => (
+                  <TableRow key={article.id}>
+                    <TableCell className="font-medium">{article.title.en}</TableCell>
+                    <TableCell>{article.title.ar}</TableCell>
+                    <TableCell>{article.tag.en ?? article.tag.ar ?? '—'}</TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button variant="ghost" size="icon" onClick={() => handleOpenDialog(article)}>
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button variant="ghost" size="icon" onClick={() => setPendingDelete(article)}>
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{editingArticle ? 'Edit article' : 'Create article'}</DialogTitle>
+          </DialogHeader>
+
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-6"
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="title_en">Title (EN)</Label>
+                <Input id="title_en" {...form.register('title_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="title_ar">العنوان (AR)</Label>
+                <Input id="title_ar" dir="rtl" {...form.register('title_ar')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tag_en">Tag (EN)</Label>
+                <Input id="tag_en" {...form.register('tag_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tag_ar">الوسم (AR)</Label>
+                <Input id="tag_ar" dir="rtl" {...form.register('tag_ar')} />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="summary_en">Summary (EN)</Label>
+                <Textarea id="summary_en" rows={3} {...form.register('summary_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="summary_ar">الملخص (AR)</Label>
+                <Textarea id="summary_ar" rows={3} dir="rtl" {...form.register('summary_ar')} />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="body_en">Body (EN)</Label>
+                <Textarea id="body_en" rows={8} {...form.register('body_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="body_ar">المحتوى (AR)</Label>
+                <Textarea id="body_ar" rows={8} dir="rtl" {...form.register('body_ar')} />
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <UploadMedia
+                value={form.watch('cover_image')}
+                label="Cover image"
+                description="Upload a hero image that will be displayed on the articles grid."
+                onChange={(url) => form.setValue('cover_image', url, { shouldDirty: true })}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={handleCloseDialog}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saveMutation.isPending}>
+                {saveMutation.isPending ? 'Saving…' : 'Save article'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        title="Delete article"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        loading={deleteMutation.isPending}
+        onConfirm={() => pendingDelete && deleteMutation.mutate(pendingDelete.id)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDelete(null);
+          }
+        }}
+      />
+    </Card>
+  );
+};
+
+export default ArticlesManager;

--- a/frontend/src/pages/admin/Website/components/BlockManager.tsx
+++ b/frontend/src/pages/admin/Website/components/BlockManager.tsx
@@ -1,0 +1,165 @@
+import { Fragment } from 'react';
+import type { Control, FieldArrayWithId, UseFieldArrayReturn, UseFormReturn } from 'react-hook-form';
+import { ArrowDown, ArrowUp, Plus, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+import JSONBlockEditor from './PageEditor/JSONBlockEditor';
+import MediaFieldEditor from './PageEditor/MediaFieldEditor';
+import TextFieldEditor from './PageEditor/TextFieldEditor';
+import type { PageFormValues } from './PageEditor/types';
+
+const BLOCK_TYPES = [
+  { value: 'text', label: 'Text block' },
+  { value: 'list', label: 'List block' },
+  { value: 'json', label: 'JSON block' },
+  { value: 'image', label: 'Image asset' },
+  { value: 'media', label: 'Media asset' },
+];
+
+interface BlockManagerProps {
+  form: UseFormReturn<PageFormValues>;
+  control: Control<PageFormValues>;
+  fields: FieldArrayWithId<PageFormValues, 'blocks', 'id'>[];
+  fieldArray: UseFieldArrayReturn<PageFormValues, 'blocks', 'id'>;
+}
+
+const BlockManager: React.FC<BlockManagerProps> = ({ form, control, fields, fieldArray }) => {
+  const { append, remove, move } = fieldArray;
+
+  const handleAddBlock = (type: string) => {
+    append({ key: '', type, value_en: '', value_ar: '' });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-lg font-semibold">Content blocks</CardTitle>
+            <CardDescription>Manage localized content modules for the selected page.</CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" size="sm" onClick={() => handleAddBlock('text')}>
+              <Plus className="mr-2 h-4 w-4" /> Add block
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {fields.length === 0 ? (
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle className="text-base font-semibold">No content blocks yet</CardTitle>
+            <CardDescription>Add your first block to start composing this page.</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
+      {fields.map((field, index) => {
+        const type = form.watch(`blocks.${index}.type`) ?? 'text';
+
+        return (
+          <Fragment key={field.id}>
+            <Card className="border-border/60">
+              <CardHeader className="space-y-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex-1 space-y-3">
+                    <FormField
+                      control={control}
+                      name={`blocks.${index}.key`}
+                      render={({ field: keyField }) => (
+                        <FormItem>
+                          <FormLabel>Block key</FormLabel>
+                          <FormControl>
+                            <Input placeholder="hero_headline" {...keyField} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-2 sm:w-60">
+                    <FormField
+                      control={control}
+                      name={`blocks.${index}.type`}
+                      render={({ field: typeField }) => (
+                        <FormItem>
+                          <FormLabel>Type</FormLabel>
+                          <Select value={typeField.value ?? 'text'} onValueChange={(value) => typeField.onChange(value)}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select block type" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {BLOCK_TYPES.map((blockType) => (
+                                <SelectItem key={blockType.value} value={blockType.value}>
+                                  {blockType.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => move(index, Math.max(0, index - 1))}
+                        disabled={index === 0}
+                        aria-label="Move block up"
+                      >
+                        <ArrowUp className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => move(index, Math.min(fields.length - 1, index + 1))}
+                        disabled={index === fields.length - 1}
+                        aria-label="Move block down"
+                      >
+                        <ArrowDown className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => remove(index)}
+                        aria-label="Remove block"
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </CardHeader>
+
+              <CardContent className="space-y-4">
+                {type === 'json' ? (
+                  <JSONBlockEditor control={control} index={index} />
+                ) : type === 'image' || type === 'media' ? (
+                  <MediaFieldEditor control={control} form={form} index={index} />
+                ) : (
+                  <TextFieldEditor control={control} index={index} type={type} />
+                )}
+              </CardContent>
+            </Card>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+export default BlockManager;

--- a/frontend/src/pages/admin/Website/components/PageEditor/JSONBlockEditor.tsx
+++ b/frontend/src/pages/admin/Website/components/PageEditor/JSONBlockEditor.tsx
@@ -1,0 +1,47 @@
+import type { Control } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
+
+import type { PageFormValues } from './types';
+
+interface JSONBlockEditorProps {
+  control: Control<PageFormValues>;
+  index: number;
+}
+
+const JSONBlockEditor: React.FC<JSONBlockEditorProps> = ({ control, index }) => {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <FormField
+        control={control}
+        name={`blocks.${index}.value_en`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>English JSON</FormLabel>
+            <FormControl>
+              <Textarea rows={12} {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name={`blocks.${index}.value_ar`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Arabic JSON</FormLabel>
+            <FormControl>
+              <Textarea rows={12} dir="rtl" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};
+
+export default JSONBlockEditor;

--- a/frontend/src/pages/admin/Website/components/PageEditor/MediaFieldEditor.tsx
+++ b/frontend/src/pages/admin/Website/components/PageEditor/MediaFieldEditor.tsx
@@ -1,0 +1,61 @@
+import type { Control, UseFormReturn } from 'react-hook-form';
+
+import UploadMedia from '../UploadMedia';
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+
+import type { PageFormValues } from './types';
+
+interface MediaFieldEditorProps {
+  control: Control<PageFormValues>;
+  form: UseFormReturn<PageFormValues>;
+  index: number;
+}
+
+const MediaFieldEditor: React.FC<MediaFieldEditorProps> = ({ control, form, index }) => {
+  const valueEn = form.watch(`blocks.${index}.value_en`);
+  const valueAr = form.watch(`blocks.${index}.value_ar`);
+
+  const handleUpload = (url: string) => {
+    form.setValue(`blocks.${index}.value_en`, url, { shouldDirty: true });
+    form.setValue(`blocks.${index}.value_ar`, url, { shouldDirty: true });
+  };
+
+  return (
+    <div className="space-y-4">
+      <UploadMedia value={valueEn || valueAr || ''} onChange={handleUpload} />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <FormField
+          control={control}
+          name={`blocks.${index}.value_en`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Media URL (EN)</FormLabel>
+              <FormControl>
+                <Input placeholder="https://" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name={`blocks.${index}.value_ar`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>رابط الوسائط (AR)</FormLabel>
+              <FormControl>
+                <Input dir="rtl" placeholder="https://" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MediaFieldEditor;

--- a/frontend/src/pages/admin/Website/components/PageEditor/PageEditor.tsx
+++ b/frontend/src/pages/admin/Website/components/PageEditor/PageEditor.tsx
@@ -1,0 +1,408 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useFieldArray, useForm, useWatch } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/use-toast';
+import BlockManager from '../BlockManager';
+import PreviewPane from './PreviewPane';
+import type { PageFormValues } from './types';
+import usePageManager from '@/hooks/usePageManager';
+import type { ContentBlock, Localized } from '@/types/website';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+
+interface PageEditorProps {
+  slug: string;
+  title?: string;
+  description?: string;
+}
+
+const defaultValues: PageFormValues = {
+  title_en: '',
+  title_ar: '',
+  blocks: [],
+};
+
+const serializeValue = (value: unknown, type: string | null | undefined): string => {
+  if (type === 'list') {
+    if (Array.isArray(value)) {
+      return value.join('\n');
+    }
+    return '';
+  }
+
+  if (type === 'json') {
+    if (value === null || value === undefined) {
+      return '';
+    }
+
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (error) {
+      return String(value ?? '');
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value);
+};
+
+const deserializeValue = (input: string, type: string | null | undefined): unknown => {
+  if (type === 'list') {
+    return input
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  if (type === 'json') {
+    if (!input.trim()) {
+      return null;
+    }
+
+    return JSON.parse(input);
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed.length) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const createFormValues = (page: { content_blocks?: ContentBlock[]; title?: Localized<string | null> } | undefined): PageFormValues => {
+  if (!page) {
+    return {
+      title_en: '',
+      title_ar: '',
+      blocks: [],
+    };
+  }
+
+  return {
+    title_en: page.title?.en ?? '',
+    title_ar: page.title?.ar ?? '',
+    blocks: (page.content_blocks ?? []).map((block) => ({
+      id: String(block.id ?? block.key ?? Math.random()),
+      key: block.key,
+      type: block.type ?? 'text',
+      value_en: serializeValue(block.value?.en ?? '', block.type),
+      value_ar: serializeValue(block.value?.ar ?? '', block.type),
+    })),
+  };
+};
+
+const toContentBlocks = (values: PageFormValues): ContentBlock[] => {
+  return values.blocks.map((block, index) => {
+    const type = block.type ?? 'text';
+
+    const parseValue = (input: string, fallback: unknown) => {
+      try {
+        return deserializeValue(input ?? '', type);
+      } catch (error) {
+        return fallback;
+      }
+    };
+
+    const valueEn = parseValue(block.value_en ?? '', block.value_en);
+    const valueAr = parseValue(block.value_ar ?? '', block.value_ar);
+
+    return {
+      key: block.key || `block_${index + 1}`,
+      type,
+      value: {
+        en: valueEn,
+        ar: valueAr,
+      },
+    };
+  });
+};
+
+const toPayload = (values: PageFormValues) => {
+    const contentBlocks = values.blocks.map((block) => {
+      const type = block.type ?? 'text';
+      const valueEn = deserializeValue(block.value_en ?? '', type);
+      const valueAr = deserializeValue(block.value_ar ?? '', type);
+
+    return {
+      key: block.key,
+      type,
+      value: {
+        en: valueEn,
+        ar: valueAr,
+      },
+    };
+  });
+
+  return {
+    title_en: values.title_en ?? null,
+    title_ar: values.title_ar ?? null,
+    content_blocks: contentBlocks,
+  };
+};
+
+const formatTimestamp = (input: string | null | undefined) => {
+  if (!input) {
+    return '—';
+  }
+
+  try {
+    const date = new Date(input);
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  } catch (error) {
+    return input;
+  }
+};
+
+const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => {
+  const { toast } = useToast();
+  const { page, status, history, isLoading, isSaving, isPublishing, isPreviewing, saveDraft, publish, requestPreview } =
+    usePageManager(slug);
+
+  const form = useForm<PageFormValues>({
+    defaultValues,
+  });
+
+  const fieldArray = useFieldArray({
+    control: form.control,
+    name: 'blocks',
+  });
+
+  const watchedValues = useWatch({ control: form.control }) as PageFormValues | undefined;
+  const previewValues = watchedValues ?? defaultValues;
+  const previewBlocks = useMemo(() => toContentBlocks(previewValues), [previewValues]);
+  const previewTitle = useMemo<Localized<string | null>>(
+    () => ({
+      en: previewValues.title_en || page?.title?.en || slug,
+      ar: previewValues.title_ar || page?.title?.ar || null,
+    }),
+    [page?.title?.ar, page?.title?.en, previewValues.title_ar, previewValues.title_en, slug],
+  );
+
+  const lastSnapshotRef = useRef<string>('');
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!page) {
+      return;
+    }
+
+    const formValues = createFormValues(page);
+    form.reset(formValues);
+    lastSnapshotRef.current = JSON.stringify(formValues);
+  }, [page, form]);
+
+  useEffect(() => {
+    const subscription = form.watch((values) => {
+      const serialized = JSON.stringify(values);
+
+      if (!serialized || serialized === lastSnapshotRef.current) {
+        return;
+      }
+
+      if (autosaveTimer.current) {
+        clearTimeout(autosaveTimer.current);
+      }
+
+      const payload = toPayload(values);
+      autosaveTimer.current = setTimeout(() => {
+        void saveDraft(payload, { silent: true })
+          .then(() => {
+            lastSnapshotRef.current = serialized;
+          })
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : 'Failed to autosave changes';
+            toast({ title: 'Autosave failed', description: message, variant: 'destructive' });
+          });
+      }, 2000);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+      if (autosaveTimer.current) {
+        clearTimeout(autosaveTimer.current);
+      }
+    };
+  }, [form, saveDraft, toast]);
+
+  const handleManualSave = (values: PageFormValues) => {
+    try {
+      const missingKey = values.blocks.find((block) => !block.key.trim());
+      if (missingKey) {
+        toast({ title: 'Each block needs a key', description: 'Please provide a unique key for every block.', variant: 'destructive' });
+        return;
+      }
+
+      const payload = toPayload(values);
+      saveDraft(payload, { status: 'draft' })
+        .then(() => {
+          toast({ title: 'Draft saved successfully' });
+          lastSnapshotRef.current = JSON.stringify(values);
+        })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : 'Unable to save draft';
+          toast({ title: 'Save failed', description: message, variant: 'destructive' });
+        });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to prepare payload';
+      toast({ title: 'Validation error', description: message, variant: 'destructive' });
+    }
+  };
+
+  const handlePublish = async () => {
+    try {
+      await publish();
+      toast({ title: 'Page published successfully' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to publish page';
+      toast({ title: 'Publish failed', description: message, variant: 'destructive' });
+    }
+  };
+
+  const handlePreview = async () => {
+    try {
+      const values = form.getValues();
+      const payload = toPayload(values);
+      await requestPreview(payload);
+      toast({ title: 'Preview link updated' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to generate preview';
+      toast({ title: 'Preview failed', description: message, variant: 'destructive' });
+    }
+  };
+
+  if (!slug) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+      <div className="space-y-6">
+        {title || description ? (
+          <div className="space-y-1">
+            {title ? <h2 className="text-xl font-semibold text-foreground">{title}</h2> : null}
+            {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-10 w-1/3" />
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+        ) : null}
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleManualSave)} className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold">Meta information</CardTitle>
+                <CardDescription>Control localized page titles for navigation and previews.</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="title_en"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Page title (EN)</FormLabel>
+                      <Input placeholder="Optional English title" {...field} />
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="title_ar"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>عنوان الصفحة (AR)</FormLabel>
+                      <Input dir="rtl" placeholder="عنوان اختياري" {...field} />
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </CardContent>
+            </Card>
+
+            <BlockManager form={form} control={form.control} fields={fieldArray.fields} fieldArray={fieldArray} />
+
+            <CardFooter className="flex items-center justify-end gap-3 border-t bg-muted/30 py-4">
+              <Badge variant="outline">Autosaving every 2s when changes detected</Badge>
+              <Button type="button" variant="outline" onClick={handlePreview} disabled={isPreviewing}>
+                {isPreviewing ? 'Generating preview…' : 'Preview draft'}
+              </Button>
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? 'Saving…' : 'Save draft'}
+              </Button>
+            </CardFooter>
+          </form>
+        </Form>
+      </div>
+
+      <div className="space-y-6">
+        <PreviewPane
+          title={previewTitle}
+          blocks={previewBlocks}
+          status={status}
+          previewUrl={page?.preview_url ?? null}
+          isPreviewing={isPreviewing}
+          isPublishing={isPublishing}
+          onPreview={handlePreview}
+          onPublish={handlePublish}
+        />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold">Version history</CardTitle>
+            <CardDescription>Review autosaved versions and published checkpoints.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {history.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No previous versions recorded yet.</p>
+            ) : (
+              history.map((entry) => (
+                <div key={entry.id} className="space-y-1 rounded-lg border border-border/60 p-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">v{entry.version}</span>
+                      <span className="text-muted-foreground">{entry.status}</span>
+                    </div>
+                    <span className="text-xs text-muted-foreground">{formatTimestamp(entry.updated_at ?? entry.created_at)}</span>
+                  </div>
+                  {entry.editor ? (
+                    <p className="text-xs text-muted-foreground">Edited by {entry.editor}</p>
+                  ) : null}
+                  {entry.notes ? <p className="text-xs text-muted-foreground">{entry.notes}</p> : null}
+                </div>
+              ))
+            )}
+          </CardContent>
+          <Separator />
+          <CardFooter>
+            <p className="text-xs text-muted-foreground">History is sourced from /api/admin/website/pages/{slug}/history.</p>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default PageEditor;

--- a/frontend/src/pages/admin/Website/components/PageEditor/PreviewPane.tsx
+++ b/frontend/src/pages/admin/Website/components/PageEditor/PreviewPane.tsx
@@ -1,0 +1,108 @@
+import { ExternalLink, Play, Send } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { ContentBlock, Localized, PageStatus } from '@/types/website';
+
+import PreviewLandingSection from '../PreviewLandingSection';
+
+interface PreviewPaneProps {
+  title?: Localized<string | null>;
+  blocks: ContentBlock[];
+  status: PageStatus;
+  isPreviewing?: boolean;
+  isPublishing?: boolean;
+  previewUrl?: string | null;
+  onPreview?: () => void;
+  onPublish?: () => void;
+}
+
+const getStatusMeta = (status: PageStatus) => {
+  switch (status) {
+    case 'published':
+      return { label: 'Published', tone: 'bg-emerald-100 text-emerald-800', icon: '🟢' };
+    case 'preview':
+      return { label: 'Preview', tone: 'bg-blue-100 text-blue-800', icon: '🔵' };
+    case 'unlinked':
+      return { label: 'Unlinked', tone: 'bg-red-100 text-red-800', icon: '🔴' };
+    default:
+      return { label: 'Draft', tone: 'bg-amber-100 text-amber-800', icon: '🟡' };
+  }
+};
+
+const PreviewPane: React.FC<PreviewPaneProps> = ({
+  title,
+  blocks,
+  status,
+  isPreviewing,
+  isPublishing,
+  previewUrl,
+  onPreview,
+  onPublish,
+}) => {
+  const statusMeta = getStatusMeta(status);
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg font-semibold">Live preview</CardTitle>
+          <Badge className={`${statusMeta.tone} font-medium`}>{statusMeta.icon} {statusMeta.label}</Badge>
+        </div>
+        <CardDescription>Review localized content before sharing changes with the world.</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <Tabs defaultValue="en" className="space-y-4">
+          <TabsList className="w-full justify-start">
+            <TabsTrigger value="en">English</TabsTrigger>
+            <TabsTrigger value="ar">العربية</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="en" className="space-y-3">
+            <PreviewLandingSection locale="en" title={title?.en ?? ''} blocks={blocks} />
+          </TabsContent>
+
+          <TabsContent value="ar" className="space-y-3">
+            <div dir="rtl">
+              <PreviewLandingSection locale="ar" title={title?.ar ?? ''} blocks={blocks} />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+
+      <Separator />
+
+      <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {previewUrl ? (
+          <a
+            href={previewUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+          >
+            <ExternalLink className="h-4 w-4" /> Preview link
+          </a>
+        ) : (
+          <p className="text-sm text-muted-foreground">Preview links are generated when you request a preview.</p>
+        )}
+
+        <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button variant="outline" size="sm" onClick={onPreview} disabled={isPreviewing}>
+            <Play className="mr-2 h-4 w-4" />
+            {isPreviewing ? 'Generating…' : 'Preview changes'}
+          </Button>
+          <Button size="sm" onClick={onPublish} disabled={isPublishing}>
+            <Send className="mr-2 h-4 w-4" />
+            {isPublishing ? 'Publishing…' : 'Publish'}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default PreviewPane;

--- a/frontend/src/pages/admin/Website/components/PageEditor/TextFieldEditor.tsx
+++ b/frontend/src/pages/admin/Website/components/PageEditor/TextFieldEditor.tsx
@@ -1,0 +1,58 @@
+import type { Control } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
+
+import type { PageFormValues } from './types';
+
+interface TextFieldEditorProps {
+  control: Control<PageFormValues>;
+  index: number;
+  type?: string | null;
+}
+
+const resolveRows = (type: string | null | undefined) => {
+  if (type === 'list') {
+    return 6;
+  }
+
+  return 4;
+};
+
+const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ control, index, type }) => {
+  const labelSuffix = type === 'list' ? ' (one item per line)' : '';
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <FormField
+        control={control}
+        name={`blocks.${index}.value_en`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>English{labelSuffix}</FormLabel>
+            <FormControl>
+              <Textarea rows={resolveRows(type)} {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name={`blocks.${index}.value_ar`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Arabic{labelSuffix}</FormLabel>
+            <FormControl>
+              <Textarea rows={resolveRows(type)} dir="rtl" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};
+
+export default TextFieldEditor;

--- a/frontend/src/pages/admin/Website/components/PageEditor/types.ts
+++ b/frontend/src/pages/admin/Website/components/PageEditor/types.ts
@@ -1,0 +1,13 @@
+export interface BlockFormValue {
+  id?: string;
+  key: string;
+  type: string | null;
+  value_en: string;
+  value_ar: string;
+}
+
+export interface PageFormValues {
+  title_en: string;
+  title_ar: string;
+  blocks: BlockFormValue[];
+}

--- a/frontend/src/pages/admin/Website/components/PagesManager.tsx
+++ b/frontend/src/pages/admin/Website/components/PagesManager.tsx
@@ -1,19 +1,43 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
-import { listWebsitePages } from '@/api/websiteAdmin.service';
+import { listWebsitePages, publishAllWebsitePages } from '@/api/websiteAdmin.service';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import PageEditor from './PageEditor';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/components/ui/use-toast';
+import type { PageStatus } from '@/types/website';
+import PageEditor from './PageEditor/PageEditor';
 
 const PagesManager: React.FC = () => {
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
   const pagesQuery = useQuery({
     queryKey: ['admin-website-pages'],
     queryFn: listWebsitePages,
   });
 
-  const pages = pagesQuery.data ?? [];
+  const pages = useMemo(() => pagesQuery.data ?? [], [pagesQuery.data]);
   const [selectedSlug, setSelectedSlug] = useState('');
+
+  const publishAllMutation = useMutation({
+    mutationFn: publishAllWebsitePages,
+    onSuccess: () => {
+      toast({ title: 'All staged changes published' });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-pages'] });
+      if (selectedSlug) {
+        queryClient.invalidateQueries({ queryKey: ['admin-website-page', selectedSlug] });
+      }
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Unable to publish all changes';
+      toast({ title: 'Bulk publish failed', description: message, variant: 'destructive' });
+    },
+  });
 
   useEffect(() => {
     if (!pages.length) {
@@ -21,8 +45,11 @@ const PagesManager: React.FC = () => {
     }
 
     if (!selectedSlug) {
-      const landing = pages.find((page) => page.slug === 'landing');
-      setSelectedSlug((landing ?? pages[0]).slug);
+      const preferredOrder = ['home', 'landing'];
+      const preferredPage = preferredOrder
+        .map((slug) => pages.find((page) => page.slug === slug))
+        .find((page) => Boolean(page));
+      setSelectedSlug((preferredPage ?? pages[0]).slug);
     } else if (!pages.some((page) => page.slug === selectedSlug)) {
       setSelectedSlug(pages[0].slug);
     }
@@ -33,32 +60,59 @@ const PagesManager: React.FC = () => {
     [pages, selectedSlug],
   );
 
+  const renderStatusBadge = (status?: PageStatus) => {
+    switch (status) {
+      case 'published':
+        return <Badge className="bg-emerald-100 text-emerald-800">🟢 Published</Badge>;
+      case 'preview':
+        return <Badge className="bg-blue-100 text-blue-800">🔵 Preview</Badge>;
+      case 'unlinked':
+        return <Badge className="bg-red-100 text-red-800">🔴 Unlinked</Badge>;
+      default:
+        return <Badge className="bg-amber-100 text-amber-800">🟡 Draft</Badge>;
+    }
+  };
+
   return (
     <div className="space-y-6">
-      <div className="w-full md:w-72">
-        {pagesQuery.isLoading ? (
-          <Skeleton className="h-10 w-full" />
-        ) : (
-          <Select value={selectedSlug} onValueChange={setSelectedSlug}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select page" />
-            </SelectTrigger>
-            <SelectContent>
-              {pages.map((page) => (
-                <SelectItem key={page.slug} value={page.slug}>
-                  {page.title?.en ?? page.slug}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="w-full md:w-80">
+          {pagesQuery.isLoading ? (
+            <Skeleton className="h-10 w-full" />
+          ) : (
+            <Select value={selectedSlug} onValueChange={setSelectedSlug}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select page" />
+              </SelectTrigger>
+              <SelectContent>
+                {pages.map((page) => (
+                  <SelectItem key={page.slug} value={page.slug}>
+                    <div className="flex items-center justify-between gap-2">
+                      <span>{page.title?.en ?? page.slug}</span>
+                      {renderStatusBadge(page.status)}
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={() => navigate('/dashboard/website/report')}>
+            View report
+          </Button>
+          <Button type="button" onClick={() => publishAllMutation.mutate()} disabled={publishAllMutation.isPending}>
+            {publishAllMutation.isPending ? 'Publishing…' : 'Publish all changes'}
+          </Button>
+        </div>
       </div>
 
       {selectedSlug ? (
         <PageEditor
           slug={selectedSlug}
           title={selectedPage?.title?.en ?? selectedSlug}
-          description="Edit localized content blocks for the selected landing page section."
+          description="Edit localized content blocks, stage drafts, and publish updates."
         />
       ) : null}
     </div>

--- a/frontend/src/pages/admin/Website/components/PreviewLandingSection.tsx
+++ b/frontend/src/pages/admin/Website/components/PreviewLandingSection.tsx
@@ -1,0 +1,73 @@
+import type { ContentBlock, Locale } from '@/types/website';
+
+interface PreviewLandingSectionProps {
+  locale: Locale;
+  title?: string | null;
+  blocks: ContentBlock[];
+}
+
+const renderValue = (value: unknown, type: string | null | undefined) => {
+  if (type === 'json' && value) {
+    try {
+      return <pre className="rounded-md bg-muted/60 p-3 text-xs">{JSON.stringify(value, null, 2)}</pre>;
+    } catch (error) {
+      return <pre className="rounded-md bg-muted/60 p-3 text-xs">{String(value)}</pre>;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <ul className="list-disc space-y-1 pl-6 text-sm">
+        {value.map((item, index) => (
+          <li key={`${index}-${String(item)}`}>{String(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (typeof value === 'string') {
+    const isImage = type?.includes('image') || type?.includes('media') || /\.(png|jpe?g|gif|webp|svg)$/i.test(value);
+    if (isImage) {
+      return (
+        <div className="overflow-hidden rounded-lg border bg-background">
+          <img src={value} alt="Preview asset" className="h-48 w-full object-cover" />
+        </div>
+      );
+    }
+
+    return <p className="text-sm leading-relaxed">{value}</p>;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return <p className="text-sm font-medium">{String(value)}</p>;
+  }
+
+  if (!value) {
+    return <p className="text-sm italic text-muted-foreground">Empty value</p>;
+  }
+
+  return <pre className="rounded-md bg-muted/60 p-3 text-xs">{JSON.stringify(value, null, 2)}</pre>;
+};
+
+const PreviewLandingSection: React.FC<PreviewLandingSectionProps> = ({ locale, title, blocks }) => {
+  return (
+    <div className="space-y-4">
+      {title ? <h3 className="text-lg font-semibold text-foreground">{title}</h3> : null}
+
+      <div className="space-y-4">
+        {blocks.map((block, index) => {
+          const localized = block.value?.[locale];
+
+          return (
+            <div key={`${block.key ?? 'block'}-${locale}-${index}`} className="space-y-1">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{block.key}</p>
+              {renderValue(localized, block.type)}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PreviewLandingSection;

--- a/frontend/src/pages/admin/Website/components/ReportWidget.tsx
+++ b/frontend/src/pages/admin/Website/components/ReportWidget.tsx
@@ -1,0 +1,156 @@
+import { useQuery } from '@tanstack/react-query';
+import { Activity, AlertTriangle, CheckCircle2, Clock } from 'lucide-react';
+
+import { getWebsiteReport } from '@/api/websiteAdmin.service';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const ReportWidget: React.FC = () => {
+  const reportQuery = useQuery({
+    queryKey: ['admin-website-report'],
+    queryFn: getWebsiteReport,
+  });
+
+  const report = reportQuery.data;
+
+  if (reportQuery.isLoading) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card key={index}>
+            <CardHeader>
+              <Skeleton className="h-4 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (reportQuery.isError || !report) {
+    return (
+      <Card className="border-red-200 bg-red-50">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-red-700">
+            <AlertTriangle className="h-5 w-5" /> Unable to load report
+          </CardTitle>
+          <CardDescription className="text-red-600">
+            Check API connectivity for /api/admin/website/report and try again.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const completion = Math.round(report.completionRate ?? 0);
+  const apiStatus = report.apiHealthy ? (
+    <Badge className="bg-emerald-100 text-emerald-800">Connected</Badge>
+  ) : (
+    <Badge className="bg-red-100 text-red-800">Unavailable</Badge>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Activity className="h-4 w-4" /> Completion
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="text-3xl font-semibold">{completion}%</div>
+            <Progress value={completion} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Clock className="h-4 w-4" /> Last edited
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-lg font-semibold text-foreground">
+              {report.lastEditedAt ? new Date(report.lastEditedAt).toLocaleString() : 'No edits recorded'}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <CheckCircle2 className="h-4 w-4" /> Completed pages
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-lg font-semibold text-foreground">
+              {report.completedPages} / {report.totalPages}
+            </p>
+            <p className="text-xs text-muted-foreground">Pending drafts: {report.pendingDrafts}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-sm font-medium text-muted-foreground">API status</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {apiStatus}
+            <p className="text-xs text-muted-foreground">Monitored endpoint: /api/admin/website/report</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold">Section progress</CardTitle>
+          <CardDescription>Track how each landing page module is progressing toward publication.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {report.sections.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No sections available.</p>
+          ) : (
+            report.sections.map((section) => {
+              const progress = Math.round(section.completion);
+              return (
+                <div key={section.slug} className="space-y-2 rounded-lg border border-border/60 p-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-foreground">{section.title}</span>
+                      {renderStatus(section.status)}
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      Last update: {section.updated_at ? new Date(section.updated_at).toLocaleString() : '—'}
+                    </span>
+                  </div>
+                  <Progress value={progress} />
+                </div>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+const renderStatus = (status: string) => {
+  switch (status) {
+    case 'published':
+      return <Badge className="bg-emerald-100 text-emerald-800">🟢 Published</Badge>;
+    case 'preview':
+      return <Badge className="bg-blue-100 text-blue-800">🔵 Preview</Badge>;
+    case 'unlinked':
+      return <Badge className="bg-red-100 text-red-800">🔴 Unlinked</Badge>;
+    default:
+      return <Badge className="bg-amber-100 text-amber-800">🟡 Draft</Badge>;
+  }
+};
+
+export default ReportWidget;

--- a/frontend/src/pages/admin/Website/components/SettingsManager.tsx
+++ b/frontend/src/pages/admin/Website/components/SettingsManager.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { resolveAssetUrl } from '@/utils/asset';
-import PageEditor from './PageEditor';
+import PageEditor from './PageEditor/PageEditor';
 import { getWebsitePage } from '@/api/websiteAdmin.service';
 import type { ContentBlock, Locale, Localized, PageContent } from '@/types/website';
 

--- a/frontend/src/pages/admin/Website/components/TestimonialsManager.tsx
+++ b/frontend/src/pages/admin/Website/components/TestimonialsManager.tsx
@@ -1,0 +1,280 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+
+import {
+  createTestimonial,
+  deleteTestimonial,
+  listTestimonials,
+  updateTestimonial,
+  type TestimonialInput,
+} from '@/api/websiteAdmin.service';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/use-toast';
+import type { TestimonialApi } from '@/types/website';
+import UploadMedia from './UploadMedia';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+
+interface TestimonialFormValues {
+  name_en: string;
+  name_ar: string;
+  quote_en: string;
+  quote_ar: string;
+  position_en: string;
+  position_ar: string;
+  avatar: string;
+}
+
+const emptyTestimonial: TestimonialFormValues = {
+  name_en: '',
+  name_ar: '',
+  quote_en: '',
+  quote_ar: '',
+  position_en: '',
+  position_ar: '',
+  avatar: '',
+};
+
+const toPayload = (values: TestimonialFormValues): TestimonialInput => ({
+  name_en: values.name_en.trim(),
+  name_ar: values.name_ar.trim(),
+  quote_en: values.quote_en.trim(),
+  quote_ar: values.quote_ar.trim(),
+  position_en: values.position_en.trim() || null,
+  position_ar: values.position_ar.trim() || null,
+  avatar: values.avatar.trim() || null,
+});
+
+const toFormValues = (testimonial: TestimonialApi | null): TestimonialFormValues => {
+  if (!testimonial) {
+    return emptyTestimonial;
+  }
+
+  return {
+    name_en: testimonial.name.en ?? '',
+    name_ar: testimonial.name.ar ?? '',
+    quote_en: testimonial.quote.en ?? '',
+    quote_ar: testimonial.quote.ar ?? '',
+    position_en: testimonial.position.en ?? '',
+    position_ar: testimonial.position.ar ?? '',
+    avatar: testimonial.avatar ?? '',
+  };
+};
+
+const TestimonialsManager: React.FC = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const testimonialsQuery = useQuery({
+    queryKey: ['admin-website-testimonials'],
+    queryFn: listTestimonials,
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTestimonial, setEditingTestimonial] = useState<TestimonialApi | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<TestimonialApi | null>(null);
+
+  const form = useForm<TestimonialFormValues>({
+    defaultValues: emptyTestimonial,
+  });
+
+  useEffect(() => {
+    form.reset(toFormValues(editingTestimonial));
+  }, [editingTestimonial, form]);
+
+  const saveMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id?: number; payload: TestimonialInput }) => {
+      if (id) {
+        return updateTestimonial(id, payload);
+      }
+      return createTestimonial(payload);
+    },
+    onSuccess: () => {
+      toast({ title: 'Testimonial saved' });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-testimonials'] });
+      setDialogOpen(false);
+      setEditingTestimonial(null);
+    },
+    onError: () => {
+      toast({ title: 'Failed to save testimonial', variant: 'destructive' });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteTestimonial(id),
+    onSuccess: () => {
+      toast({ title: 'Testimonial removed' });
+      queryClient.invalidateQueries({ queryKey: ['admin-website-testimonials'] });
+    },
+    onError: () => {
+      toast({ title: 'Unable to delete testimonial', variant: 'destructive' });
+    },
+    onSettled: () => setPendingDelete(null),
+  });
+
+  const handleSubmit = (values: TestimonialFormValues) => {
+    const payload = toPayload(values);
+    if (!payload.name_en || !payload.name_ar || !payload.quote_en || !payload.quote_ar) {
+      toast({ title: 'Name and quote are required in both languages', variant: 'destructive' });
+      return;
+    }
+
+    const id = editingTestimonial?.id;
+    saveMutation.mutate({ id, payload });
+  };
+
+  const handleOpenDialog = (testimonial: TestimonialApi | null = null) => {
+    setEditingTestimonial(testimonial);
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setEditingTestimonial(null);
+  };
+
+  const testimonials = useMemo(() => testimonialsQuery.data ?? [], [testimonialsQuery.data]);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle className="text-xl font-semibold">Testimonials</CardTitle>
+          <CardDescription>Manage client stories displayed on the landing page testimonials slider.</CardDescription>
+        </div>
+        <Button type="button" onClick={() => handleOpenDialog(null)}>
+          <Plus className="mr-2 h-4 w-4" /> New testimonial
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {testimonialsQuery.isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        ) : testimonials.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No testimonials found.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name (EN)</TableHead>
+                  <TableHead>الاسم (AR)</TableHead>
+                  <TableHead>Position</TableHead>
+                  <TableHead className="w-32 text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {testimonials.map((testimonial) => (
+                  <TableRow key={testimonial.id}>
+                    <TableCell className="font-medium">{testimonial.name.en}</TableCell>
+                    <TableCell>{testimonial.name.ar}</TableCell>
+                    <TableCell>{testimonial.position.en ?? testimonial.position.ar ?? '—'}</TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button variant="ghost" size="icon" onClick={() => handleOpenDialog(testimonial)}>
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button variant="ghost" size="icon" onClick={() => setPendingDelete(testimonial)}>
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{editingTestimonial ? 'Edit testimonial' : 'Create testimonial'}</DialogTitle>
+          </DialogHeader>
+
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="name_en">Name (EN)</Label>
+                <Input id="name_en" {...form.register('name_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="name_ar">الاسم (AR)</Label>
+                <Input id="name_ar" dir="rtl" {...form.register('name_ar')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="position_en">Position (EN)</Label>
+                <Input id="position_en" {...form.register('position_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="position_ar">المنصب (AR)</Label>
+                <Input id="position_ar" dir="rtl" {...form.register('position_ar')} />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="quote_en">Quote (EN)</Label>
+                <Textarea id="quote_en" rows={4} {...form.register('quote_en')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="quote_ar">الشهادة (AR)</Label>
+                <Textarea id="quote_ar" rows={4} dir="rtl" {...form.register('quote_ar')} />
+              </div>
+            </div>
+
+            <UploadMedia
+              value={form.watch('avatar')}
+              label="Avatar image"
+              description="Upload a square avatar (512x512 recommended)."
+              onChange={(url) => form.setValue('avatar', url, { shouldDirty: true })}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={handleCloseDialog}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saveMutation.isPending}>
+                {saveMutation.isPending ? 'Saving…' : 'Save testimonial'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        title="Delete testimonial"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        loading={deleteMutation.isPending}
+        onConfirm={() => pendingDelete && deleteMutation.mutate(pendingDelete.id)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDelete(null);
+          }
+        }}
+      />
+    </Card>
+  );
+};
+
+export default TestimonialsManager;

--- a/frontend/src/pages/admin/Website/components/UploadMedia.tsx
+++ b/frontend/src/pages/admin/Website/components/UploadMedia.tsx
@@ -1,0 +1,131 @@
+import { useRef, useState } from 'react';
+import { ImagePlus, Loader2 } from 'lucide-react';
+
+import { uploadWebsiteMedia } from '@/api/websiteAdmin.service';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/use-toast';
+
+interface UploadMediaProps {
+  value?: string;
+  label?: string;
+  description?: string;
+  onChange?: (url: string) => void;
+}
+
+const formatFileSize = (bytes: number) => {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} bytes`;
+};
+
+const UploadMedia: React.FC<UploadMediaProps> = ({ value, label = 'Upload media asset', description, onChange }) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const { toast } = useToast();
+  const [isDragging, setDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [fileSize, setFileSize] = useState<number | null>(null);
+
+  const handleFile = async (file: File | null) => {
+    if (!file) {
+      return;
+    }
+
+    setUploading(true);
+    setFileSize(file.size);
+
+    try {
+      const result = await uploadWebsiteMedia(file);
+      onChange?.(result.url);
+      setFileSize(result.size ?? file.size);
+      toast({ title: 'Media uploaded', description: result.filename ?? result.url });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to upload file';
+      toast({ title: 'Upload failed', description: message, variant: 'destructive' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const [file] = event.target.files ?? [];
+    void handleFile(file ?? null);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    const [file] = Array.from(event.dataTransfer.files ?? []);
+    void handleFile(file ?? null);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragging(true);
+  };
+
+  const handleDragLeave = () => setDragging(false);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">{label}</CardTitle>
+        <CardDescription>
+          {description ?? 'Drag & drop an image or browse to upload. The generated URL will be saved to the CMS block.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div
+          className={`flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 text-center transition ${
+            isDragging ? 'border-primary/60 bg-primary/5' : 'border-border/60'
+          }`}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          role="button"
+          tabIndex={0}
+          onClick={() => inputRef.current?.click()}
+        >
+          {uploading ? (
+            <Loader2 className="mb-2 h-6 w-6 animate-spin text-primary" />
+          ) : (
+            <ImagePlus className="mb-2 h-6 w-6 text-muted-foreground" />
+          )}
+          <p className="text-sm font-medium text-foreground">{uploading ? 'Uploading…' : 'Drop image or click to upload'}</p>
+          <p className="text-xs text-muted-foreground">JPEG, PNG, WebP up to 10 MB</p>
+          <Input ref={inputRef} type="file" accept="image/*" className="hidden" onChange={handleInputChange} />
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            type="button"
+            disabled={uploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            Browse files
+          </Button>
+        </div>
+
+        {value ? (
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Current asset</p>
+            <div className="overflow-hidden rounded-lg border bg-background">
+              <img src={value} alt="Uploaded asset" className="h-48 w-full object-cover" />
+            </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{value}</span>
+              {fileSize ? <span>{formatFileSize(fileSize)}</span> : null}
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default UploadMedia;

--- a/frontend/src/types/website.ts
+++ b/frontend/src/types/website.ts
@@ -12,14 +12,49 @@ export interface ContentBlock<T = unknown> {
   value: Localized<T>;
 }
 
+export type PageStatus = 'draft' | 'preview' | 'published' | 'unlinked';
+
 export interface PageContent {
   id: number;
   slug: string;
   title: Localized<string | null>;
   content_blocks: ContentBlock[];
   content: ContentBlock[];
+  status?: PageStatus;
+  draft_updated_at?: string | null;
+  published_at?: string | null;
+  preview_url?: string | null;
+  last_edited_by?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+}
+
+export interface PageHistoryEntry {
+  id: number;
+  version: number;
+  status: PageStatus;
+  created_at: string;
+  updated_at?: string | null;
+  editor?: string | null;
+  notes?: string | null;
+}
+
+export interface WebsiteReportSection {
+  slug: string;
+  title: string;
+  status: PageStatus;
+  completion: number;
+  updated_at: string | null;
+}
+
+export interface WebsiteReportSummary {
+  completionRate: number;
+  completedPages: number;
+  totalPages: number;
+  pendingDrafts: number;
+  lastEditedAt: string | null;
+  apiHealthy: boolean;
+  sections: WebsiteReportSection[];
 }
 
 export interface TeamMemberApi {
@@ -35,6 +70,14 @@ export interface AchievementApi {
   id: number;
   title: Localized<string>;
   number: number;
+}
+
+export interface TestimonialApi {
+  id: number;
+  name: Localized<string>;
+  quote: Localized<string>;
+  position: Localized<string | null>;
+  avatar: string | null;
 }
 
 export interface ArticleApi {


### PR DESCRIPTION
## Summary
- add a `usePageManager` hook and extend admin APIs to support publishing, history, media uploads, and reporting
- refactor the website PageEditor into modular components with autosave, block management, media upload, and preview capabilities
- introduce articles and testimonials managers plus a reporting route with completion dashboards inside the admin website area

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e14c0510ac832f9eac9afa3767fc89