### PR TITLE
Add CMS page workflow endpoints and history

### DIFF
--- a/backend/app/Http/Controllers/Api/Website/PageController.php
+++ b/backend/app/Http/Controllers/Api/Website/PageController.php
@@ -4,9 +4,15 @@ namespace App\Http\Controllers\Api\Website;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\PageResource;
+use App\Http\Resources\PageRevisionResource;
+use App\Http\Resources\PublishingQueueResource;
+use App\Models\ContentBlock;
 use App\Models\Page;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\Rule;
 
 class PageController extends Controller
@@ -24,6 +30,7 @@ class PageController extends Controller
     public function adminIndex(): AnonymousResourceCollection
     {
         $pages = Page::query()
+            ->with($this->pageRelations())
             ->orderBy('slug')
             ->get();
 
@@ -39,7 +46,141 @@ class PageController extends Controller
     {
         $page = $this->persistPage($request, $slug);
 
-        return new PageResource($page->load($this->contentBlockRelation()));
+        return new PageResource($page->load($this->pageRelations()));
+    }
+
+    public function preview(Request $request, string $slug): PageResource
+    {
+        $page = $this->resolvePage($slug);
+        $payload = $this->validatePagePayload($request);
+
+        $preview = $this->makePreviewPage($page, $payload);
+
+        return new PageResource($preview);
+    }
+
+    public function publish(Request $request, string $slug): PageResource
+    {
+        $page = $this->resolvePage($slug);
+
+        $page->status = 'published';
+        $page->workflow_state = 'published';
+        $page->published_at = Carbon::now();
+        $page->scheduled_for = null;
+        $page->last_editor_id = $request->user()?->id;
+        $page->save();
+
+        $this->logRevision($page, 'workflow.published', null, $request->user()?->id);
+
+        return new PageResource($page->load($this->pageRelations()));
+    }
+
+    public function publishAll(Request $request): Response
+    {
+        Page::query()->each(function (Page $page) use ($request) {
+            $page->status = 'published';
+            $page->workflow_state = 'published';
+            $page->published_at = Carbon::now();
+            $page->scheduled_for = null;
+            $page->last_editor_id = $request->user()?->id;
+            $page->save();
+
+            $this->logRevision($page, 'workflow.published', null, $request->user()?->id);
+        });
+
+        return response()->noContent();
+    }
+
+    public function requestApproval(Request $request, string $slug): PageResource
+    {
+        $page = $this->resolvePage($slug);
+        $data = $request->validate([
+            'notes' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $page->workflow_state = 'pendingReview';
+        $page->last_editor_id = $request->user()?->id;
+        $page->save();
+
+        $this->logRevision($page, 'workflow.submitted', $data['notes'] ?? null, $request->user()?->id);
+
+        return new PageResource($page->load($this->pageRelations()));
+    }
+
+    public function approve(Request $request, string $slug): PageResource
+    {
+        $page = $this->resolvePage($slug);
+        $data = $request->validate([
+            'notes' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $page->status = 'published';
+        $page->workflow_state = 'published';
+        $page->published_at = Carbon::now();
+        $page->scheduled_for = null;
+        $page->last_editor_id = $request->user()?->id;
+        $page->save();
+
+        $this->logRevision($page, 'workflow.approved', $data['notes'] ?? null, $request->user()?->id);
+
+        return new PageResource($page->load($this->pageRelations()));
+    }
+
+    public function schedule(Request $request, string $slug): PageResource
+    {
+        $page = $this->resolvePage($slug);
+        $data = $request->validate([
+            'scheduled_for' => ['required', 'date', 'after:now'],
+            'notes' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $page->workflow_state = 'scheduled';
+        $page->scheduled_for = Carbon::parse($data['scheduled_for']);
+        $page->last_editor_id = $request->user()?->id;
+        $page->save();
+
+        $this->logRevision($page, 'workflow.scheduled', $data['notes'] ?? null, $request->user()?->id);
+
+        return new PageResource($page->load($this->pageRelations()));
+    }
+
+    public function cancelSchedule(Request $request, string $slug): PageResource
+    {
+        $page = $this->resolvePage($slug);
+
+        $page->scheduled_for = null;
+        if ($page->status !== 'published') {
+            $page->workflow_state = 'draft';
+        }
+        $page->last_editor_id = $request->user()?->id;
+        $page->save();
+
+        $this->logRevision($page, 'workflow.schedule_cancelled', null, $request->user()?->id);
+
+        return new PageResource($page->load($this->pageRelations()));
+    }
+
+    public function history(string $slug): AnonymousResourceCollection
+    {
+        $page = $this->resolvePage($slug);
+
+        $revisions = $page->revisions()
+            ->with('editor')
+            ->orderByDesc('version')
+            ->get();
+
+        return PageRevisionResource::collection($revisions);
+    }
+
+    public function publishingQueue(): AnonymousResourceCollection
+    {
+        $queue = Page::query()
+            ->whereNotNull('scheduled_for')
+            ->with('lastEditor')
+            ->orderBy('scheduled_for')
+            ->get();
+
+        return PublishingQueueResource::collection($queue);
     }
 
     public function settings(): PageResource
@@ -54,7 +195,58 @@ class PageController extends Controller
 
     private function persistPage(Request $request, string $slug): Page
     {
-        $validated = $request->validate([
+        $validated = $this->validatePagePayload($request);
+        $notes = Arr::pull($validated, 'notes');
+        $editorId = $request->user()?->id;
+
+        $page = Page::firstOrCreate(['slug' => $slug]);
+
+        $page->fill([
+            'title_ar' => $validated['title_ar'] ?? $page->title_ar,
+            'title_en' => $validated['title_en'] ?? $page->title_en,
+        ]);
+
+        if (array_key_exists('status', $validated)) {
+            $page->status = $validated['status'] ?? $page->status;
+        }
+
+        if (array_key_exists('workflow_state', $validated)) {
+            $page->workflow_state = $validated['workflow_state'] ?? $page->workflow_state;
+        }
+
+        if (array_key_exists('scheduled_for', $validated)) {
+            $page->scheduled_for = $validated['scheduled_for'] ? Carbon::parse($validated['scheduled_for']) : null;
+        }
+
+        $page->last_editor_id = $editorId;
+        $page->save();
+
+        if (array_key_exists('content_blocks', $validated)) {
+            $this->syncContentBlocks($page, $validated['content_blocks']);
+        }
+
+        $page->load($this->pageRelations());
+
+        $this->logRevision($page, 'content.updated', $notes, $editorId);
+
+        return $page;
+    }
+
+    private function validatePagePayload(Request $request): array
+    {
+        $statusRule = [
+            'nullable',
+            'string',
+            Rule::in(['draft', 'preview', 'published', 'unlinked']),
+        ];
+
+        $workflowRule = [
+            'nullable',
+            'string',
+            Rule::in(['draft', 'pendingReview', 'scheduled', 'published']),
+        ];
+
+        $rules = [
             'title_ar' => ['nullable', 'string', 'max:255'],
             'title_en' => ['nullable', 'string', 'max:255'],
             'content_blocks' => ['sometimes', 'array'],
@@ -66,52 +258,119 @@ class PageController extends Controller
             'content_blocks.*.value' => ['required', 'array'],
             'content_blocks.*.value.ar' => ['nullable'],
             'content_blocks.*.value.en' => ['nullable'],
-        ]);
+            'status' => $statusRule,
+            'workflow_state' => $workflowRule,
+            'scheduled_for' => ['nullable', 'date'],
+            'notes' => ['nullable', 'string', 'max:2000'],
+        ];
 
-        $page = Page::firstOrCreate(['slug' => $slug]);
+        return $request->validate($rules);
+    }
 
-        $page->fill([
-            'title_ar' => $validated['title_ar'] ?? $page->title_ar,
-            'title_en' => $validated['title_en'] ?? $page->title_en,
-        ]);
-        $page->save();
+    private function syncContentBlocks(Page $page, array $blocks): void
+    {
+        $keys = [];
 
-        if (array_key_exists('content_blocks', $validated)) {
-            $keys = [];
+        foreach ($blocks as $block) {
+            $normalized = $this->normalizeBlockPayload($block);
 
-            foreach ($validated['content_blocks'] as $block) {
-                $page->contentBlocks()->updateOrCreate(
-                    ['key' => $block['key']],
-                    [
-                        'type' => $block['type'] ?? 'text',
-                        'value' => [
-                            'ar' => $block['value']['ar'] ?? null,
-                            'en' => $block['value']['en'] ?? null,
-                        ],
-                    ]
-                );
+            $page->contentBlocks()->updateOrCreate(
+                ['key' => $normalized['key']],
+                [
+                    'type' => $normalized['type'],
+                    'value' => $normalized['value'],
+                ]
+            );
 
-                $keys[] = $block['key'];
-            }
-
-            $this->purgeMissingBlocks($page, $keys);
+            $keys[] = $normalized['key'];
         }
 
-        return $page;
+        $this->purgeMissingBlocks($page, $keys);
+    }
+
+    private function normalizeBlockPayload(array $block): array
+    {
+        return [
+            'key' => $block['key'],
+            'type' => $block['type'] ?? 'text',
+            'value' => [
+                'ar' => Arr::get($block, 'value.ar'),
+                'en' => Arr::get($block, 'value.en'),
+            ],
+        ];
+    }
+
+    private function makePreviewPage(Page $page, array $payload): Page
+    {
+        $preview = clone $page;
+
+        $preview->title_ar = $payload['title_ar'] ?? $page->title_ar;
+        $preview->title_en = $payload['title_en'] ?? $page->title_en;
+        $preview->status = $payload['status'] ?? $page->status;
+        $preview->workflow_state = $payload['workflow_state'] ?? $page->workflow_state;
+        $preview->scheduled_for = isset($payload['scheduled_for'])
+            ? ($payload['scheduled_for'] ? Carbon::parse($payload['scheduled_for']) : null)
+            : $page->scheduled_for;
+
+        if (array_key_exists('content_blocks', $payload)) {
+            $collection = collect($payload['content_blocks'])
+                ->map(fn (array $block) => new ContentBlock($this->normalizeBlockPayload($block)));
+        } else {
+            $collection = $page->contentBlocks;
+        }
+
+        $preview->setRelation('contentBlocks', $collection);
+
+        return $preview;
+    }
+
+    private function logRevision(Page $page, string $event, ?string $notes = null, ?int $editorId = null): void
+    {
+        $page->loadMissing($this->pageRelations());
+
+        $payload = [
+            'title' => [
+                'ar' => $page->title_ar,
+                'en' => $page->title_en,
+            ],
+            'content_blocks' => $page->contentBlocks
+                ->map(fn (ContentBlock $block) => [
+                    'key' => $block->key,
+                    'type' => $block->type,
+                    'value' => [
+                        'ar' => Arr::get($block->value, 'ar'),
+                        'en' => Arr::get($block->value, 'en'),
+                    ],
+                ])
+                ->values(),
+        ];
+
+        $version = ($page->revisions()->max('version') ?? 0) + 1;
+
+        $page->revisions()->create([
+            'version' => $version,
+            'status' => $page->status ?? 'draft',
+            'workflow_state' => $page->workflow_state ?? 'draft',
+            'payload' => $payload,
+            'event' => $event,
+            'notes' => $notes,
+            'editor_id' => $editorId,
+        ]);
     }
 
     private function resolvePage(string $slug): Page
     {
         return Page::query()
-            ->with($this->contentBlockRelation())
+            ->with($this->pageRelations())
             ->where('slug', $slug)
             ->firstOrFail();
     }
 
-    private function contentBlockRelation(): array
+    private function pageRelations(): array
     {
         return [
             'contentBlocks' => fn ($query) => $query->orderBy('id'),
+            'lastEditor',
         ];
     }
 

--- a/backend/app/Http/Resources/PageResource.php
+++ b/backend/app/Http/Resources/PageResource.php
@@ -11,6 +11,8 @@ class PageResource extends JsonResource
      */
     public function toArray($request): array
     {
+        $contentBlocks = $this->whenLoaded('contentBlocks');
+
         return [
             'id' => $this->id,
             'slug' => $this->slug,
@@ -18,14 +20,21 @@ class PageResource extends JsonResource
                 'ar' => $this->title_ar,
                 'en' => $this->title_en,
             ],
-            'content_blocks' => ContentBlockResource::collection(
-                $this->whenLoaded('contentBlocks')
-            ),
-            'content' => ContentBlockResource::collection(
-                $this->whenLoaded('contentBlocks')
-            ),
+            'content_blocks' => ContentBlockResource::collection($contentBlocks),
+            'content' => ContentBlockResource::collection($contentBlocks),
+            'status' => $this->status ?? 'draft',
+            'draft_updated_at' => $this->updated_at?->toISOString(),
+            'published_at' => $this->published_at?->toISOString(),
+            'preview_url' => null,
+            'last_edited_by' => $this->lastEditor?->name,
             'created_at' => $this->created_at?->toISOString(),
             'updated_at' => $this->updated_at?->toISOString(),
+            'workflow' => [
+                'state' => $this->workflow_state ?? 'draft',
+                'scheduled_for' => $this->scheduled_for?->toISOString(),
+                'draft_id' => null,
+                'events' => [],
+            ],
         ];
     }
 }

--- a/backend/app/Http/Resources/PageRevisionResource.php
+++ b/backend/app/Http/Resources/PageRevisionResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PageRevisionResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'version' => $this->version,
+            'status' => $this->status,
+            'workflow_state' => $this->workflow_state,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+            'editor' => $this->editor?->name,
+            'notes' => $this->notes,
+            'event' => $this->event,
+        ];
+    }
+}

--- a/backend/app/Http/Resources/PublishingQueueResource.php
+++ b/backend/app/Http/Resources/PublishingQueueResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PublishingQueueResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $title = $this->title_en ?: ($this->title_ar ?: $this->slug);
+
+        return [
+            'slug' => $this->slug,
+            'title' => $title,
+            'state' => $this->workflow_state ?? 'draft',
+            'draft_id' => null,
+            'scheduled_for' => $this->scheduled_for?->toISOString(),
+            'last_updated' => $this->updated_at?->toISOString(),
+            'submitted_by' => $this->lastEditor?->name,
+            'approved_by' => null,
+            'progress' => null,
+        ];
+    }
+}

--- a/backend/app/Models/Page.php
+++ b/backend/app/Models/Page.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Page extends Model
 {
@@ -13,10 +15,30 @@ class Page extends Model
         'slug',
         'title_ar',
         'title_en',
+        'status',
+        'workflow_state',
+        'published_at',
+        'scheduled_for',
+        'last_editor_id',
     ];
 
-    public function contentBlocks()
+    protected $casts = [
+        'published_at' => 'datetime',
+        'scheduled_for' => 'datetime',
+    ];
+
+    public function contentBlocks(): HasMany
     {
         return $this->hasMany(ContentBlock::class);
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(PageRevision::class);
+    }
+
+    public function lastEditor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'last_editor_id');
     }
 }

