### PR TITLE
Fix mobile drawer toggle on small screens

### DIFF
--- a/frontend/src/contexts/SidebarContext.tsx
+++ b/frontend/src/contexts/SidebarContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 interface SidebarContextType {
   isCollapsed: boolean;
@@ -59,17 +65,17 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ child
     }
   }, [isCollapsed]);
 
-  const toggleCollapsed = () => {
+  const toggleCollapsed = useCallback(() => {
     setIsCollapsed(prev => !prev);
-  };
+  }, []);
 
-  const toggleMobile = () => {
+  const toggleMobile = useCallback(() => {
     setIsMobileOpen(prev => !prev);
-  };
+  }, []);
 
-  const closeMobile = () => {
+  const closeMobile = useCallback(() => {
     setIsMobileOpen(false);
-  };
+  }, []);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;


### PR DESCRIPTION
## Summary
- memoize sidebar context actions to keep stable references across renders
- ensure the mobile drawer remains open after tapping the header toggle on small screens

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bb17a164832f92b14d1c6db55066