### PR TITLE
feat: add neon frosted section title styling

### DIFF
--- a/frontend/src/components/SectionTitle.tsx
+++ b/frontend/src/components/SectionTitle.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import { motion, type HTMLMotionProps } from 'framer-motion';
+import type { ReactNode, CSSProperties } from 'react';
+
+import { cn } from '@/lib/utils';
+
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4';
+
+const motionMap = {
+  h1: motion.h1,
+  h2: motion.h2,
+  h3: motion.h3,
+  h4: motion.h4,
+} as const;
+
+type GlowStyle = CSSProperties & {
+  '--glow-intensity'?: number | string;
+};
+
+type SectionTitleProps<T extends HeadingTag = 'h2'> = HTMLMotionProps<T> & {
+  as?: T;
+  children: ReactNode;
+  glowIntensity?: number | string;
+  animateOnView?: boolean;
+};
+
+export const SectionTitle = <T extends HeadingTag = 'h2'>(props: SectionTitleProps<T>) => {
+  const {
+    as: componentTag = 'h2',
+    animateOnView = true,
+    className,
+    children,
+    glowIntensity,
+    style,
+    initial,
+    whileInView,
+    viewport,
+    transition,
+    ...rest
+  } = props;
+
+  const MotionComponent = useMemo(() => motionMap[componentTag as HeadingTag], [componentTag]);
+
+  const resolvedStyle: GlowStyle = {
+    ...(style as GlowStyle),
+  };
+
+  if (glowIntensity !== undefined) {
+    resolvedStyle['--glow-intensity'] = glowIntensity;
+  }
+
+  const defaultInitial = { opacity: 0, y: 30, scale: 0.97 };
+  const defaultWhileInView = { opacity: 1, y: 0, scale: 1 };
+  const defaultViewport = { once: true, amount: 0.55 };
+  const defaultTransition = { duration: 0.6, ease: [0.22, 1, 0.36, 1] as [number, number, number, number] };
+
+  return (
+    <MotionComponent
+      initial={initial ?? (animateOnView ? defaultInitial : undefined)}
+      whileInView={whileInView ?? (animateOnView ? defaultWhileInView : undefined)}
+      viewport={viewport ?? (animateOnView ? defaultViewport : undefined)}
+      transition={transition ?? (animateOnView ? defaultTransition : undefined)}
+      className={cn(
+        'section-title relative inline-flex w-fit items-center justify-center text-balance font-extrabold',
+        'tracking-[0.08em] text-3xl md:text-5xl',
+        'text-[hsl(var(--title-color-light))] dark:text-[hsl(var(--title-color-dark))]',
+        'drop-shadow-[0_0_18px_rgba(175,220,255,var(--glow-intensity))]',
+        'after:pointer-events-none after:absolute after:inset-0 after:-z-10 after:rounded-[2.5rem]',
+        'after:bg-gradient-to-b after:from-transparent after:via-white/10 after:to-white/5',
+        'dark:after:via-white/5 dark:after:to-white/0',
+        'transition-all duration-700 ease-out',
+        'hover:text-white hover:drop-shadow-[0_0_25px_rgba(175,220,255,0.8)]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2',
+        'focus-visible:ring-offset-background',
+        className,
+      )}
+      style={resolvedStyle}
+      {...rest}
+    >
+      <span className="relative z-10">
+        {children}
+      </span>
+    </MotionComponent>
+  );
+};
+
+export default SectionTitle;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Amiri:wght@400;700&family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@500;600;700;800&family=Outfit:wght@500;600;700;800&family=Poppins:wght@600;700;800;900&display=swap');
 @import './styles/theme-tokens.css';
 @import './styles/radix-vars.css';
 @import './styles/dashboard-shell.css';
