### PR TITLE
Add admin API endpoints and wire frontend auth to backend

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/AdminAuthController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminAuthController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Middleware\EnsureUserHasRole;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AdminAuthController extends Controller
+{
+    private const ROLE_LABELS = [
+        'admin' => 'Admin',
+        'editor' => 'Editor',
+        'viewer' => 'Viewer',
+    ];
+
+    private const ROLE_PERMISSIONS = [
+        'admin' => [
+            'pages:view',
+            'pages:edit',
+            'pages:publish',
+            'pages:approve',
+            'pages:schedule',
+            'pages:bulk-publish',
+            'media:upload',
+            'analytics:view',
+        ],
+        'editor' => [
+            'pages:view',
+            'pages:edit',
+            'pages:schedule',
+            'media:upload',
+        ],
+        'viewer' => [
+            'pages:view',
+            'analytics:view',
+        ],
+    ];
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if ($user === null) {
+            return new JsonResponse(['message' => 'Unauthenticated.'], 401);
+        }
+
+        $roleKey = EnsureUserHasRole::normalizeRole($user->role ?? null) ?? 'viewer';
+        $roles = [$this->resolveRoleLabel($roleKey)];
+
+        $token = $user->tokens()
+            ->orderByDesc('last_used_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        $lastLoginAt = $token?->last_used_at ?? $token?->created_at;
+
+        return new JsonResponse([
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'avatar' => $user->avatar ?? null,
+            'roles' => $roles,
+            'permissions' => $this->resolvePermissions($roleKey),
+            'last_login_at' => $lastLoginAt?->toIso8601String(),
+        ]);
+    }
+
+    private function resolveRoleLabel(string $roleKey): string
+    {
+        return self::ROLE_LABELS[$roleKey] ?? self::ROLE_LABELS['viewer'];
+    }
+
+    private function resolvePermissions(string $roleKey): array
+    {
+        $permissions = self::ROLE_PERMISSIONS[$roleKey] ?? self::ROLE_PERMISSIONS['viewer'];
+
+        return array_values(array_unique($permissions));
+    }
+}
+

--- a/backend/app/Http/Controllers/Api/Admin/AdminEventController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminEventController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Middleware\EnsureUserHasRole;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class AdminEventController extends Controller
+{
+    public function subscribe(Request $request): StreamedResponse
+    {
+        $tokenValue = $request->query('token') ?? $request->bearerToken();
+
+        if (! is_string($tokenValue) || $tokenValue === '') {
+            abort(401, 'Unauthenticated.');
+        }
+
+        $accessToken = PersonalAccessToken::findToken($tokenValue);
+
+        if ($accessToken === null || $accessToken->tokenable === null) {
+            abort(401, 'Unauthenticated.');
+        }
+
+        $user = $accessToken->tokenable;
+
+        if (! EnsureUserHasRole::userHasRole($user, ['admin'])) {
+            abort(403, 'Forbidden.');
+        }
+
+        $accessToken->forceFill(['last_used_at' => Carbon::now()])->save();
+
+        return response()->stream(function () use ($user): void {
+            $this->sendEvent('connected', [
+                'message' => 'Connected to admin event stream.',
+                'timestamp' => Carbon::now()->toIso8601String(),
+                'user' => $user->name ?? 'Administrator',
+            ]);
+
+            while (! connection_aborted()) {
+                $this->sendEvent('heartbeat', [
+                    'message' => 'heartbeat',
+                    'timestamp' => Carbon::now()->toIso8601String(),
+                ]);
+
+                sleep(15);
+            }
+        }, 200, [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache, no-store, must-revalidate',
+            'X-Accel-Buffering' => 'no',
+        ]);
+    }
+
+    private function sendEvent(string $event, array $payload): void
+    {
+        try {
+            echo 'event: ' . $event . "\n";
+            echo 'data: ' . json_encode($payload, JSON_THROW_ON_ERROR) . "\n\n";
+            @ob_flush();
+            flush();
+        } catch (\Throwable $exception) {
+            Log::warning('Unable to dispatch admin SSE event.', [
+                'event' => $event,
+                'exception' => $exception->getMessage(),
+            ]);
+        }
+    }
+}
+

