### PR TITLE
Fallback to public website activity feed when unauthorized

### DIFF
--- a/backend/app/Http/Controllers/Api/Website/WebsiteActivityController.php
+++ b/backend/app/Http/Controllers/Api/Website/WebsiteActivityController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api\Website;
+
+use App\Http\Controllers\Controller;
+use App\Models\PageRevision;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebsiteActivityController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $limit = (int) $request->integer('limit', 50);
+        $limit = max(1, min($limit, 200));
+
+        $revisions = PageRevision::query()
+            ->with(['page', 'editor'])
+            ->orderByDesc('created_at')
+            ->limit($limit)
+            ->get();
+
+        $activity = $revisions->map(function (PageRevision $revision): array {
+            $timestamp = $revision->created_at?->toIso8601String();
+            $page = $revision->page;
+
+            return [
+                'id' => (string) $revision->id,
+                'timestamp' => $timestamp,
+                'user' => $revision->editor?->name ?? 'System',
+                'action' => $revision->event ?? $revision->status ?? 'update',
+                'section' => $page?->slug,
+                'diffSummary' => $revision->notes,
+                'metadata' => array_filter([
+                    'page_id' => $revision->page_id,
+                    'page_slug' => $page?->slug,
+                    'version' => $revision->version,
+                    'status' => $revision->status,
+                    'workflow_state' => $revision->workflow_state,
+                ], static fn ($value) => $value !== null),
+            ];
+        });
+
+        return new JsonResponse($activity);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,7 +2,8 @@
 
 use App\Http\Controllers\Api\Admin\AdminAuthController;
 use App\Http\Controllers\Api\Admin\AdminEventController;
-use App\Http\Controllers\Api\Admin\WebsiteActivityController;
+use App\Http\Controllers\Api\Admin\WebsiteActivityController as AdminWebsiteActivityController;
+use App\Http\Controllers\Api\Website\WebsiteActivityController as PublicWebsiteActivityController;
 use App\Http\Controllers\Api\Admin\WebsiteReportController;
 use App\Http\Controllers\Api\Website\AchievementController;
 use App\Http\Controllers\Api\Website\ArticleController;
@@ -66,12 +67,15 @@ Route::prefix('admin')
         Route::get('/auth/me', AdminAuthController::class);
 
         Route::middleware('role:admin')->group(function () {
-            Route::get('/website/activity', WebsiteActivityController::class);
+            Route::get('/website/activity', AdminWebsiteActivityController::class);
             Route::get('/website/report', WebsiteReportController::class);
         });
     });
 
 Route::get('/admin/events/subscribe', [AdminEventController::class, 'subscribe']);
+
+// Website activity (public)
+Route::get('/website/activity', PublicWebsiteActivityController::class);
 
 // Dashboard & searches
 Route::get('/search-court', [CourtSearchController::class, 'index']);

--- a/frontend/src/api/websiteAdmin.service.ts
+++ b/frontend/src/api/websiteAdmin.service.ts
@@ -1,4 +1,5 @@
 import api from '@/api/axiosConfig';
+import { isAxiosError } from 'axios';
 import type {
   AchievementApi,
   ArticleApi,
@@ -137,8 +138,17 @@ export const getWebsiteReport = async (): Promise<WebsiteReportSummary> => {
 };
 
 export const getActivityLog = async (params?: { limit?: number }): Promise<ActivityLogEntry[]> => {
-  const { data } = await api.get('/api/admin/website/activity', { params });
-  return unwrapCollection<ActivityLogEntry>(data);
+  try {
+    const { data } = await api.get('/api/admin/website/activity', { params });
+    return unwrapCollection<ActivityLogEntry>(data);
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 401) {
+      const { data } = await api.get('/api/website/activity', { params });
+      return unwrapCollection<ActivityLogEntry>(data);
+    }
+
+    throw error;
+  }
 };
 
 export const getWebsiteSettings = async (): Promise<PageContent> => getWebsitePage('settings');


### PR DESCRIPTION
## Summary
- add a public website activity API endpoint that mirrors the admin feed
- keep the admin-only activity endpoint while routing to the admin controller explicitly
- fall back to the public activity endpoint on the frontend when the admin request is unauthorized so guests can load the landing page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3c9516694832fa6a851922dd08f00