### PR TITLE
Guard admin notifications behind admin auth

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,23 @@
+# Troubleshooting admin API errors
+
+When you open the web admin UI without an authenticated admin session you will see the browser console fill up with messages like:
+
+```
+Failed to load resource: the server responded with a status of 401 (Unauthorized)
+GET http://127.0.0.1:8000/api/admin/auth/me 401 (Unauthorized)
+GET http://127.0.0.1:8000/api/admin/website/pages 401 (Unauthorized)
+GET http://127.0.0.1:8000/api/admin/website/testimonials 404 (Not Found)
+```
+
+These errors originate from the frontend calling Laravel Sanctum-protected endpoints. The relevant routes are defined in [`backend/routes/api.php`](../backend/routes/api.php) and all `/api/admin/...` routes require an authenticated Sanctum token that belongs to a user with the `admin` role. Until you log in, the interceptor in [`frontend/src/api/axiosConfig.ts`](../frontend/src/api/axiosConfig.ts) has no bearer token to attach, so Sanctum responds with `401 Unauthorized`.
+
+To resolve the issue:
+
+1. Log in through the normal authentication flow (`/api/auth/login`). The response contains an `access_token` that the frontend stores in `sessionStorage`.
+2. After a successful login refresh, the axios interceptor sends the `Authorization: Bearer <token>` header, allowing requests such as `/api/admin/auth/me` and `/api/admin/website/pages` to succeed.
+
+If you are logged in as a non-admin user, the same calls will still fail with `403 Forbidden` because of the `role:admin` middleware on those routes. Switch to an account whose `role` value maps to `admin`.
+
+The `404 Not Found` responses for `/api/admin/website/testimonials` and `/api/admin/website/articles` occur because the backend only exposes `team`, `achievements`, and `articles` CRUD endpoints inside the `/api/website` prefix. There is currently no `/api/admin/website/testimonials` route, so the frontend call returns `404`. Fetch testimonials from the page content instead, or add the missing backend route before calling it.
+
+In short, authenticate with an admin account before visiting the admin dashboard and avoid calling routes that are not implemented on the backend.

--- a/frontend/src/hooks/useUserRoles.ts
+++ b/frontend/src/hooks/useUserRoles.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getAdminProfile } from '@/api/adminAuth.service';
 import type { Permission, Role } from '@/types/website';
