### PR TITLE
Add admin testimonials API and extend website admin routes

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/TestimonialController.php
+++ b/backend/app/Http/Controllers/Api/Admin/TestimonialController.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\TestimonialResource;
+use App\Models\ContentBlock;
+use App\Models\Page;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class TestimonialController extends Controller
+{
+    private const PAGE_SLUG = 'testimonials';
+    private const BLOCK_PREFIX = 'testimonial_';
+
+    public function index(): AnonymousResourceCollection
+    {
+        return TestimonialResource::collection($this->testimonialBlocks());
+    }
+
+    public function store(Request $request): TestimonialResource
+    {
+        $data = $this->validatePayload($request);
+
+        $page = $this->resolvePage();
+        $nextId = $this->nextIdentifier($this->testimonialBlocks($page));
+
+        $block = $page->contentBlocks()->create([
+            'key' => self::BLOCK_PREFIX.$nextId,
+            'type' => 'json',
+            'value' => $this->buildValuePayload($data),
+        ]);
+
+        return new TestimonialResource($block);
+    }
+
+    public function show(int $testimonial): TestimonialResource
+    {
+        return new TestimonialResource($this->findTestimonialBlock($testimonial));
+    }
+
+    public function update(Request $request, int $testimonial): TestimonialResource
+    {
+        $data = $this->validatePayload($request, true);
+        $block = $this->findTestimonialBlock($testimonial);
+
+        $value = $block->value ?? [];
+
+        $block->value = $this->mergeValuePayload($value, $data);
+        $block->save();
+
+        return new TestimonialResource($block);
+    }
+
+    public function destroy(int $testimonial): Response
+    {
+        $block = $this->findTestimonialBlock($testimonial);
+        $block->delete();
+
+        return response()->noContent();
+    }
+
+    private function testimonialBlocks(?Page $page = null): Collection
+    {
+        $page ??= $this->resolvePage();
+
+        return $page->contentBlocks()
+            ->where('key', 'like', self::BLOCK_PREFIX.'%')
+            ->get()
+            ->sortBy(fn (ContentBlock $block) => $this->extractIdentifier($block->key))
+            ->values();
+    }
+
+    private function resolvePage(): Page
+    {
+        return Page::firstOrCreate(
+            ['slug' => self::PAGE_SLUG],
+            [
+                'title_en' => 'Testimonials',
+                'title_ar' => 'الشهادات',
+            ]
+        );
+    }
+
+    private function findTestimonialBlock(int $id): ContentBlock
+    {
+        $page = $this->resolvePage();
+
+        return $page->contentBlocks()
+            ->where('key', self::BLOCK_PREFIX.$id)
+            ->firstOrFail();
+    }
+
+    private function nextIdentifier(Collection $blocks): int
+    {
+        $max = $blocks
+            ->map(fn (ContentBlock $block) => $this->extractIdentifier($block->key))
+            ->max();
+
+        return ($max ?? 0) + 1;
+    }
+
+    private function extractIdentifier(string $key): int
+    {
+        if (preg_match('/(\d+)/', $key, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return 0;
+    }
+
+    private function validatePayload(Request $request, bool $isUpdate = false): array
+    {
+        $required = $isUpdate ? 'sometimes' : 'required';
+        $optional = $isUpdate ? 'sometimes' : 'nullable';
+
+        return $request->validate([
+            'name_en' => [$required, 'string', 'max:255'],
+            'name_ar' => [$required, 'string', 'max:255'],
+            'quote_en' => [$required, 'string'],
+            'quote_ar' => [$required, 'string'],
+            'position_en' => [$optional, 'nullable', 'string', 'max:255'],
+            'position_ar' => [$optional, 'nullable', 'string', 'max:255'],
+            'avatar' => [$optional, 'nullable', 'string', 'max:2048'],
+        ]);
+    }
+
+    private function buildValuePayload(array $data): array
+    {
+        $en = [
+            'name' => $data['name_en'],
+            'quote' => $data['quote_en'],
+            'position' => $data['position_en'] ?? null,
+        ];
+        $ar = [
+            'name' => $data['name_ar'],
+            'quote' => $data['quote_ar'],
+            'position' => $data['position_ar'] ?? null,
+        ];
+
+        if (array_key_exists('avatar', $data)) {
+            $en['avatar'] = $data['avatar'];
+            $ar['avatar'] = $data['avatar'];
+        }
+
+        return [
+            'en' => $en,
+            'ar' => $ar,
+        ];
+    }
+
+    private function mergeValuePayload(array $existing, array $data): array
+    {
+        $currentEn = Arr::get($existing, 'en', []);
+        $currentAr = Arr::get($existing, 'ar', []);
+
+        $en = array_merge($currentEn, array_filter([
+            'name' => $data['name_en'] ?? null,
+            'quote' => $data['quote_en'] ?? null,
+            'position' => $data['position_en'] ?? null,
+        ], fn ($value) => $value !== null));
+
+        $ar = array_merge($currentAr, array_filter([
+            'name' => $data['name_ar'] ?? null,
+            'quote' => $data['quote_ar'] ?? null,
+            'position' => $data['position_ar'] ?? null,
+        ], fn ($value) => $value !== null));
+
+        if (array_key_exists('avatar', $data)) {
+            $en['avatar'] = $data['avatar'];
+            $ar['avatar'] = $data['avatar'];
+        }
+
+        return [
+            'en' => $en,
+            'ar' => $ar,
+        ];
+    }
+}

--- a/backend/app/Http/Resources/TestimonialResource.php
+++ b/backend/app/Http/Resources/TestimonialResource.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\ContentBlock;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Arr;
+
+/**
+ * @mixin ContentBlock
+ */
+class TestimonialResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        $value = is_array($this->value) ? $this->value : [];
+
+        return [
+            'id' => $this->extractIdentifier($this->key),
+            'name' => [
+                'ar' => Arr::get($value, 'ar.name'),
+                'en' => Arr::get($value, 'en.name'),
+            ],
+            'quote' => [
+                'ar' => Arr::get($value, 'ar.quote'),
+                'en' => Arr::get($value, 'en.quote'),
+            ],
+            'position' => [
+                'ar' => Arr::get($value, 'ar.position'),
+                'en' => Arr::get($value, 'en.position'),
+            ],
+            'avatar' => Arr::get($value, 'en.avatar') ?? Arr::get($value, 'ar.avatar'),
+        ];
+    }
+
+    private function extractIdentifier(?string $key): ?int
+    {
+        if (! $key) {
+            return null;
+        }
+
+        if (preg_match('/(\d+)/', $key, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\Admin\AdminAuthController;
 use App\Http\Controllers\Api\Admin\AdminEventController;
+use App\Http\Controllers\Api\Admin\TestimonialController as AdminTestimonialController;
 use App\Http\Controllers\Api\Admin\WebsiteActivityController as AdminWebsiteActivityController;
 use App\Http\Controllers\Api\Website\WebsiteActivityController as PublicWebsiteActivityController;
 use App\Http\Controllers\Api\Admin\WebsiteReportController;
@@ -216,7 +217,7 @@ Route::prefix('website')->group(function () {
 });
 
 Route::prefix('admin/website')
-    ->middleware(['auth:sanctum', 'role:admin'])
+    ->middleware(['auth:sanctum', 'role:admin,editor'])
     ->group(function () {
         Route::get('/pages', [PageController::class, 'adminIndex']);
         Route::get('/pages/{slug}', [PageController::class, 'adminShow']);
@@ -233,4 +234,16 @@ Route::prefix('admin/website')
         Route::post('/upload', [UploadController::class, 'store']);
         Route::get('/settings', [PageController::class, 'settings']);
         Route::put('/settings', [PageController::class, 'updateSettings']);
+
+        Route::get('/articles', [ArticleController::class, 'index']);
+        Route::post('/articles', [ArticleController::class, 'store']);
+        Route::get('/articles/{article}', [ArticleController::class, 'show']);
+        Route::put('/articles/{article}', [ArticleController::class, 'update']);
+        Route::delete('/articles/{article}', [ArticleController::class, 'destroy']);
+
+        Route::get('/testimonials', [AdminTestimonialController::class, 'index']);
+        Route::post('/testimonials', [AdminTestimonialController::class, 'store']);
+        Route::get('/testimonials/{testimonial}', [AdminTestimonialController::class, 'show']);
+        Route::put('/testimonials/{testimonial}', [AdminTestimonialController::class, 'update']);
+        Route::delete('/testimonials/{testimonial}', [AdminTestimonialController::class, 'destroy']);
     });


### PR DESCRIPTION
## Summary
- allow admin and editor roles to reach the website management API routes
- expose website article management endpoints under the /api/admin/website namespace
- add a testimonial controller and resource that persist records via page content blocks

## Testing
- php artisan test --filter=AdminWebsitePagesTest *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cdfe1828832fae79df6b8e60113f