### PR TITLE
Fix mobile drawer stacking on small screens

### DIFF
--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -47,8 +47,6 @@ const MobileDrawer: React.FC = () => {
     return undefined;
   }, [isMobileOpen]);
 
-  const headerOffsetClass = "top-16"; // ارتفاع الـ Header (64px)
-
   return (
     <AnimatePresence mode="wait">
       {isMobileOpen && (
@@ -60,9 +58,7 @@ const MobileDrawer: React.FC = () => {
             exit={{ opacity: 0 }}
             onClick={closeMobile}
             className={cn(
-              "fixed inset-x-0 z-[9998] bg-black/50 backdrop-blur-sm md:hidden",
-              headerOffsetClass,
-              "bottom-0"
+              "fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm md:hidden"
             )}
           />
 
@@ -73,7 +69,7 @@ const MobileDrawer: React.FC = () => {
             exit={{ x: isRTL ? "100%" : "-100%", opacity: 0 }}
             transition={{ type: "spring", damping: 25, stiffness: 200 }}
             className={cn(
-              "fixed top-0 z-50 h-full w-full max-w-[100vw] bg-sidebar-background border-border md:hidden",
+              "fixed inset-y-0 z-[9999] h-full w-full max-w-[100vw] bg-sidebar-background border-border md:hidden",
               "flex flex-col shadow-card",
               isRTL ? "right-0 border-l" : "left-0 border-r"
             )}

--- a/frontend/src/contexts/SidebarContext.tsx
+++ b/frontend/src/contexts/SidebarContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 interface SidebarContextType {
   isCollapsed: boolean;
@@ -59,17 +65,17 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ child
     }
   }, [isCollapsed]);
 
-  const toggleCollapsed = () => {
+  const toggleCollapsed = useCallback(() => {
     setIsCollapsed(prev => !prev);
-  };
+  }, []);
 
-  const toggleMobile = () => {
+  const toggleMobile = useCallback(() => {
     setIsMobileOpen(prev => !prev);
-  };
+  }, []);
 
-  const closeMobile = () => {
+  const closeMobile = useCallback(() => {
     setIsMobileOpen(false);
-  };
+  }, []);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;


### PR DESCRIPTION
## Summary
- memoize sidebar context actions to keep stable references across renders
- ensure the mobile drawer remains open after tapping the header toggle on small screens
- extend the mobile drawer backdrop across the full viewport and raise its z-index so it sits above the header on small screens

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bb17a164832f92b14d1c6db55066