--- a/backend/app/Http/Controllers/Api/Admin/WebsiteActivityController.php
+++ b/backend/app/Http/Controllers/Api/Admin/WebsiteActivityController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\PageRevision;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebsiteActivityController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $limit = (int) $request->integer('limit', 50);
+        $limit = max(1, min($limit, 200));
+
+        $revisions = PageRevision::query()
+            ->with(['page', 'editor'])
+            ->orderByDesc('created_at')
+            ->limit($limit)
+            ->get();
+
+        $activity = $revisions->map(function (PageRevision $revision): array {
+            $timestamp = $revision->created_at?->toIso8601String();
+            $page = $revision->page;
+
+            return [
+                'id' => (string) $revision->id,
+                'timestamp' => $timestamp,
+                'user' => $revision->editor?->name ?? 'System',
+                'action' => $revision->event ?? $revision->status ?? 'update',
+                'section' => $page?->slug,
+                'diffSummary' => $revision->notes,
+                'metadata' => array_filter([
+                    'page_id' => $revision->page_id,
+                    'page_slug' => $page?->slug,
+                    'version' => $revision->version,
+                    'status' => $revision->status,
+                    'workflow_state' => $revision->workflow_state,
+                ], static fn ($value) => $value !== null),
+            ];
+        });
+
+        return new JsonResponse($activity);
+    }
+}
+

--- a/backend/app/Http/Controllers/Api/Admin/WebsiteReportController.php
+++ b/backend/app/Http/Controllers/Api/Admin/WebsiteReportController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Page;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Carbon;
+
+class WebsiteReportController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $pages = Page::query()
+            ->withCount('revisions')
+            ->get();
+
+        $totalPages = $pages->count();
+        $publishedPages = $pages->where('status', 'published')->count();
+        $pendingDrafts = $pages->where('status', '!=', 'published')->count();
+        $completionRate = $totalPages > 0
+            ? round(($publishedPages / $totalPages) * 100, 2)
+            : 0;
+
+        $sections = $pages->map(function (Page $page): array {
+            return [
+                'slug' => $page->slug,
+                'title' => $page->title_en ?? $page->title_ar ?? ucfirst($page->slug),
+                'status' => $page->status ?? 'draft',
+                'completion' => $this->calculateCompletion($page),
+                'updated_at' => $page->updated_at?->toIso8601String(),
+                'edit_frequency' => $page->revisions_count,
+                'pending_approvals' => $page->workflow_state === 'pendingReview' ? 1 : 0,
+            ];
+        });
+
+        $pendingApprovals = $sections->sum(static fn (array $section) => $section['pending_approvals'] ?? 0);
+
+        $lastEditedTimestamp = $pages
+            ->map(fn (Page $page) => $page->updated_at?->getTimestamp())
+            ->filter()
+            ->max();
+
+        $lastEditedAt = $lastEditedTimestamp
+            ? Carbon::createFromTimestamp($lastEditedTimestamp)->toIso8601String()
+            : null;
+
+        $report = [
+            'completionRate' => $completionRate,
+            'completedPages' => $publishedPages,
+            'totalPages' => $totalPages,
+            'pendingDrafts' => $pendingDrafts,
+            'lastEditedAt' => $lastEditedAt,
+            'apiHealthy' => true,
+            'sections' => $sections->values(),
+            'editFrequencyPerPage' => $pages->map(fn (Page $page) => [
+                'slug' => $page->slug,
+                'edits' => (int) $page->revisions_count,
+            ])->values(),
+            'timeSinceLastPublish' => $pages
+                ->filter(fn (Page $page) => $page->published_at !== null)
+                ->map(fn (Page $page) => [
+                    'slug' => $page->slug,
+                    'minutes' => $page->published_at?->diffInMinutes(Carbon::now()) ?? 0,
+                ])->values(),
+            'pendingApprovals' => $pendingApprovals,
+            'mediaStorageUsage' => null,
+        ];
+
+        return new JsonResponse($report);
+    }
+
+    private function calculateCompletion(Page $page): float
+    {
+        return match ($page->status) {
+            'published' => 100.0,
+            'pendingReview', 'pending' => 75.0,
+            'preview', 'scheduled' => 60.0,
+            default => 35.0,
+        };
+    }
+}
+

--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -15,12 +15,16 @@ class AuthController extends Controller
             'name' => 'required|string',
             'email' => 'required|string|email|unique:users',
             'password' => 'required|string|confirmed',
+            'role' => 'sometimes|string|in:1,2,3',
         ]);
+
+        $role = $request->input('role', '3');
 
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'role' => $role,
         ]);
 
         $token = $user->createToken('auth_token')->plainTextToken;

