### PR TITLE
Expose website activity feed publicly

### DIFF
--- a/backend/app/Http/Controllers/Api/Website/WebsiteActivityController.php
+++ b/backend/app/Http/Controllers/Api/Website/WebsiteActivityController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use App\Models\PageRevision;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebsiteActivityController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $limit = (int) $request->integer('limit', 50);
+        $limit = max(1, min($limit, 200));
+
+        $revisions = PageRevision::query()
+            ->with(['page', 'editor'])
+            ->orderByDesc('created_at')
+            ->limit($limit)
+            ->get();
+
+        $activity = $revisions->map(function (PageRevision $revision): array {
+            $timestamp = $revision->created_at?->toIso8601String();
+            $page = $revision->page;
+
+            return [
+                'id' => (string) $revision->id,
+                'timestamp' => $timestamp,
+                'user' => $revision->editor?->name ?? 'System',
+                'action' => $revision->event ?? $revision->status ?? 'update',
+                'section' => $page?->slug,
+                'diffSummary' => $revision->notes,
+                'metadata' => array_filter([
+                    'page_id' => $revision->page_id,
+                    'page_slug' => $page?->slug,
+                    'version' => $revision->version,
+                    'status' => $revision->status,
+                    'workflow_state' => $revision->workflow_state,
+                ], static fn ($value) => $value !== null),
+            ];
+        });
+
+        return new JsonResponse($activity);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,7 +2,8 @@
 
 use App\Http\Controllers\Api\Admin\AdminAuthController;
 use App\Http\Controllers\Api\Admin\AdminEventController;
-use App\Http\Controllers\Api\Admin\WebsiteActivityController;
+use App\Http\Controllers\Api\Admin\WebsiteActivityController as AdminWebsiteActivityController;
+use App\Http\Controllers\Api\Website\WebsiteActivityController as PublicWebsiteActivityController;
 use App\Http\Controllers\Api\Admin\WebsiteReportController;
 use App\Http\Controllers\Api\Website\AchievementController;
 use App\Http\Controllers\Api\Website\ArticleController;
@@ -66,12 +67,15 @@ Route::prefix('admin')
         Route::get('/auth/me', AdminAuthController::class);
 
         Route::middleware('role:admin')->group(function () {
-            Route::get('/website/activity', WebsiteActivityController::class);
+            Route::get('/website/activity', AdminWebsiteActivityController::class);
             Route::get('/website/report', WebsiteReportController::class);
         });
     });
 
 Route::get('/admin/events/subscribe', [AdminEventController::class, 'subscribe']);
+
+// Website activity (public)
+Route::get('/website/activity', PublicWebsiteActivityController::class);
 
 // Dashboard & searches
 Route::get('/search-court', [CourtSearchController::class, 'index']);


### PR DESCRIPTION
## Summary
- add a public website activity API endpoint that mirrors the admin feed
- keep the admin-only activity endpoint while routing to the admin controller explicitly

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c9516694832fa6a851922dd08f00