### PR TITLE
Add realtime notification center and activity log dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,8 @@ import NotFound from '@/pages/NotFound';
 import AdminWebsitePage from '@/pages/admin/Website/AdminWebsitePage';
 import WebsiteReportPage from '@/pages/admin/Website/WebsiteReportPage';
 import WorkflowBoardPage from '@/pages/admin/Website/WorkflowBoardPage';
+import ActivityLogPage from '@/pages/admin/Website/ActivityLogPage';
+import NotificationsPage from '@/pages/admin/Website/NotificationsPage';
 
 // 🌀 نوع الأقسام المستقبلية
 type DashboardSectionKey =
@@ -88,6 +90,8 @@ const App = () => {
             <Route index element={<Navigate to="pages" replace />} />
             <Route path="report" element={<WebsiteReportPage />} />
             <Route path="workflow" element={<WorkflowBoardPage />} />
+            <Route path="activity" element={<ActivityLogPage />} />
+            <Route path="notifications" element={<NotificationsPage />} />
             <Route path=":section" element={<AdminWebsitePage />} />
           </Route>
 

--- a/frontend/src/api/websiteAdmin.service.ts
+++ b/frontend/src/api/websiteAdmin.service.ts
@@ -12,6 +12,7 @@ import type {
   WebsiteReportSummary,
   WorkflowState,
 } from '@/types/website';
+import type { ActivityLogEntry } from '@/types/notifications';
 
 const unwrap = <T>(payload: unknown): T => {
   if (payload && typeof payload === 'object' && 'data' in (payload as Record<string, unknown>)) {
@@ -133,6 +134,11 @@ export const uploadWebsiteMedia = async (file: File): Promise<UploadMediaResult>
 export const getWebsiteReport = async (): Promise<WebsiteReportSummary> => {
   const { data } = await api.get('/api/admin/website/report');
   return unwrap<WebsiteReportSummary>(data);
+};
+
+export const getActivityLog = async (params?: { limit?: number }): Promise<ActivityLogEntry[]> => {
+  const { data } = await api.get('/api/admin/website/activity', { params });
+  return unwrapCollection<ActivityLogEntry>(data);
 };
 
 export const getWebsiteSettings = async (): Promise<PageContent> => getWebsitePage('settings');

--- a/frontend/src/components/common/NotificationBell.tsx
+++ b/frontend/src/components/common/NotificationBell.tsx
@@ -1,0 +1,182 @@
+import type { ComponentType } from 'react';
+import { AlertCircle, AlertTriangle, Bell, CheckCircle2, Info, Loader2, WifiOff, X } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import useNotifications from '@/hooks/useNotifications';
+import { cn } from '@/lib/utils';
+
+const severityConfig = {
+  success: {
+    badge: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    icon: CheckCircle2,
+  },
+  warning: {
+    badge: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+    icon: AlertTriangle,
+  },
+  error: {
+    badge: 'bg-red-500/10 text-red-600 dark:text-red-400',
+    icon: AlertCircle,
+  },
+  info: {
+    badge: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+    icon: Info,
+  },
+} as const;
+
+const connectionLabel: Record<string, { label: string; tone: string; icon: ComponentType<{ className?: string }> }> = {
+  idle: { label: 'Idle', tone: 'text-muted-foreground', icon: Info },
+  connecting: { label: 'Connecting…', tone: 'text-muted-foreground', icon: Loader2 },
+  open: { label: 'Live', tone: 'text-emerald-600 dark:text-emerald-400', icon: CheckCircle2 },
+  error: { label: 'Offline', tone: 'text-red-600 dark:text-red-400', icon: WifiOff },
+};
+
+const NotificationBell = () => {
+  const {
+    notifications,
+    unreadCount,
+    markAsRead,
+    markAllAsRead,
+    dismissNotification,
+    connectionState,
+    isBootstrapping,
+  } = useNotifications();
+
+  const visibleNotifications = notifications.slice(0, 8);
+  const connection = connectionLabel[connectionState];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative h-9 w-9" aria-label="Notifications">
+          <Bell className="h-5 w-5" />
+          {unreadCount > 0 ? (
+            <span className="absolute -right-1 -top-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-primary px-1 text-xs font-semibold text-primary-foreground">
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent sideOffset={8} align="end" className="w-80 p-0">
+        <DropdownMenuLabel className="flex items-center justify-between gap-2 px-4 py-3 text-sm font-semibold">
+          <span>Live notifications</span>
+          <span className={cn('inline-flex items-center gap-1 text-xs font-medium', connection.tone)}>
+            <connection.icon className={cn('h-3.5 w-3.5', connectionState === 'connecting' && 'animate-spin')} />
+            {connection.label}
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <div className="p-2">
+          {isBootstrapping ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Initializing notification center…
+            </div>
+          ) : visibleNotifications.length === 0 ? (
+            <div className="space-y-2 rounded-md border border-dashed border-border/70 bg-muted/40 p-4 text-center text-sm text-muted-foreground">
+              <p>No notifications yet.</p>
+              <p className="text-xs">Updates will appear here as editors collaborate.</p>
+            </div>
+          ) : (
+            <ScrollArea className="max-h-80 pr-2">
+              <div className="space-y-2">
+                {visibleNotifications.map((notification) => {
+                  const severity = severityConfig[notification.severity] ?? severityConfig.info;
+                  const Icon = severity.icon;
+                  return (
+                    <button
+                      key={notification.id}
+                      type="button"
+                      className="group relative flex w-full items-start gap-3 rounded-lg border border-transparent bg-background/50 p-3 text-left transition hover:border-border hover:bg-muted/70"
+                      onClick={() => markAsRead(notification.id)}
+                    >
+                      <span className={cn('flex h-8 w-8 items-center justify-center rounded-full', severity.badge)}>
+                        <Icon className="h-4 w-4" />
+                      </span>
+                      <span className="absolute right-2 top-2">
+                        {!notification.read ? <span className="inline-block h-2.5 w-2.5 rounded-full bg-primary" /> : null}
+                      </span>
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Badge variant="secondary" className={cn('text-xs font-medium capitalize', severity.badge)}>
+                            {notification.category}
+                          </Badge>
+                          <time className="text-xs text-muted-foreground">
+                            {formatRelativeTime(notification.createdAt)}
+                          </time>
+                        </div>
+                        <p className="text-sm font-medium text-foreground line-clamp-2">
+                          {notification.message}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="ml-2 h-7 w-7 shrink-0 text-muted-foreground opacity-0 transition group-hover:opacity-100"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          dismissNotification(notification.id);
+                        }}
+                        aria-label="Dismiss notification"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </button>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+        <div className="flex items-center justify-between px-3 py-2">
+          <Button variant="ghost" size="sm" onClick={markAllAsRead} disabled={unreadCount === 0}>
+            Mark all as read
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/dashboard/website/notifications">View all</Link>
+          </Button>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+const formatRelativeTime = (timestamp: string) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'just now';
+  }
+
+  const diff = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diff < minute) {
+    return 'just now';
+  }
+  if (diff < hour) {
+    const minutes = Math.floor(diff / minute);
+    return `${minutes}m ago`;
+  }
+  if (diff < day) {
+    const hours = Math.floor(diff / hour);
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(diff / day);
+  return `${days}d ago`;
+};
+
+export default NotificationBell;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -15,6 +15,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useSidebar } from "@/contexts/SidebarContext";
 import { cn } from "@/lib/utils";
 import BrandLogo from "../common/BrandLogo";
+import NotificationBell from "../common/NotificationBell";
 import { useTheme } from "@/contexts/ThemeContext";
 
 interface HeaderProps {
@@ -82,6 +83,7 @@ export const Header: React.FC<HeaderProps> = ({ title, className }) => {
 
         {/* Right side */}
         <div className="flex items-center gap-4">
+          <NotificationBell />
           <div className="hidden sm:flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
             {theme === "dark" ? (
               <>

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+import { useNotificationCenterContext } from '@/modules/notifications/NotificationCenter';
+
+const useNotifications = () => {
+  const context = useNotificationCenterContext();
+
+  const sortedNotifications = useMemo(
+    () => [...context.notifications].sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)),
+    [context.notifications],
+  );
+
+  const sortedActivity = useMemo(
+    () => [...context.activity].sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1)),
+    [context.activity],
+  );
+
+  return {
+    ...context,
+    notifications: sortedNotifications,
+    activity: sortedActivity,
+  };
+};
+
+export default useNotifications;

--- a/frontend/src/modules/notifications/NotificationCenter.tsx
+++ b/frontend/src/modules/notifications/NotificationCenter.tsx
@@ -1,0 +1,296 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import API_CONFIG from '@/config/config';
+import { getActivityLog } from '@/api/websiteAdmin.service';
+import type {
+  ActivityLogEntry,
+  AdminNotification,
+  AdminNotificationCategory,
+  AdminNotificationSeverity,
+  AdminServerEventPayload,
+} from '@/types/notifications';
+
+export type NotificationConnectionState = 'idle' | 'connecting' | 'open' | 'error';
+
+interface NotificationCenterContextValue {
+  notifications: AdminNotification[];
+  activity: ActivityLogEntry[];
+  unreadCount: number;
+  connectionState: NotificationConnectionState;
+  isBootstrapping: boolean;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  dismissNotification: (id: string) => void;
+  refreshActivity: () => Promise<void>;
+}
+
+const NotificationCenterContext = createContext<NotificationCenterContextValue | undefined>(
+  undefined,
+);
+
+const MAX_ITEMS = 100;
+
+const mapSeverity = (severity?: AdminNotificationSeverity): AdminNotificationSeverity => {
+  if (!severity) {
+    return 'info';
+  }
+  return severity;
+};
+
+const mapCategory = (category?: AdminNotificationCategory): AdminNotificationCategory => {
+  if (!category) {
+    return 'system';
+  }
+  return category;
+};
+
+const bootstrapActivityFallback = (event: AdminServerEventPayload): ActivityLogEntry => {
+  const timestamp = event.timestamp ?? new Date().toISOString();
+  const payload = event.payload ?? {};
+  return {
+    id: event.id ?? `${event.type}-${timestamp}`,
+    timestamp,
+    user: (payload.user as string) ?? 'System',
+    action: event.type,
+    section: (payload.section as string | undefined) ?? null,
+    diffSummary: event.message ?? null,
+    metadata: payload,
+  };
+};
+
+const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
+  const queryClient = useQueryClient();
+  const [notifications, setNotifications] = useState<AdminNotification[]>([]);
+  const [activity, setActivity] = useState<ActivityLogEntry[]>([]);
+  const [connectionState, setConnectionState] = useState<NotificationConnectionState>('idle');
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+  const reconnectAttempts = useRef(0);
+  const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const markAsRead = useCallback((id: string) => {
+    setNotifications((prev) => prev.map((item) => (item.id === id ? { ...item, read: true } : item)));
+  }, []);
+
+  const markAllAsRead = useCallback(() => {
+    setNotifications((prev) => prev.map((item) => ({ ...item, read: true })));
+  }, []);
+
+  const dismissNotification = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const refreshActivity = useCallback(async () => {
+    try {
+      const entries = await getActivityLog({ limit: 100 });
+      setActivity(entries);
+    } catch (error) {
+      console.warn('Failed to refresh activity log', error);
+    }
+  }, []);
+
+  const handleServerEvent = useCallback(
+    (payload: AdminServerEventPayload) => {
+      const timestamp = payload.timestamp ?? new Date().toISOString();
+      const id = payload.id ?? `${payload.type}-${timestamp}`;
+      const severity = mapSeverity(payload.severity);
+      const category = mapCategory(payload.category);
+      const meta = payload.payload;
+
+      if (payload.activity) {
+        const entry: ActivityLogEntry = {
+          ...payload.activity,
+          id: payload.activity.id ?? id,
+          timestamp: payload.activity.timestamp ?? timestamp,
+        };
+        setActivity((prev) => {
+          const filtered = prev.filter((item) => item.id !== entry.id);
+          return [entry, ...filtered].slice(0, MAX_ITEMS);
+        });
+      } else {
+        setActivity((prev) => {
+          const entry = bootstrapActivityFallback(payload);
+          const filtered = prev.filter((item) => item.id !== entry.id);
+          return [entry, ...filtered].slice(0, MAX_ITEMS);
+        });
+      }
+
+      setNotifications((prev) => {
+        const next: AdminNotification = {
+          id,
+          type: payload.type,
+          message: payload.message ?? payload.type,
+          createdAt: timestamp,
+          severity,
+          category,
+          read: false,
+          meta: meta,
+        };
+        const filtered = prev.filter((item) => item.id !== id);
+        return [next, ...filtered].slice(0, MAX_ITEMS);
+      });
+
+      const invalidateTargets = payload.invalidateQueries ?? [];
+      if (invalidateTargets.length > 0) {
+        invalidateTargets.forEach((key) => {
+          queryClient
+            .invalidateQueries({ queryKey: [key] })
+            .catch((error) => console.warn('Failed to invalidate query for key', key, error));
+        });
+      } else if (payload.type.startsWith('workflow.') || payload.type.startsWith('publish.')) {
+        queryClient.invalidateQueries({ queryKey: ['admin-website-publishing-queue'] }).catch(() => undefined);
+        queryClient.invalidateQueries({ queryKey: ['admin-website-report'] }).catch(() => undefined);
+      }
+    },
+    [queryClient],
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const bootstrap = async () => {
+      try {
+        await refreshActivity();
+      } finally {
+        if (isMounted) {
+          setIsBootstrapping(false);
+        }
+      }
+    };
+
+    bootstrap().catch((error) => {
+      console.warn('Notification center bootstrap failed', error);
+      if (isMounted) {
+        setIsBootstrapping(false);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      if (reconnectTimeout.current) {
+        clearTimeout(reconnectTimeout.current);
+      }
+    };
+  }, [refreshActivity]);
+
+  useEffect(() => {
+    let eventSource: EventSource | null = null;
+
+    const connect = () => {
+      if (eventSource) {
+        eventSource.close();
+        eventSource = null;
+      }
+
+      setConnectionState('connecting');
+
+      const url = new URL('/api/admin/events/subscribe', API_CONFIG.baseURL);
+      try {
+        const storedToken = sessionStorage.getItem('token');
+        if (storedToken) {
+          const parsedToken = JSON.parse(storedToken) as string;
+          if (parsedToken) {
+            url.searchParams.set('token', parsedToken);
+          }
+        }
+      } catch (error) {
+        console.warn('Unable to parse session token for SSE connection', error);
+      }
+
+      const source = new EventSource(url.toString(), { withCredentials: true });
+      eventSource = source;
+
+      source.onopen = () => {
+        setConnectionState('open');
+        reconnectAttempts.current = 0;
+      };
+
+      source.onerror = () => {
+        setConnectionState('error');
+        source.close();
+        if (reconnectAttempts.current < 5) {
+          const timeout = Math.min(30000, 1000 * 2 ** reconnectAttempts.current);
+          reconnectAttempts.current += 1;
+          reconnectTimeout.current = setTimeout(connect, timeout);
+        }
+      };
+
+      source.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data) as AdminServerEventPayload;
+          handleServerEvent(data);
+        } catch (error) {
+          console.warn('Failed to parse admin event payload', error);
+        }
+      };
+
+      source.addEventListener('ping', () => {
+        setConnectionState('open');
+      });
+    };
+
+    connect();
+
+    return () => {
+      if (eventSource) {
+        eventSource.close();
+      }
+    };
+  }, [handleServerEvent]);
+
+  const unreadCount = useMemo(
+    () => notifications.reduce((total, notification) => (notification.read ? total : total + 1), 0),
+    [notifications],
+  );
+
+  const contextValue = useMemo<NotificationCenterContextValue>(
+    () => ({
+      notifications,
+      activity,
+      unreadCount,
+      connectionState,
+      isBootstrapping,
+      markAsRead,
+      markAllAsRead,
+      dismissNotification,
+      refreshActivity,
+    }),
+    [
+      activity,
+      connectionState,
+      dismissNotification,
+      isBootstrapping,
+      markAllAsRead,
+      markAsRead,
+      notifications,
+      refreshActivity,
+      unreadCount,
+    ],
+  );
+
+  return (
+    <NotificationCenterContext.Provider value={contextValue}>
+      {children}
+    </NotificationCenterContext.Provider>
+  );
+};
+
+export const useNotificationCenterContext = () => {
+  const context = useContext(NotificationCenterContext);
+  if (!context) {
+    throw new Error('useNotificationCenterContext must be used within NotificationCenterProvider');
+  }
+
+  return context;
+};
+
+export default NotificationCenterProvider;

--- a/frontend/src/pages/admin/Website/ActivityLogPage.tsx
+++ b/frontend/src/pages/admin/Website/ActivityLogPage.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Clock, FolderKanban, RefreshCcw, ShieldCheck, UserCircle } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import useNotifications from '@/hooks/useNotifications';
+
+const ActivityLogPage = () => {
+  const { activity, refreshActivity, connectionState, isBootstrapping } = useNotifications();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(() => {
+    refreshActivity().catch((error) => console.warn('Failed to fetch activity log on mount', error));
+  }, [refreshActivity]);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    try {
+      await refreshActivity();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const items = useMemo(() => activity.slice(0, 200), [activity]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold text-foreground">Website activity log</h1>
+          <p className="text-sm text-muted-foreground">
+            Audit every workflow step including edits, approvals, publishing attempts, and scheduling changes.
+          </p>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <ShieldCheck className="h-3.5 w-3.5" /> Real-time feed status: <strong className="font-semibold text-foreground">{connectionState}</strong>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isRefreshing}>
+          <RefreshCcw className="mr-2 h-4 w-4" /> Refresh
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+            <FolderKanban className="h-5 w-5" /> Latest activity
+          </CardTitle>
+          <CardDescription>
+            Entries are captured whenever an admin edits, reviews, or publishes website content.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isBootstrapping && items.length === 0 ? (
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div key={`skeleton-${index}`} className="flex items-center gap-4">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-1/3" />
+                    <Skeleton className="h-3 w-1/5" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border/60 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+              No activity has been recorded yet. Actions performed inside the CMS will appear instantly.
+            </div>
+          ) : (
+            <ul className="space-y-4">
+              {items.map((entry) => (
+                <li key={entry.id} className="flex flex-col gap-2 rounded-lg border border-border/60 bg-background/80 p-4 shadow-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                      <UserCircle className="h-4 w-4" /> {entry.user}
+                    </div>
+                    <time className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Clock className="h-3.5 w-3.5" /> {formatRelativeTime(entry.timestamp)}
+                    </time>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-sm text-foreground">
+                    <Badge variant="secondary" className="capitalize">
+                      {entry.action}
+                    </Badge>
+                    {entry.section ? (
+                      <Badge variant="outline" className="capitalize">
+                        {entry.section}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {entry.diffSummary ? (
+                    <p className="text-sm text-muted-foreground">{entry.diffSummary}</p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+const formatRelativeTime = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'just now';
+  }
+
+  const diff = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diff < minute) {
+    return 'just now';
+  }
+  if (diff < hour) {
+    const minutes = Math.floor(diff / minute);
+    return `${minutes}m ago`;
+  }
+  if (diff < day) {
+    const hours = Math.floor(diff / hour);
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(diff / day);
+  return `${days}d ago`;
+};
+
+export default ActivityLogPage;

--- a/frontend/src/pages/admin/Website/NotificationsPage.tsx
+++ b/frontend/src/pages/admin/Website/NotificationsPage.tsx
@@ -1,0 +1,168 @@
+import { useMemo } from 'react';
+import { AlertCircle, AlertTriangle, BellRing, CheckCircle2, RefreshCcw } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import useNotifications from '@/hooks/useNotifications';
+import { cn } from '@/lib/utils';
+
+const severityTone = {
+  success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300',
+  info: 'bg-sky-100 text-sky-700 dark:bg-sky-500/10 dark:text-sky-300',
+  warning: 'bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300',
+  error: 'bg-red-100 text-red-700 dark:bg-red-500/10 dark:text-red-300',
+} as const;
+
+const severityIcon = {
+  success: CheckCircle2,
+  info: BellRing,
+  warning: AlertTriangle,
+  error: AlertCircle,
+} as const;
+
+const NotificationsPage = () => {
+  const {
+    notifications,
+    unreadCount,
+    markAsRead,
+    markAllAsRead,
+    dismissNotification,
+    connectionState,
+    isBootstrapping,
+  } = useNotifications();
+
+  const items = useMemo(() => notifications.slice(0, 200), [notifications]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold text-foreground">Notification center</h1>
+          <p className="text-sm text-muted-foreground">
+            Live workflow alerts for approvals, publishing, scheduling, and autosave health inside the CMS.
+          </p>
+          <p className="text-xs text-muted-foreground">Connection state: {connectionState}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={markAllAsRead} disabled={unreadCount === 0}>
+            Mark all as read
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              items.forEach((item) => markAsRead(item.id));
+            }}
+          >
+            <RefreshCcw className="mr-2 h-4 w-4" /> Sync
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+            <BellRing className="h-5 w-5" /> Live alerts
+          </CardTitle>
+          <CardDescription>Latest notifications from the website publishing workflow and editor tooling.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isBootstrapping && items.length === 0 ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div key={`notification-skeleton-${index}`} className="flex items-start gap-3">
+                  <Skeleton className="h-9 w-9 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-1/2" />
+                    <Skeleton className="h-3 w-1/3" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border/60 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+              No notifications have been received. Collaboration events and publishing outcomes will surface here instantly.
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {items.map((notification) => {
+                const tone = severityTone[notification.severity] ?? severityTone.info;
+                const Icon = severityIcon[notification.severity] ?? BellRing;
+                return (
+                  <li
+                    key={notification.id}
+                    className={cn(
+                      'flex flex-col gap-2 rounded-lg border border-border/60 bg-background/90 p-4 shadow-sm transition',
+                      !notification.read && 'border-primary/60 ring-1 ring-primary/30',
+                    )}
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <span className={cn('flex h-9 w-9 items-center justify-center rounded-full', tone)}>
+                          <Icon className="h-4 w-4" />
+                        </span>
+                        <div className="flex flex-col">
+                          <span className="text-sm font-semibold text-foreground">{notification.message}</span>
+                          <span className="text-xs text-muted-foreground">{formatRelativeTime(notification.createdAt)}</span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {!notification.read ? (
+                          <Badge variant="outline" className="border-primary/60 text-primary">
+                            Unread
+                          </Badge>
+                        ) : null}
+                        <Button variant="ghost" size="sm" onClick={() => markAsRead(notification.id)}>
+                          Mark read
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={() => dismissNotification(notification.id)}>
+                          Dismiss
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <Badge variant="secondary" className="capitalize">
+                        {notification.category}
+                      </Badge>
+                      <span>Event: {notification.type}</span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+const formatRelativeTime = (timestamp: string) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'just now';
+  }
+
+  const diff = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diff < minute) {
+    return 'just now';
+  }
+  if (diff < hour) {
+    const minutes = Math.floor(diff / minute);
+    return `${minutes}m ago`;
+  }
+  if (diff < day) {
+    const hours = Math.floor(diff / hour);
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(diff / day);
+  return `${days}d ago`;
+};
+
+export default NotificationsPage;

--- a/frontend/src/pages/admin/Website/WorkflowBoardPage.tsx
+++ b/frontend/src/pages/admin/Website/WorkflowBoardPage.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import WorkflowStatusBadge from './components/WorkflowStatusBadge';
+import useNotifications from '@/hooks/useNotifications';
 
 const WorkflowBoardPage: React.FC = () => {
   const queryClient = useQueryClient();
@@ -17,6 +18,7 @@ const WorkflowBoardPage: React.FC = () => {
     queryKey: ['admin-website-publishing-queue'],
     queryFn: getPublishingQueue,
   });
+  const { connectionState } = useNotifications();
 
   const items = useMemo(() => queueQuery.data ?? [], [queueQuery.data]);
 
@@ -32,6 +34,7 @@ const WorkflowBoardPage: React.FC = () => {
           <p className="text-sm text-muted-foreground">
             Monitor drafts awaiting approval, scheduled publishes, and bulk publishing progress in real time.
           </p>
+          <p className="text-xs text-muted-foreground">Live updates: {connectionState}</p>
         </div>
         <Button variant="outline" onClick={handleRefresh} disabled={queueQuery.isFetching}>
           <RefreshCcw className="mr-2 h-4 w-4" /> Refresh

--- a/frontend/src/pages/admin/Website/components/ReportWidget.tsx
+++ b/frontend/src/pages/admin/Website/components/ReportWidget.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Activity, AlertTriangle, BarChart3, CheckCircle2, Clock, Database, Timer } from 'lucide-react';
+import { Activity, AlertTriangle, BarChart3, CheckCircle2, Clock, Database, History, Timer } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 import { getWebsiteReport } from '@/api/websiteAdmin.service';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -7,6 +9,7 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import WorkflowStatusBadge from './WorkflowStatusBadge';
+import useNotifications from '@/hooks/useNotifications';
 
 const ReportWidget: React.FC = () => {
   const reportQuery = useQuery({
@@ -15,6 +18,8 @@ const ReportWidget: React.FC = () => {
   });
 
   const report = reportQuery.data;
+  const { activity, connectionState } = useNotifications();
+  const recentActivity = useMemo(() => activity.slice(0, 10), [activity]);
 
   if (reportQuery.isLoading) {
     return (
@@ -218,6 +223,47 @@ const ReportWidget: React.FC = () => {
             )}
           </CardContent>
         </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+              <History className="h-5 w-5" /> Recent admin activity
+            </CardTitle>
+            <CardDescription>Live audit log events streaming from website collaborators.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Status: {connectionState === 'open' ? 'Live' : connectionState}</span>
+              <Link to="/dashboard/website/activity" className="font-medium text-primary hover:underline">
+                View all
+              </Link>
+            </div>
+            {recentActivity.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No activity captured in the last updates.</p>
+            ) : (
+              <ul className="space-y-2">
+                {recentActivity.map((entry) => (
+                  <li
+                    key={entry.id}
+                    className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/40 px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-foreground line-clamp-1">{entry.action}</p>
+                      <p className="text-xs text-muted-foreground line-clamp-1">
+                        {entry.user} • {formatRelativeTimestamp(entry.timestamp)}
+                      </p>
+                    </div>
+                    {entry.section ? (
+                      <Badge variant="outline" className="shrink-0 capitalize">
+                        {entry.section}
+                      </Badge>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );
@@ -251,6 +297,32 @@ const formatMinutes = (minutes: number) => {
     return `${hours}h ago`;
   }
   const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+};
+
+const formatRelativeTimestamp = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'just now';
+  }
+
+  const diff = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diff < minute) {
+    return 'just now';
+  }
+  if (diff < hour) {
+    const minutes = Math.floor(diff / minute);
+    return `${minutes}m ago`;
+  }
+  if (diff < day) {
+    const hours = Math.floor(diff / hour);
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(diff / day);
   return `${days}d ago`;
 };
 

--- a/frontend/src/providers/AppProviders.tsx
+++ b/frontend/src/providers/AppProviders.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
+import NotificationCenterProvider from '@/modules/notifications/NotificationCenter';
 
 const queryClient = new QueryClient();
 
@@ -20,15 +21,17 @@ const AppProviders = ({ children }: AppProvidersProps) => {
     <ThemeProvider>
       <LanguageProvider>
         <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <SidebarProvider>
-              <TooltipProvider>
-                <Toaster />
-                <Sonner />
-                {children}
-              </TooltipProvider>
-            </SidebarProvider>
-          </AuthProvider>
+          <NotificationCenterProvider>
+            <AuthProvider>
+              <SidebarProvider>
+                <TooltipProvider>
+                  <Toaster />
+                  <Sonner />
+                  {children}
+                </TooltipProvider>
+              </SidebarProvider>
+            </AuthProvider>
+          </NotificationCenterProvider>
         </QueryClientProvider>
       </LanguageProvider>
     </ThemeProvider>

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -1,10 +1,42 @@
-export interface Notification {
-  id: number;
-  user_id: number;
-  event_id: number;
+export type AdminNotificationCategory =
+  | 'approval'
+  | 'publishing'
+  | 'schedule'
+  | 'workflow'
+  | 'system'
+  | 'media';
+
+export type AdminNotificationSeverity = 'info' | 'success' | 'warning' | 'error';
+
+export interface ActivityLogEntry {
+  id: string;
+  timestamp: string;
+  user: string;
+  action: string;
+  section?: string | null;
+  diffSummary?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface AdminNotification {
+  id: string;
   type: string;
   message: string;
+  createdAt: string;
+  severity: AdminNotificationSeverity;
+  category: AdminNotificationCategory;
   read: boolean;
-  created_at: string;
-  updated_at: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface AdminServerEventPayload {
+  id?: string;
+  type: string;
+  message?: string;
+  timestamp?: string;
+  severity?: AdminNotificationSeverity;
+  category?: AdminNotificationCategory;
+  payload?: Record<string, unknown>;
+  invalidateQueries?: string[];
+  activity?: ActivityLogEntry;
 }


### PR DESCRIPTION
## Summary
- create a notification center module with SSE subscription, context provider, and consumer hook for live admin events
- add notification bell UI, dedicated notifications and activity log pages, and surface recent audit events inside the website report
- wire the notification provider through the app shell and expose live connection status on workflow monitoring views

## Testing
- npm run lint *(fails: existing TypeScript lint issues in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e188620f18832fb54e76f9f020fd66