--- a/backend/app/Http/Middleware/EnsureUserHasRole.php
+++ b/backend/app/Http/Middleware/EnsureUserHasRole.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserHasRole
+{
+    /**
+     * Aliases that can be used to match a stored user role to a friendly name.
+     */
+    private const ROLE_ALIASES = [
+        'admin' => 'admin',
+        'administrator' => 'admin',
+        '1' => 'admin',
+
+        'editor' => 'editor',
+        '2' => 'editor',
+
+        'viewer' => 'viewer',
+        'client' => 'viewer',
+        '3' => 'viewer',
+    ];
+
+    /**
+     * Resolve the canonical role name for the provided value.
+     */
+    public static function normalizeRole(string|int|null $role): ?string
+    {
+        if ($role === null) {
+            return null;
+        }
+
+        $key = strtolower((string) $role);
+
+        return self::ROLE_ALIASES[$key] ?? null;
+    }
+
+    /**
+     * Determine if the given user owns one of the provided roles.
+     */
+    public static function userHasRole(object|null $user, array $roles): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        $normalizedUserRole = self::normalizeRole($user->role ?? null);
+
+        if ($normalizedUserRole === null) {
+            return false;
+        }
+
+        $targets = array_map(function ($role) {
+            return self::normalizeRole($role) ?? strtolower((string) $role);
+        }, $roles);
+
+        return in_array($normalizedUserRole, $targets, true);
+    }
+
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            return new JsonResponse(['message' => 'Unauthenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if ($roles === [] || self::userHasRole($user, $roles)) {
+            return $next($request);
+        }
+
+        return new JsonResponse(['message' => 'Forbidden.'], Response::HTTP_FORBIDDEN);
+    }
+}
+

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'name',
         'email',
         'password',
+        'role',
     ];
 
 

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\EnsureUserHasRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/backend/database/seeders/UsersTableSeeder.php
+++ b/backend/database/seeders/UsersTableSeeder.php
@@ -22,11 +22,13 @@ DB::statement('SET FOREIGN_KEY_CHECKS=1;');
                 'name' => 'عبدالحميد عسكر',
                 'email' => 'a@a.com',
                 'password' => 'Ask@123456',
+                'role' => '1',
             ],
             [
                 'name' => 'User 2',
                 'email' => 'user2@example.com',
                 'password' => 'password',
+                'role' => '3',
             ],
         ];
 
@@ -37,6 +39,7 @@ DB::statement('SET FOREIGN_KEY_CHECKS=1;');
                     'name' => $userData['name'],
                     'email' => $userData['email'],
                     'password' => Hash::make($userData['password']),
+                    'role' => $userData['role'],
                 ]);
 
                 // إنشاء التوكن الشخصي للمستخدم

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Http\Controllers\Api\Admin\AdminAuthController;
+use App\Http\Controllers\Api\Admin\AdminEventController;
+use App\Http\Controllers\Api\Admin\WebsiteActivityController;
+use App\Http\Controllers\Api\Admin\WebsiteReportController;
 use App\Http\Controllers\Api\Website\AchievementController;
 use App\Http\Controllers\Api\Website\ArticleController;
 use App\Http\Controllers\Api\Website\PageController;
@@ -55,6 +59,19 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::put('/user/{user}', [UserController::class, 'updateProfile'])->name('user.update');
     Route::get('/user/{user}', [UserController::class, 'getUserDetails'])->name('user.details');
 });
+
+Route::prefix('admin')
+    ->middleware('auth:sanctum')
+    ->group(function () {
+        Route::get('/auth/me', AdminAuthController::class);
+
+        Route::middleware('role:admin')->group(function () {
+            Route::get('/website/activity', WebsiteActivityController::class);
+            Route::get('/website/report', WebsiteReportController::class);
+        });
+    });
+
+Route::get('/admin/events/subscribe', [AdminEventController::class, 'subscribe']);
 
 // Dashboard & searches
 Route::get('/search-court', [CourtSearchController::class, 'index']);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,15 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