@@ -10,6 +11,13 @@
 
 
 @layer base {
+  :root {
+    --title-color-light: 215 80% 22%;
+    --title-color-dark: 215 100% 88%;
+    --title-glow-dark: 175 220 255;
+    --glow-intensity: 0.65;
+  }
+
   * {
     @apply border-border;
   }
@@ -17,12 +25,42 @@
   body {
     @apply bg-background text-foreground;
   }
+
   /* Dark CTA background */
-.bg-cta-dark {
-  @apply bg-gradient-to-br from-primary via-primary-glow to-slate-bg;
-  background-image: url('/textures/stars.svg');
-  background-size: cover;
-  opacity: 0.9;
+  .bg-cta-dark {
+    @apply bg-gradient-to-br from-primary via-primary-glow to-slate-bg;
+    background-image: url('/textures/stars.svg');
+    background-size: cover;
+    opacity: 0.9;
+  }
 }
 
+@layer components {
+  .section-title {
+    font-family: 'Poppins', 'Cairo', 'Outfit', 'Inter', var(--font-display, 'Inter'), sans-serif;
+    letter-spacing: 0.08em;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    text-shadow:
+      0 0 10px rgba(175, 220, 255, 0.25),
+      0 0 20px rgba(175, 220, 255, 0.15),
+      1px 2px 4px rgba(0, 0, 0, 0.35);
+  }
+
+  .section-title::after {
+    background-image: linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.1));
+  }
+
+  .dark .section-title {
+    color: hsl(var(--title-color-dark));
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.45);
+    text-shadow:
+      0 0 12px rgba(var(--title-glow-dark), 0.3),
+      0 0 24px rgba(var(--title-glow-dark), 0.2),
+      0 0 40px rgba(var(--title-glow-dark), 0.35),
+      1px 2px 6px rgba(0, 0, 0, 0.45);
+  }
+
+  .dark .section-title::after {
+    background-image: linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.08));
+  }
 }

--- a/frontend/src/pages/Landing/Capabilities.tsx
+++ b/frontend/src/pages/Landing/Capabilities.tsx
@@ -1,8 +1,10 @@
-    import { useCallback, useMemo } from 'react';
-    import { Cpu, Layers, ShieldEllipsis } from 'lucide-react';
-    import { useLanguage } from '@/contexts/LanguageContext';
-    import { useWebsiteContent } from '@/hooks/useWebsiteContent';
-    import type { ContentBlock, Locale } from '@/types/website';
+import { useCallback, useMemo } from 'react';
+import { Cpu, Layers, ShieldEllipsis } from 'lucide-react';
+
+import SectionTitle from '@/components/SectionTitle';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useWebsiteContent } from '@/hooks/useWebsiteContent';
+import type { ContentBlock, Locale } from '@/types/website';
 
     const iconLookup: Record<string, typeof Layers> = {
       layers: Layers,
@@ -49,9 +51,12 @@
               <div className="relative mx-auto mt-8 inline-flex max-w-3xl flex-col items-center overflow-hidden rounded-3xl bg-gradient-to-r from-primary via-primary-hover to-accent p-[1px]">
                 <div className="relative w-full overflow-hidden rounded-[calc(1.5rem-1px)] bg-gradient-to-r from-background/95 via-background/90 to-background/95 px-8 py-10 shadow-header-light transition-shadow duration-500 dark:from-secondary/40 dark:via-primary-darker/60 dark:to-secondary/40 dark:shadow-header-dark">
                   <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-aurora opacity-0 blur-3xl transition-opacity duration-500 dark:opacity-20" />
-                  <h2 className="text-4xl font-display font-bold text-foreground lg:text-5xl">
+                  <SectionTitle
+                    className="mx-auto text-center font-display"
+                    glowIntensity={0.7}
+                  >
                     {header.title}
-                  </h2>
+                  </SectionTitle>
                   <p className="mt-3 text-lg leading-relaxed text-muted-foreground/90 lg:text-xl">
                     {header.subtitle}
                   </p>

--- a/frontend/src/pages/Landing/HeroCarousel.tsx
+++ b/frontend/src/pages/Landing/HeroCarousel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { motion, AnimatePresence, easeOut } from 'framer-motion';
 import { Button } from '@/components/ui/button';
+import SectionTitle from '@/components/SectionTitle';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useWebsiteContent } from '@/hooks/useWebsiteContent';
 import type { Locale } from '@/types/website';
@@ -160,13 +161,16 @@ const HeroCarousel: React.FC = () => {
             )}
 
             {/* العنوان */}
-            <motion.h1
+            <SectionTitle
+              as="h1"
               variants={textVariants}
               custom={1}
-              className="text-4xl lg:text-5xl font-bold leading-tight text-white drop-shadow-md"
+              animateOnView={false}
+              glowIntensity={0.85}
+              className="max-w-3xl text-left font-display text-[hsl(var(--title-color-dark))] dark:text-[hsl(var(--title-color-dark))] lg:text-6xl"
             >
               {active.title}