+import { useAuth } from '@/contexts/AuthContext';
 
 const rolePermissions: Record<Role, Permission[]> = {
   Admin: [
@@ -38,22 +39,37 @@ export interface UseUserRolesResult {
 }
 
 export const useUserRoles = (): UseUserRolesResult => {
+  const { user, isAuthenticated } = useAuth();
+  const isAdmin = isAuthenticated && user?.role === 'admin';
+
   const profileQuery = useQuery({
     queryKey: ['admin-profile'],
     queryFn: getAdminProfile,
+    enabled: isAdmin,
   });
 
-  const roles = useMemo(() => normalizeRoles(profileQuery.data?.roles), [profileQuery.data?.roles]);
+  const roles = useMemo(() => {
+    if (!isAdmin) {
+      return ['Viewer'] as Role[];
+    }
+
+    return normalizeRoles(profileQuery.data?.roles);
+  }, [isAdmin, profileQuery.data?.roles]);
 
   const permissions = useMemo(() => {
     const base = new Set<Permission>();
+
+    if (!isAdmin) {
+      return Array.from(base);
+    }
+
     roles.forEach((role) => {
       const rolePerms = rolePermissions[role];
       rolePerms?.forEach((permission) => base.add(permission));
     });
     profileQuery.data?.permissions?.forEach((permission) => base.add(permission));
     return Array.from(base);
-  }, [profileQuery.data?.permissions, roles]);
+  }, [isAdmin, profileQuery.data?.permissions, roles]);
 
   const hasRole = useCallback(
     (role: Role | Role[]) => {
@@ -75,7 +91,7 @@ export const useUserRoles = (): UseUserRolesResult => {
     permissions,
     hasRole,
     can,
-    isLoading: profileQuery.isLoading,
+    isLoading: profileQuery.isLoading && isAdmin,
     isError: profileQuery.isError,
     error: profileQuery.error,
   };

--- a/frontend/src/modules/notifications/NotificationCenter.tsx
+++ b/frontend/src/modules/notifications/NotificationCenter.tsx
@@ -19,6 +19,7 @@ import type {
   AdminNotificationSeverity,
   AdminServerEventPayload,
 } from '@/types/notifications';
+import { useAuth } from '@/contexts/AuthContext';
 
 export type NotificationConnectionState = 'idle' | 'connecting' | 'open' | 'error';
 
@@ -76,6 +77,8 @@ const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const reconnectAttempts = useRef(0);
   const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { user, isAuthenticated } = useAuth();
+  const isAdmin = isAuthenticated && user?.role === 'admin';
 
   const markAsRead = useCallback((id: string) => {
     setNotifications((prev) => prev.map((item) => (item.id === id ? { ...item, read: true } : item)));
@@ -89,14 +92,38 @@ const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
     setNotifications((prev) => prev.filter((item) => item.id !== id));
   }, []);
 
+  const readToken = useCallback((): string | null => {
+    try {
+      const storedToken = sessionStorage.getItem('token');
+      if (!storedToken) {
+        return null;
+      }
+
+      const parsed = JSON.parse(storedToken) as string | null;
+      if (!parsed || typeof parsed !== 'string' || parsed.length === 0) {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      console.warn('Unable to parse session token for SSE connection', error);
+      return null;
+    }
+  }, []);
+
   const refreshActivity = useCallback(async () => {
+    if (!isAdmin) {
+      setActivity([]);
+      return;
+    }
+
     try {
       const entries = await getActivityLog({ limit: 100 });
       setActivity(entries);
     } catch (error) {
       console.warn('Failed to refresh activity log', error);
     }
-  }, []);
+  }, [isAdmin]);
 
   const handleServerEvent = useCallback(
     (payload: AdminServerEventPayload) => {
@@ -157,6 +184,21 @@ const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     let isMounted = true;
 
+    if (!isAdmin) {
+      setIsBootstrapping(false);
+      setConnectionState('idle');
+      setActivity([]);
+      setNotifications([]);
+      reconnectAttempts.current = 0;
+      if (reconnectTimeout.current) {
+        clearTimeout(reconnectTimeout.current);
+        reconnectTimeout.current = null;
+      }
+      return () => {
+        isMounted = false;
+      };
+    }
+
     const bootstrap = async () => {
       try {
         await refreshActivity();
@@ -180,10 +222,24 @@ const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
         clearTimeout(reconnectTimeout.current);
       }
     };
-  }, [refreshActivity]);
+  }, [isAdmin, refreshActivity]);
 
   useEffect(() => {
     let eventSource: EventSource | null = null;
+
+    if (!isAdmin) {
+      setConnectionState('idle');
+      reconnectAttempts.current = 0;
+      if (reconnectTimeout.current) {
+        clearTimeout(reconnectTimeout.current);
+        reconnectTimeout.current = null;
+      }
+      return () => {
+        if (eventSource) {
+          eventSource.close();
+        }
+      };
+    }
 
     const connect = () => {
       if (eventSource) {
@@ -194,17 +250,13 @@ const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
       setConnectionState('connecting');
 
       const url = new URL('/api/admin/events/subscribe', API_CONFIG.baseURL);
-      try {
-        const storedToken = sessionStorage.getItem('token');
-        if (storedToken) {
-          const parsedToken = JSON.parse(storedToken) as string;
-          if (parsedToken) {
-            url.searchParams.set('token', parsedToken);
-          }
-        }
-      } catch (error) {
-        console.warn('Unable to parse session token for SSE connection', error);
+      const token = readToken();
+      if (!token) {
+        setConnectionState('idle');
+        return;
       }
+
+      url.searchParams.set('token', token);
 
       const source = new EventSource(url.toString(), { withCredentials: true });
       eventSource = source;
@@ -245,7 +297,7 @@ const NotificationCenterProvider = ({ children }: { children: ReactNode }) => {
         eventSource.close();
       }
     };
-  }, [handleServerEvent]);
+  }, [handleServerEvent, isAdmin, readToken]);
 
   const unreadCount = useMemo(
     () => notifications.reduce((total, notification) => (notification.read ? total : total + 1), 0),


### PR DESCRIPTION
## Summary
- gate the admin notification center so it only connects and fetches activity when an admin token is available
- read the persisted session token defensively before opening the admin SSE stream
- skip loading the admin profile when the signed-in user is not an admin

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bdf3eaf8832fbfb4bcb813b7c95e