### PR TITLE
Ensure seeded admin user aligns with role checks

### DIFF
--- a/backend/app/Http/Middleware/EnsureUserHasRole.php
+++ b/backend/app/Http/Middleware/EnsureUserHasRole.php
@@ -40,6 +40,19 @@ class EnsureUserHasRole
     }
 
     /**
+     * Map the provided role (alias or canonical) to the value stored in the database.
+     */
+    public static function databaseRoleValue(string|int $role): string
+    {
+        return match (self::normalizeRole($role)) {
+            'admin' => '1',
+            'editor' => '2',
+            'viewer' => '3',
+            default => (string) $role,
+        };
+    }
+
+    /**
      * Determine if the given user owns one of the provided roles.
      */
     public static function userHasRole(object|null $user, array $roles): bool

--- a/backend/database/seeders/UsersTableSeeder.php
+++ b/backend/database/seeders/UsersTableSeeder.php
@@ -2,33 +2,33 @@
 
 namespace Database\Seeders;
 
+use App\Http\Middleware\EnsureUserHasRole;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
-
 use Illuminate\Support\Facades\DB;
 
 class UsersTableSeeder extends Seeder
 {
     public function run(): void
     {
-             // 🧹 مسح كل المستخدمين قبل الإنشاء
-             DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-DB::table('users')->truncate();
-DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+        // 🧹 مسح كل المستخدمين قبل الإنشاء
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        DB::table('users')->truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         $users = [
             [
                 'name' => 'عبدالحميد عسكر',
                 'email' => 'a@a.com',
                 'password' => 'Ask@123456',
-                'role' => '1',
+                'role' => EnsureUserHasRole::databaseRoleValue('admin'),
             ],
             [
                 'name' => 'User 2',
                 'email' => 'user2@example.com',
                 'password' => 'password',
-                'role' => '3',
+                'role' => EnsureUserHasRole::databaseRoleValue('viewer'),
             ],
         ];
 


### PR DESCRIPTION
## Summary
- add a helper on `EnsureUserHasRole` to translate canonical role names to stored enum values
- update the users table seeder to rely on the helper so the default admin is seeded with the correct role after the new role/permission checks

## Testing
- `php artisan test` *(fails: vendor directory is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bee9f564832fba66660d35d649b6