--- a/backend/app/Models/PageRevision.php
+++ b/backend/app/Models/PageRevision.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PageRevision extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'page_id',
+        'version',
+        'status',
+        'workflow_state',
+        'payload',
+        'event',
+        'notes',
+        'editor_id',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+
+    public function page(): BelongsTo
+    {
+        return $this->belongsTo(Page::class);
+    }
+
+    public function editor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'editor_id');
+    }
+}

--- a/backend/database/migrations/2024_02_10_001000_add_workflow_fields_to_pages_table.php
+++ b/backend/database/migrations/2024_02_10_001000_add_workflow_fields_to_pages_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->string('status')->default('draft');
+            $table->string('workflow_state')->default('draft');
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_for')->nullable();
+            $table->foreignId('last_editor_id')->nullable()->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('last_editor_id');
+            $table->dropColumn(['status', 'workflow_state', 'published_at', 'scheduled_for']);
+        });
+    }
+};

--- a/backend/database/migrations/2024_02_10_001100_create_page_revisions_table.php
+++ b/backend/database/migrations/2024_02_10_001100_create_page_revisions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('page_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('page_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('version');
+            $table->string('status')->default('draft');
+            $table->string('workflow_state')->default('draft');
+            $table->json('payload');
+            $table->string('event')->nullable();
+            $table->text('notes')->nullable();
+            $table->foreignId('editor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['page_id', 'version']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('page_revisions');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -200,6 +200,16 @@ Route::prefix('admin/website')
         Route::get('/pages', [PageController::class, 'adminIndex']);
         Route::get('/pages/{slug}', [PageController::class, 'adminShow']);
         Route::put('/pages/{slug}', [PageController::class, 'adminUpdate']);
+        Route::post('/pages/{slug}/preview', [PageController::class, 'preview']);
+        Route::post('/pages/{slug}/publish', [PageController::class, 'publish']);
+        Route::post('/pages/publish-all', [PageController::class, 'publishAll']);
+        Route::post('/pages/{slug}/request-approval', [PageController::class, 'requestApproval']);
+        Route::post('/pages/{slug}/approve', [PageController::class, 'approve']);
+        Route::post('/pages/{slug}/schedule', [PageController::class, 'schedule']);
+        Route::delete('/pages/{slug}/schedule', [PageController::class, 'cancelSchedule']);
+        Route::get('/pages/{slug}/history', [PageController::class, 'history']);
+        Route::get('/pages/publishing-queue', [PageController::class, 'publishingQueue']);
+        Route::post('/upload', [UploadController::class, 'store']);
         Route::get('/settings', [PageController::class, 'settings']);
         Route::put('/settings', [PageController::class, 'updateSettings']);
     });


### PR DESCRIPTION
## Summary
- extend the page admin controller with workflow, scheduling, preview, publishing, and history endpoints
- add dedicated resources for publishing queue and page revisions while enriching page payloads for the dashboard
- introduce workflow metadata columns and a page revisions table to persist history snapshots

## Testing
- php -l app/Http/Controllers/Api/Website/PageController.php
- php -l app/Models/Page.php
- php -l app/Models/PageRevision.php
- php -l app/Http/Resources/PageResource.php
- php -l app/Http/Resources/PageRevisionResource.php
- php -l app/Http/Resources/PublishingQueueResource.php
- php -l database/migrations/2024_02_10_001000_add_workflow_fields_to_pages_table.php
- php -l database/migrations/2024_02_10_001100_create_page_revisions_table.php

------
https://chatgpt.com/codex/tasks/task_e_68e18b9f18a0832fa5aae867d96f12e9