### PR TITLE
Protect admin website API calls behind role checks

### DIFF
--- a/frontend/src/hooks/useUserRoles.ts
+++ b/frontend/src/hooks/useUserRoles.ts
@@ -34,8 +34,10 @@ export interface UseUserRolesResult {
   hasRole: (role: Role | Role[]) => boolean;
   can: (permission: Permission) => boolean;
   isLoading: boolean;
+  isFetching: boolean;
   isError: boolean;
   error: unknown;
+  isAdmin: boolean;
 }
 
 export const useUserRoles = (): UseUserRolesResult => {
@@ -92,8 +94,10 @@ export const useUserRoles = (): UseUserRolesResult => {
     hasRole,
     can,
     isLoading: profileQuery.isLoading && isAdmin,
+    isFetching: profileQuery.isFetching && isAdmin,
     isError: profileQuery.isError,
     error: profileQuery.error,
+    isAdmin,
   };
 };
 

--- a/frontend/src/pages/admin/Website/WorkflowBoardPage.tsx
+++ b/frontend/src/pages/admin/Website/WorkflowBoardPage.tsx
@@ -11,12 +11,18 @@ import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import WorkflowStatusBadge from './components/WorkflowStatusBadge';
 import useNotifications from '@/hooks/useNotifications';
+import useUserRoles from '@/hooks/useUserRoles';
 
 const WorkflowBoardPage: React.FC = () => {
   const queryClient = useQueryClient();
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
+  const canViewWorkflow = permissionsReady && can('pages:view');
+
   const queueQuery = useQuery({
     queryKey: ['admin-website-publishing-queue'],
     queryFn: getPublishingQueue,
+    enabled: canViewWorkflow,
   });
   const { connectionState } = useNotifications();
 
@@ -25,6 +31,23 @@ const WorkflowBoardPage: React.FC = () => {
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['admin-website-publishing-queue'] });
   };
+
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-60" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!canViewWorkflow) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view the publishing workflow.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/admin/Website/components/AchievementsManager.tsx
+++ b/frontend/src/pages/admin/Website/components/AchievementsManager.tsx
@@ -26,6 +26,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import ConfirmDialog from '@/components/common/ConfirmDialog';
 import type { AchievementApi } from '@/types/website';
 import { useToast } from '@/components/ui/use-toast';