-            </motion.h1>
+            </SectionTitle>
 
             <motion.p
               variants={textVariants}

--- a/frontend/src/pages/Landing/Insights.tsx
+++ b/frontend/src/pages/Landing/Insights.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { useWebsiteContent } from "@/hooks/useWebsiteContent";
 import { useWebsiteCollection } from "@/hooks/useWebsiteCollection";
+import SectionTitle from '@/components/SectionTitle';
 import type { ArticleApi, Locale } from "@/types/website";
 import { BrainCircuit, Newspaper, ShieldAlert } from "lucide-react";
 
@@ -37,7 +38,9 @@ const Insights: React.FC = () => {
           <div className="inline-flex items-center gap-3 rounded-full border border-border bg-card px-5 py-2 text-xs font-semibold text-muted-foreground">
             <span>{badge}</span>
           </div>
-          <h2 className="mt-6 text-4xl font-display font-bold text-foreground lg:text-5xl">{title}</h2>
+          <SectionTitle className="mx-auto font-display" glowIntensity={0.68}>
+            {title}
+          </SectionTitle>
           <p className="mt-4 text-lg text-muted-foreground lg:text-xl">{description}</p>
 
         </div>

--- a/frontend/src/pages/Landing/Testimonials.tsx
+++ b/frontend/src/pages/Landing/Testimonials.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import SectionTitle from '@/components/SectionTitle';
 import { motion, useAnimationFrame } from 'framer-motion';
 import { Star, Quote } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -48,9 +49,12 @@ const Testimonials: React.FC = () => {
           <span className="inline-block px-4 py-2 rounded-full bg-gold-light text-gold-muted font-semibold text-sm mb-4">
             {direction === 'rtl' ? 'آراء العملاء' : 'Client Reviews'}
           </span>
-          <h2 className="text-4xl md:text-5xl font-bold text-primary mb-6 font-cairo">
+          <SectionTitle
+            className="mx-auto font-cairo"
+            glowIntensity={0.75}
+          >
             {direction === 'rtl' ? 'ماذا يقول عملاؤنا' : 'What Our Clients Say'}
-          </h2>
+          </SectionTitle>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
             {direction === 'rtl'
               ? 'آراء حقيقية من محامين ومكاتب قانونية تستخدم حلولنا يومياً'

--- a/frontend/src/pages/Landing/components/SectionHeader.tsx
+++ b/frontend/src/pages/Landing/components/SectionHeader.tsx
@@ -1,6 +1,7 @@
 import { memo, type ReactNode } from 'react';
 import { motion, cubicBezier } from 'framer-motion';
 
+import SectionTitle from '@/components/SectionTitle';
 import { cn } from '@/lib/utils';
 
 interface SectionHeaderProps {
@@ -16,18 +17,6 @@ const premiumEase = cubicBezier(0.22, 1, 0.36, 1);
 const badgeMotion = {
   hidden: { opacity: 0, y: 12 },
   visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: premiumEase } },
-};
-
-const titleMotion = {
-  hidden: { opacity: 0, y: 32 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.75,
-      ease: premiumEase,
-    },
-  },
 };
 
 const subtitleMotion = {
@@ -75,14 +64,15 @@ const SectionHeader: React.FC<SectionHeaderProps> = memo(({ badge, title, subtit
       ) : null}
 
       {title ? (
-        <motion.h2
-          variants={titleMotion}
-          className="text-balance font-display text-4xl font-semibold tracking-tight text-foreground transition-colors duration-500 md:text-5xl"
+        <SectionTitle
+          className={cn(
+            'font-display',
+            align === 'center' && 'mx-auto',
+            align === 'right' && 'ml-auto',
+          )}
         >
-          <span className="headline-neon" data-title={title ?? ''}>
-            {title}
-          </span>
-        </motion.h2>
+          {title}
+        </SectionTitle>
       ) : null}
 
       {subtitle ? (


### PR DESCRIPTION
## Summary
- add a reusable SectionTitle component with neon frost motion, glow intensity control, and optional heading levels
- introduce theme-aware typography variables, imported luxury fonts, and frosted headline styling in the global stylesheet
- update landing sections (hero, header, capabilities, testimonials, insights) to render their titles with the new luminous component

## Testing
- npm run lint *(fails: existing eslint @typescript-eslint/no-explicit-any issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1968030e0832f8bc9d6c2e56768d8