### PR TITLE
Fix NotificationCenter provider placement

### DIFF
--- a/frontend/src/providers/AppProviders.tsx
+++ b/frontend/src/providers/AppProviders.tsx
@@ -21,8 +21,8 @@ const AppProviders = ({ children }: AppProvidersProps) => {
     <ThemeProvider>
       <LanguageProvider>
         <QueryClientProvider client={queryClient}>
-          <NotificationCenterProvider>
-            <AuthProvider>
+          <AuthProvider>
+            <NotificationCenterProvider>
               <SidebarProvider>
                 <TooltipProvider>
                   <Toaster />
@@ -30,8 +30,8 @@ const AppProviders = ({ children }: AppProvidersProps) => {
                   {children}
                 </TooltipProvider>
               </SidebarProvider>
-            </AuthProvider>
-          </NotificationCenterProvider>
+            </NotificationCenterProvider>
+          </AuthProvider>
         </QueryClientProvider>
       </LanguageProvider>
     </ThemeProvider>


### PR DESCRIPTION
## Summary
- ensure the NotificationCenterProvider is rendered within the AuthProvider so it can access the authentication context

## Testing
- npm run lint *(fails due to existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c854f820832fb8295235efede3bd