+import api from '@/api/axiosConfig';
+
+interface ApiUser {
+  id: number | string;
+  email: string;
+  name: string;
+  role?: string | number | null;
+  avatar?: string | null;
+}
+
 export interface User {
   id: string;
   email: string;
@@ -32,33 +42,100 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Check for stored auth state
-    const storedUser = localStorage.getItem('avocat_user');
-    if (storedUser) {
-      setUser(JSON.parse(storedUser));
-    }
-    setLoading(false);
+    const initialize = async () => {
+      try {
+        const storedUser = localStorage.getItem('avocat_user');
+        if (storedUser) {
+          try {
+            setUser(JSON.parse(storedUser) as User);
+          } catch (error) {
+            console.warn('Failed to parse stored user payload', error);
+            localStorage.removeItem('avocat_user');
+          }
+        }
+
+        const storedToken = sessionStorage.getItem('token');
+        if (storedToken) {
+          const parsedToken = JSON.parse(storedToken) as string;
+          if (parsedToken) {
+            const { data } = await api.get<ApiUser>('/api/auth/profile');
+            const mappedUser = mapApiUserToContextUser(data);
+            setUser(mappedUser);
+            localStorage.setItem('avocat_user', JSON.stringify(mappedUser));
+          }
+        }
+      } catch (error) {
+        console.warn('Failed to bootstrap auth state from API', error);
+        sessionStorage.removeItem('token');
+        localStorage.removeItem('avocat_user');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void initialize();
   }, []);
+
+  const mapRole = (role: ApiUser['role']): User['role'] => {
+    const normalized = typeof role === 'string' ? role.toLowerCase() : String(role ?? '').toLowerCase();
+
+    if (normalized === '1' || normalized === 'admin') {
+      return 'admin';
+    }
+
+    if (normalized === '2' || normalized === 'lawyer') {
+      return 'lawyer';
+    }
+
+    return 'client';
+  };
+
+  const mapApiUserToContextUser = (payload: ApiUser): User => ({
+    id: String(payload.id),
+    email: payload.email,
+    name: payload.name,
+    avatar: payload.avatar ?? undefined,
+    role: mapRole(payload.role ?? null),
+  });
+
+  const extractErrorMessage = (error: unknown, fallback: string): string => {
+    if (error && typeof error === 'object') {
+      const maybeResponse = (error as { response?: { data?: { message?: string } } }).response;
+      if (maybeResponse?.data?.message && typeof maybeResponse.data.message === 'string') {
+        return maybeResponse.data.message;
+      }
+
+      if ('message' in error && typeof (error as { message?: string }).message === 'string') {
+        return (error as { message: string }).message;
+      }
+    }
+
+    return fallback;
+  };
 
   const login = async (email: string, password: string) => {
     setLoading(true);
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Mock user data
-      const mockUser: User = {
-        id: '1',
-        email,
-        name: email === 'admin@avocat.com' ? 'أحمد المحامي' : 'محمد العميل',
-        avatar: `https://api.dicebear.com/7.x/initials/svg?seed=${email}`,
-        role: email === 'admin@avocat.com' ? 'admin' : 'client'
-      };
+      const response = await api.post<{ user: ApiUser; access_token: string }>(
+        '/api/auth/login',
+        { email, password },
+      );
 
-      setUser(mockUser);
-      localStorage.setItem('avocat_user', JSON.stringify(mockUser));
+      const token = response.data?.access_token;
+      const apiUser = response.data?.user;
+
+      if (!token || !apiUser) {
+        throw new Error('Invalid authentication response.');
+      }
+
+      sessionStorage.setItem('token', JSON.stringify(token));
+
+      const mappedUser = mapApiUserToContextUser(apiUser);
+      setUser(mappedUser);
+      localStorage.setItem('avocat_user', JSON.stringify(mappedUser));
     } catch (error) {
-      throw new Error('فشل في تسجيل الدخول');
+      const message = extractErrorMessage(error, 'فشل في تسجيل الدخول');
+      throw new Error(message);
     } finally {
       setLoading(false);
     }
@@ -67,21 +144,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signup = async (email: string, password: string, name: string) => {
     setLoading(true);
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      const newUser: User = {
-        id: Date.now().toString(),
-        email,
-        name,
-        avatar: `https://api.dicebear.com/7.x/initials/svg?seed=${name}`,
-        role: 'client'
-      };
+      const response = await api.post<{ user: ApiUser; access_token: string }>(
+        '/api/auth/register',
+        {
+          name,
+          email,
+          password,
+          password_confirmation: password,
+          role: '3',
+        },
+      );
 
-      setUser(newUser);
-      localStorage.setItem('avocat_user', JSON.stringify(newUser));
+      const token = response.data?.access_token;
+      const apiUser = response.data?.user;
+
+      if (!token || !apiUser) {
+        throw new Error('Invalid registration response.');
+      }
+
+      sessionStorage.setItem('token', JSON.stringify(token));
+
+      const mappedUser = mapApiUserToContextUser(apiUser);
+      setUser(mappedUser);
+      localStorage.setItem('avocat_user', JSON.stringify(mappedUser));
     } catch (error) {
-      throw new Error('فشل في إنشاء الحساب');
+      const message = extractErrorMessage(error, 'فشل في إنشاء الحساب');
+      throw new Error(message);
     } finally {
       setLoading(false);
     }
@@ -90,6 +178,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const logout = () => {
     setUser(null);
     localStorage.removeItem('avocat_user');
+    sessionStorage.removeItem('token');
+    void api.post('/api/auth/logout').catch(() => undefined);
   };
 
   const value = {


### PR DESCRIPTION
## Summary
- add dedicated admin controllers for profile, activity, report, and server-sent event subscriptions guarded by a role middleware
- default user roles during registration/seeding and expose the role middleware alias for routing
- switch the React auth context to use the backend login/register/profile APIs so admin pages receive valid tokens

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b5c5daf8832fbc6c29f4ebe9c550