+import useUserRoles from '@/hooks/useUserRoles';
 
 interface AchievementFormValues {
   title_en: string;
@@ -60,10 +61,15 @@ const toPayload = (values: AchievementFormValues): AchievementInput => ({
 const AchievementsManager: React.FC = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
+  const canViewAchievements = permissionsReady && can('pages:view');
+  const canManageAchievements = permissionsReady && can('pages:edit');
 
   const achievementsQuery = useQuery({
     queryKey: ['admin-achievements'],
     queryFn: listAchievements,
+    enabled: canViewAchievements,
   });
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -108,6 +114,10 @@ const AchievementsManager: React.FC = () => {
   });
 
   const handleSubmit = (values: AchievementFormValues) => {
+    if (!canManageAchievements) {
+      toast({ title: 'Read-only mode', description: 'You do not have permission to modify achievements.', variant: 'destructive' });
+      return;
+    }
     const payload = toPayload(values);
     if (!payload.title_en || !payload.title_ar) {
       toast({ title: 'Title is required in both languages', variant: 'destructive' });
@@ -118,6 +128,10 @@ const AchievementsManager: React.FC = () => {
   };
 
   const handleOpenDialog = (achievement: AchievementApi | null = null) => {
+    if (!canManageAchievements) {
+      toast({ title: 'Read-only mode', description: 'You do not have permission to edit achievements.', variant: 'destructive' });
+      return;
+    }
     setEditingAchievement(achievement);
     setDialogOpen(true);
   };
@@ -129,6 +143,23 @@ const AchievementsManager: React.FC = () => {
 
   const achievements = useMemo(() => achievementsQuery.data ?? [], [achievementsQuery.data]);
 
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (!canViewAchievements) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view achievements.
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <Card>
@@ -137,7 +168,7 @@ const AchievementsManager: React.FC = () => {
             <CardTitle className="text-xl font-semibold">Achievements</CardTitle>
             <CardDescription>Control the statistics shown in the achievements strip.</CardDescription>
           </div>
-          <Button type="button" onClick={() => handleOpenDialog(null)}>
+          <Button type="button" onClick={() => handleOpenDialog(null)} disabled={!canManageAchievements}>
             <Plus className="mr-2 h-4 w-4" /> Add achievement
           </Button>
         </CardHeader>
@@ -173,6 +204,7 @@ const AchievementsManager: React.FC = () => {
                           variant="outline"
                           size="icon"
                           onClick={() => handleOpenDialog(achievement)}
+                          disabled={!canManageAchievements}
                         >
                           <Pencil className="h-4 w-4" />
                         </Button>
@@ -180,7 +212,14 @@ const AchievementsManager: React.FC = () => {
                           type="button"
                           variant="destructive"
                           size="icon"
-                          onClick={() => setPendingDelete(achievement)}
+                          onClick={() => {
+                            if (!canManageAchievements) {
+                              toast({ title: 'Read-only mode', description: 'You do not have permission to delete achievements.', variant: 'destructive' });
+                              return;
+                            }
+                            setPendingDelete(achievement);
+                          }}
+                          disabled={!canManageAchievements}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -211,21 +250,21 @@ const AchievementsManager: React.FC = () => {
           <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4">
             <div className="grid gap-2">
               <Label htmlFor="title_en">Title (EN)</Label>
-              <Input id="title_en" {...form.register('title_en')} required />
+              <Input id="title_en" disabled={!canManageAchievements} {...form.register('title_en')} required />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="title_ar">العنوان (AR)</Label>
-              <Input id="title_ar" dir="rtl" {...form.register('title_ar')} required />
+              <Input id="title_ar" dir="rtl" disabled={!canManageAchievements} {...form.register('title_ar')} required />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="number">Number (optional)</Label>
-              <Input id="number" type="number" min={0} {...form.register('number')} />
+              <Input id="number" type="number" min={0} disabled={!canManageAchievements} {...form.register('number')} />
             </div>
             <DialogFooter className="pt-2">
               <Button type="button" variant="outline" onClick={handleCloseDialog}>
                 Cancel
               </Button>
-              <Button type="submit" disabled={saveMutation.isPending}>
+              <Button type="submit" disabled={saveMutation.isPending || !canManageAchievements}>
                 {saveMutation.isPending ? 'Saving…' : 'Save'}
               </Button>
             </DialogFooter>
@@ -240,9 +279,14 @@ const AchievementsManager: React.FC = () => {
         confirmLabel="Delete"
         cancelLabel="Cancel"
         onConfirm={() => {
-          if (pendingDelete) {
-            deleteMutation.mutate(pendingDelete.id);
+          if (!pendingDelete) {
+            return;
           }
+          if (!canManageAchievements) {
+            toast({ title: 'Read-only mode', description: 'You do not have permission to delete achievements.', variant: 'destructive' });
+            return;
+          }
+          deleteMutation.mutate(pendingDelete.id);
         }}
         onClose={() => setPendingDelete(null)}
       />

--- a/frontend/src/pages/admin/Website/components/ArticlesManager.tsx
+++ b/frontend/src/pages/admin/Website/components/ArticlesManager.tsx
@@ -87,14 +87,17 @@ const toFormValues = (article: ArticleApi | null): ArticleFormValues => {
 const ArticlesManager: React.FC = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { can } = useUserRoles();
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
   const [searchTerm, setSearchTerm] = useState('');
   const [visibleCount, setVisibleCount] = useState(10);
-  const canManageArticles = can('pages:edit');
+  const canViewArticles = permissionsReady && can('pages:view');
+  const canManageArticles = permissionsReady && can('pages:edit');
 
   const articlesQuery = useQuery({
     queryKey: ['admin-website-articles'],
     queryFn: listArticles,
+    enabled: canViewArticles,
   });
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -190,6 +193,23 @@ const ArticlesManager: React.FC = () => {
   }, [articles, searchTerm]);
   const visibleArticles = useMemo(() => filteredArticles.slice(0, visibleCount), [filteredArticles, visibleCount]);
   const hasMoreArticles = visibleArticles.length < filteredArticles.length;
+
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-56" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (!canViewArticles) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view articles.
+      </div>
+    );
+  }
 
   return (
     <Card>

--- a/frontend/src/pages/admin/Website/components/PageEditor/PageEditor.tsx
+++ b/frontend/src/pages/admin/Website/components/PageEditor/PageEditor.tsx
@@ -210,12 +210,18 @@ const workflowEventMeta: Record<WorkflowEvent['type'], { label: string; icon: Re
 
 const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => {
   const { toast } = useToast();
-  const { page, status, workflow, workflowState, history, isLoading, isSaving, isPreviewing, saveDraft, requestPreview } =
-    usePageManager(slug);
   const {
     can,
     isLoading: isRolesLoading,
+    isFetching: isRolesFetching,
   } = useUserRoles();
+  const permissionsReady = !(isRolesLoading || isRolesFetching);
+  const hasViewAccess = permissionsReady && can('pages:view');
+  const canManageWorkflow =
+    permissionsReady && (can('pages:approve') || can('pages:publish') || can('pages:schedule'));
+
+  const { page, status, workflow, workflowState, history, isLoading, isSaving, isPreviewing, saveDraft, requestPreview } =
+    usePageManager(slug, { enabled: hasViewAccess });
   const {
     requestApproval,
     approveAndPublish,
@@ -227,7 +233,7 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
     isPublishing: isWorkflowPublishing,
     isScheduling,
     isCancellingSchedule,
-  } = useWorkflowManager({ slug });
+  } = useWorkflowManager({ slug, enabled: hasViewAccess, loadQueue: canManageWorkflow });
 
   const form = useForm<PageFormValues>({
     defaultValues,
@@ -254,12 +260,12 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
   const lastSnapshotRef = useRef<string>('');
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const allowEditing = !isRolesLoading && can('pages:edit');
+  const allowEditing = permissionsReady && can('pages:edit');
   const isReadOnly = !allowEditing;
-  const canPreviewDraft = !isRolesLoading && (can('pages:view') || allowEditing);
-  const canPublishNow = !isRolesLoading && can('pages:publish');
-  const canApproveContent = !isRolesLoading && can('pages:approve');
-  const canScheduleContent = !isRolesLoading && can('pages:schedule');
+  const canPreviewDraft = permissionsReady && (can('pages:view') || allowEditing);
+  const canPublishNow = permissionsReady && can('pages:publish');
+  const canApproveContent = permissionsReady && can('pages:approve');
+  const canScheduleContent = permissionsReady && can('pages:schedule');
   const showRequestApprovalButton = allowEditing && !canApproveContent && !canPublishNow;
 
   const previewHref = useMemo(() => {
@@ -403,6 +409,10 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
   };
 
   const handleRequestApproval = async () => {
+    if (!allowEditing) {
+      toast({ title: 'Request blocked', description: 'You do not have permission to request approval.', variant: 'destructive' });
+      return;
+    }
     try {
       await requestApproval({ draft_id: workflow?.draft_id ?? null });
       toast({ title: 'Approval requested', description: 'An administrator will review the draft shortly.' });
@@ -413,6 +423,10 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
   };
 
   const handleApprovePublish = async () => {
+    if (!canApproveContent) {
+      toast({ title: 'Approval restricted', description: 'You do not have permission to approve this page.', variant: 'destructive' });
+      return;
+    }
     try {
       await approveAndPublish({ draft_id: workflow?.draft_id ?? null });
       toast({ title: 'Changes approved and published' });
@@ -423,6 +437,10 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
   };
 
   const handleScheduleSubmit = async ({ scheduled_for, notes }: { scheduled_for: string; notes?: string | null }) => {
+    if (!canScheduleContent) {
+      toast({ title: 'Scheduling restricted', description: 'You do not have permission to schedule this page.', variant: 'destructive' });
+      return;
+    }
     try {
       await schedulePublish({ scheduled_for, notes: notes ?? null, draft_id: workflow?.draft_id ?? null });
       toast({ title: 'Publish scheduled', description: `Content will go live at ${formatTimestamp(scheduled_for)}` });
@@ -434,6 +452,10 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
   };
 
   const handleCancelSchedule = async () => {
+    if (!canScheduleContent && !canApproveContent && !canPublishNow) {
+      toast({ title: 'Cancel restricted', description: 'You do not have permission to cancel scheduled publishes.', variant: 'destructive' });
+      return;
+    }
     try {
       await cancelSchedule();
       toast({ title: 'Scheduled publish cancelled' });
@@ -442,6 +464,23 @@ const PageEditor: React.FC<PageEditorProps> = ({ slug, title, description }) => 
       toast({ title: 'Cancel failed', description: message, variant: 'destructive' });
     }
   };
+
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!hasViewAccess) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view this page.
+      </div>
+    );
+  }
 
   if (!slug) {
     return null;

--- a/frontend/src/pages/admin/Website/components/PagesManager.tsx
+++ b/frontend/src/pages/admin/Website/components/PagesManager.tsx
@@ -19,11 +19,15 @@ const PagesManager: React.FC = () => {
   const { toast } = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { can } = useUserRoles();
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+
+  const canViewPages = can('pages:view');
+  const shouldFetchPages = canViewPages && !rolesLoading && !rolesFetching;
 
   const pagesQuery = useQuery({
     queryKey: ['admin-website-pages'],
     queryFn: listWebsitePages,
+    enabled: shouldFetchPages,
   });
 
   const pages = useMemo(() => pagesQuery.data ?? [], [pagesQuery.data]);
@@ -120,6 +124,23 @@ const PagesManager: React.FC = () => {
         return <Badge className="bg-amber-100 text-amber-800">🟡 Draft</Badge>;
     }
   };
+
+  if (rolesLoading || rolesFetching) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!canViewPages) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view website pages. Please contact an administrator if you believe this is an error.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/admin/Website/components/ReportWidget.tsx
+++ b/frontend/src/pages/admin/Website/components/ReportWidget.tsx
@@ -10,16 +10,50 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import WorkflowStatusBadge from './WorkflowStatusBadge';
 import useNotifications from '@/hooks/useNotifications';
+import useUserRoles from '@/hooks/useUserRoles';
 
 const ReportWidget: React.FC = () => {
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
+  const canViewReport = permissionsReady && can('analytics:view');
+
   const reportQuery = useQuery({
     queryKey: ['admin-website-report'],
     queryFn: getWebsiteReport,
+    enabled: canViewReport,
   });
 
   const report = reportQuery.data;
   const { activity, connectionState } = useNotifications();
   const recentActivity = useMemo(() => activity.slice(0, 10), [activity]);
+
+  if (!permissionsReady) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card key={index}>
+            <CardHeader>
+              <Skeleton className="h-4 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (!canViewReport) {
+    return (
+      <Card className="border-dashed border-border/60 bg-muted/30">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium text-muted-foreground">Analytics access required</CardTitle>
+          <CardDescription>You do not have permission to view website analytics.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
 
   if (reportQuery.isLoading) {
     return (

--- a/frontend/src/pages/admin/Website/components/SettingsManager.tsx
+++ b/frontend/src/pages/admin/Website/components/SettingsManager.tsx
@@ -7,6 +7,7 @@ import { resolveAssetUrl } from '@/utils/asset';
 import PageEditor from './PageEditor/PageEditor';
 import { getWebsitePage } from '@/api/websiteAdmin.service';
 import type { ContentBlock, Locale, Localized, PageContent } from '@/types/website';
+import useUserRoles from '@/hooks/useUserRoles';
 
 interface LogoPreview {
   id: string;
@@ -19,12 +20,40 @@ const LOCALES: Locale[] = ['en', 'ar'];
 const MODES: Array<'light' | 'dark'> = ['light', 'dark'];
 
 const SettingsManager: React.FC = () => {
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
+  const canViewSettings = permissionsReady && can('pages:view');
+
   const settingsQuery = useQuery({
     queryKey: ['admin-website-page', 'settings'],
     queryFn: () => getWebsitePage('settings'),
+    enabled: canViewSettings,
   });
 
   const previews = useMemo(() => buildLogoPreviews(settingsQuery.data), [settingsQuery.data]);
+
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-6">
+        <Card className="border-border/70">
+          <CardHeader>
+            <Skeleton className="h-6 w-40" />
+          </CardHeader>
+          <CardContent>
+            <LogoSkeletonGrid />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!canViewSettings) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view website settings.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-8">

--- a/frontend/src/pages/admin/Website/components/TeamManager.tsx
+++ b/frontend/src/pages/admin/Website/components/TeamManager.tsx
@@ -92,14 +92,17 @@ const toFormValues = (member: TeamMemberApi | null): TeamMemberFormValues => {
 const TeamManager: React.FC = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { can } = useUserRoles();
-  const canManageTeam = can('pages:edit');
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
+  const canViewTeam = permissionsReady && can('pages:view');
+  const canManageTeam = permissionsReady && can('pages:edit');
   const [searchTerm, setSearchTerm] = useState('');
   const [visibleCount, setVisibleCount] = useState(10);
 
   const teamQuery = useQuery({
     queryKey: ['admin-team-members'],
     queryFn: listTeamMembers,
+    enabled: canViewTeam,
   });
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -195,6 +198,23 @@ const TeamManager: React.FC = () => {
   }, [members, searchTerm]);
   const visibleMembers = useMemo(() => filteredMembers.slice(0, visibleCount), [filteredMembers, visibleCount]);
   const hasMoreMembers = visibleMembers.length < filteredMembers.length;
+
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (!canViewTeam) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view team members.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/admin/Website/components/TestimonialsManager.tsx
+++ b/frontend/src/pages/admin/Website/components/TestimonialsManager.tsx
@@ -28,6 +28,7 @@ import { useToast } from '@/components/ui/use-toast';
 import type { TestimonialApi } from '@/types/website';
 import UploadMedia from './UploadMedia';
 import ConfirmDialog from '@/components/common/ConfirmDialog';
+import useUserRoles from '@/hooks/useUserRoles';
 
 interface TestimonialFormValues {
   name_en: string;
@@ -78,10 +79,15 @@ const toFormValues = (testimonial: TestimonialApi | null): TestimonialFormValues
 const TestimonialsManager: React.FC = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { can, isLoading: rolesLoading, isFetching: rolesFetching } = useUserRoles();
+  const permissionsReady = !(rolesLoading || rolesFetching);
+  const canViewTestimonials = permissionsReady && can('pages:view');
+  const canManageTestimonials = permissionsReady && can('pages:edit');
 
   const testimonialsQuery = useQuery({
     queryKey: ['admin-website-testimonials'],
     queryFn: listTestimonials,
+    enabled: canViewTestimonials,
   });
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -127,6 +133,10 @@ const TestimonialsManager: React.FC = () => {
   });
 
   const handleSubmit = (values: TestimonialFormValues) => {
+    if (!canManageTestimonials) {
+      toast({ title: 'Read-only mode', description: 'You do not have permission to modify testimonials.', variant: 'destructive' });
+      return;
+    }
     const payload = toPayload(values);
     if (!payload.name_en || !payload.name_ar || !payload.quote_en || !payload.quote_ar) {
       toast({ title: 'Name and quote are required in both languages', variant: 'destructive' });
@@ -138,6 +148,10 @@ const TestimonialsManager: React.FC = () => {
   };
 
   const handleOpenDialog = (testimonial: TestimonialApi | null = null) => {
+    if (!canManageTestimonials) {
+      toast({ title: 'Read-only mode', description: 'You do not have permission to edit testimonials.', variant: 'destructive' });
+      return;
+    }
     setEditingTestimonial(testimonial);
     setDialogOpen(true);
   };
@@ -149,6 +163,23 @@ const TestimonialsManager: React.FC = () => {
 
   const testimonials = useMemo(() => testimonialsQuery.data ?? [], [testimonialsQuery.data]);
 
+  if (!permissionsReady) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (!canViewTestimonials) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+        You do not have permission to view testimonials.
+      </div>
+    );
+  }
+
   return (
     <Card>
       <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -156,7 +187,7 @@ const TestimonialsManager: React.FC = () => {
           <CardTitle className="text-xl font-semibold">Testimonials</CardTitle>
           <CardDescription>Manage client stories displayed on the landing page testimonials slider.</CardDescription>
         </div>
-        <Button type="button" onClick={() => handleOpenDialog(null)}>
+        <Button type="button" onClick={() => handleOpenDialog(null)} disabled={!canManageTestimonials}>
           <Plus className="mr-2 h-4 w-4" /> New testimonial
         </Button>
       </CardHeader>
@@ -188,10 +219,26 @@ const TestimonialsManager: React.FC = () => {
                     <TableCell>{testimonial.position.en ?? testimonial.position.ar ?? '—'}</TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">
-                        <Button variant="ghost" size="icon" onClick={() => handleOpenDialog(testimonial)}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleOpenDialog(testimonial)}
+                          disabled={!canManageTestimonials}
+                        >
                           <Pencil className="h-4 w-4" />
                         </Button>
-                        <Button variant="ghost" size="icon" onClick={() => setPendingDelete(testimonial)}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => {
+                            if (!canManageTestimonials) {
+                              toast({ title: 'Read-only mode', description: 'You do not have permission to delete testimonials.', variant: 'destructive' });
+                              return;
+                            }
+                            setPendingDelete(testimonial);
+                          }}
+                          disabled={!canManageTestimonials}
+                        >
                           <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
                       </div>
@@ -214,30 +261,30 @@ const TestimonialsManager: React.FC = () => {
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="name_en">Name (EN)</Label>
-                <Input id="name_en" {...form.register('name_en')} />
+                <Input id="name_en" disabled={!canManageTestimonials} {...form.register('name_en')} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="name_ar">الاسم (AR)</Label>
-                <Input id="name_ar" dir="rtl" {...form.register('name_ar')} />
+                <Input id="name_ar" dir="rtl" disabled={!canManageTestimonials} {...form.register('name_ar')} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="position_en">Position (EN)</Label>
-                <Input id="position_en" {...form.register('position_en')} />
+                <Input id="position_en" disabled={!canManageTestimonials} {...form.register('position_en')} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="position_ar">المنصب (AR)</Label>
-                <Input id="position_ar" dir="rtl" {...form.register('position_ar')} />
+                <Input id="position_ar" dir="rtl" disabled={!canManageTestimonials} {...form.register('position_ar')} />
               </div>
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="quote_en">Quote (EN)</Label>
-                <Textarea id="quote_en" rows={4} {...form.register('quote_en')} />
+                <Textarea id="quote_en" rows={4} disabled={!canManageTestimonials} {...form.register('quote_en')} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="quote_ar">الشهادة (AR)</Label>
-                <Textarea id="quote_ar" rows={4} dir="rtl" {...form.register('quote_ar')} />
+                <Textarea id="quote_ar" rows={4} dir="rtl" disabled={!canManageTestimonials} {...form.register('quote_ar')} />
               </div>
             </div>
 
@@ -246,13 +293,14 @@ const TestimonialsManager: React.FC = () => {
               label="Avatar image"
               description="Upload a square avatar (512x512 recommended)."
               onChange={(url) => form.setValue('avatar', url, { shouldDirty: true })}
+              disabled={!canManageTestimonials}
             />
 
             <DialogFooter>
               <Button type="button" variant="outline" onClick={handleCloseDialog}>
                 Cancel
               </Button>
-              <Button type="submit" disabled={saveMutation.isPending}>
+              <Button type="submit" disabled={saveMutation.isPending || !canManageTestimonials}>
                 {saveMutation.isPending ? 'Saving…' : 'Save testimonial'}
               </Button>
             </DialogFooter>
@@ -261,12 +309,18 @@ const TestimonialsManager: React.FC = () => {
       </Dialog>
 
       <ConfirmDialog
-        open={Boolean(pendingDelete)}
+        open={Boolean(pendingDelete && canManageTestimonials)}
         title="Delete testimonial"
         description="This action cannot be undone."
         confirmLabel="Delete"
         loading={deleteMutation.isPending}
-        onConfirm={() => pendingDelete && deleteMutation.mutate(pendingDelete.id)}
+        onConfirm={() => {
+          if (pendingDelete && canManageTestimonials) {
+            deleteMutation.mutate(pendingDelete.id);
+          } else if (!canManageTestimonials) {
+            toast({ title: 'Read-only mode', description: 'You do not have permission to delete testimonials.', variant: 'destructive' });
+          }
+        }}
         onOpenChange={(open) => {
           if (!open) {
             setPendingDelete(null);


### PR DESCRIPTION
## Summary
- gate admin website data fetches behind `useUserRoles` permission checks and stop hitting APIs before auth is ready
- add loading and unauthorized fallbacks plus permission-aware UI states across website management modules
- ensure admin report and workflow views respect analytics/workflow permissions while preserving existing feedback toasts

## Testing
- `npm run lint` *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d17e1cd8832fade27c2b558976dc