### PR TITLE
Improve landing responsiveness and admin auth guard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 import ProtectedRoute from '@/components/ProtectedRoute';
+import AdminRoute from '@/components/AdminRoute';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 // Pages
@@ -86,7 +87,7 @@ const App = () => {
           <Route path="office_settings" element={<OfficeSettingsPage />} />
 
           {/* 🌐 Website Management */}
-          <Route path="website">
+          <Route path="website" element={<AdminRoute />}>
             <Route index element={<Navigate to="pages" replace />} />
             <Route path="report" element={<WebsiteReportPage />} />
             <Route path="workflow" element={<WorkflowBoardPage />} />

--- a/frontend/src/api/axiosConfig.ts
+++ b/frontend/src/api/axiosConfig.ts
@@ -1,6 +1,12 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import API_CONFIG from '@/config/config';
 
+declare module 'axios' {
+  interface InternalAxiosRequestConfig {
+    _retry?: boolean;
+  }
+}
+
 const api: AxiosInstance = axios.create({
   baseURL: API_CONFIG.baseURL,
   withCredentials: true,
@@ -10,24 +16,117 @@ const api: AxiosInstance = axios.create({
   },
 });
 
-// Interceptor: Attach token to every request
-api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+const refreshClient = axios.create({
+  baseURL: API_CONFIG.baseURL,
+  withCredentials: true,
+});
+
+const broadcastAuthEvent = (event: 'auth:authorized' | 'auth:unauthorized' | 'auth:logout') => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(event));
+};
+
+const readTokenFromStorage = (): string | null => {
   try {
     const token = sessionStorage.getItem('token');
-    if (token) {
-      const parsedToken = JSON.parse(token) as string;
-      if (parsedToken) {
-        config.headers = {
-          ...config.headers,
-          Authorization: `Bearer ${parsedToken}`,
-        } as typeof config.headers;
-      }
+    if (!token) {
+      return null;
     }
-  } catch (err) {
-    console.error('Error parsing token from sessionStorage', err);
+
+    const parsed = JSON.parse(token) as unknown;
+    return typeof parsed === 'string' ? parsed : null;
+  } catch (error) {
+    console.warn('Error parsing token from sessionStorage', error);
+    return null;
+  }
+};
+
+const persistToken = (token: string | null) => {
+  if (!token) {
+    sessionStorage.removeItem('token');
+    return;
+  }
+
+  sessionStorage.setItem('token', JSON.stringify(token));
+};
+
+let refreshPromise: Promise<string | null> | null = null;
+
+const refreshAccessToken = async (): Promise<string | null> => {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      try {
+        const { data } = await refreshClient.post<{ access_token?: string }>('/api/auth/refresh');
+        const nextToken = data?.access_token ?? null;
+
+        if (nextToken) {
+          persistToken(nextToken);
+          broadcastAuthEvent('auth:authorized');
+        }
+
+        return nextToken;
+      } catch (error) {
+        persistToken(null);
+        broadcastAuthEvent('auth:unauthorized');
+        return null;
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+  }
+
+  return refreshPromise;
+};
+
+// Interceptor: Attach token to every request
+api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = readTokenFromStorage();
+  if (token) {
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${token}`,
+    } as typeof config.headers;
   }
 
   return config;
 });
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { response, config } = error ?? {};
+    if (!response || !config) {
+      return Promise.reject(error);
+    }
+
+    const status = response.status;
+    const isAuthEndpoint = typeof config.url === 'string' &&
+      (config.url.includes('/api/auth/login') || config.url.includes('/api/auth/register') || config.url.includes('/api/auth/refresh'));
+
+    if ((status === 401 || status === 419) && !config._retry && !isAuthEndpoint) {
+      config._retry = true;
+      const nextToken = await refreshAccessToken();
+
+      if (nextToken) {
+        config.headers = {
+          ...config.headers,
+          Authorization: `Bearer ${nextToken}`,
+        } as typeof config.headers;
+
+        return api(config);
+      }
+
+      broadcastAuthEvent('auth:unauthorized');
+    } else if (status === 401 && !isAuthEndpoint) {
+      broadcastAuthEvent('auth:unauthorized');
+      persistToken(null);
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export default api;

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,42 @@
+import { type ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import { useAuth } from '@/contexts/AuthContext';
+import useUserRoles from '@/hooks/useUserRoles';
+
+interface AdminRouteProps {
+  children?: ReactNode;
+}
+
+const AdminRoute = ({ children }: AdminRouteProps) => {
+  const location = useLocation();
+  const { isAuthenticated, loading } = useAuth();
+  const { isAdmin, isLoading, isFetching } = useUserRoles();
+
+  const isBusy = loading || isLoading || isFetching;
+
+  if (isBusy) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (children) {
+    return <>{children}</>;
+  }
+
+  return <Outlet />;
+};
+
+export default AdminRoute;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import api from '@/api/axiosConfig';
 
@@ -27,6 +27,14 @@ interface AuthContextType {
   loading: boolean;
 }
 
+const STORAGE_USER_KEY = 'avocat_user';
+const TOKEN_STORAGE_KEY = 'token';
+const AUTH_EVENTS = {
+  unauthorized: 'auth:unauthorized',
+  logout: 'auth:logout',
+  authorized: 'auth:authorized',
+} as const;
+
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const useAuth = () => {
@@ -41,42 +49,96 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const broadcastAuthEvent = useCallback((event: keyof typeof AUTH_EVENTS) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.dispatchEvent(new CustomEvent(AUTH_EVENTS[event]));
+  }, []);
+
+  const readUserFromStorage = useCallback(() => {
+    const storedUser = localStorage.getItem(STORAGE_USER_KEY);
+    if (!storedUser) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(storedUser) as User;
+    } catch (error) {
+      console.warn('Failed to parse stored user payload', error);
+      localStorage.removeItem(STORAGE_USER_KEY);
+      return null;
+    }
+  }, []);
+
   useEffect(() => {
     const initialize = async () => {
       try {
-        const storedUser = localStorage.getItem('avocat_user');
+        const storedUser = readUserFromStorage();
         if (storedUser) {
-          try {
-            setUser(JSON.parse(storedUser) as User);
-          } catch (error) {
-            console.warn('Failed to parse stored user payload', error);
-            localStorage.removeItem('avocat_user');
-          }
+          setUser(storedUser);
         }
 
-        const storedToken = sessionStorage.getItem('token');
+        const storedToken = sessionStorage.getItem(TOKEN_STORAGE_KEY);
         if (storedToken) {
-          const parsedToken = JSON.parse(storedToken) as string;
+          const parsedToken = JSON.parse(storedToken) as string | null;
           if (parsedToken) {
             const { data } = await api.get<ApiUser>('/api/auth/profile');
             const mappedUser = mapApiUserToContextUser(data);
             setUser(mappedUser);
-            localStorage.setItem('avocat_user', JSON.stringify(mappedUser));
+            localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(mappedUser));
           }
         }
       } catch (error) {
         console.warn('Failed to bootstrap auth state from API', error);
-        sessionStorage.removeItem('token');
-        localStorage.removeItem('avocat_user');
+        sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+        localStorage.removeItem(STORAGE_USER_KEY);
       } finally {
         setLoading(false);
       }
     };
 
     void initialize();
-  }, []);
+  }, [mapApiUserToContextUser, readUserFromStorage]);
 
-  const mapRole = (role: ApiUser['role']): User['role'] => {
+  useEffect(() => {
+    const handleAuthReset = () => {
+      setUser(null);
+      sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+      localStorage.removeItem(STORAGE_USER_KEY);
+    };
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (!event.key) {
+        return;
+      }
+
+      if (event.key === STORAGE_USER_KEY) {
+        const nextUser = readUserFromStorage();
+        setUser(nextUser);
+      }
+
+      if (event.key === TOKEN_STORAGE_KEY && event.storageArea === sessionStorage) {
+        // sessionStorage events don't fire across tabs, guard for safety
+        if (!event.newValue) {
+          setUser(null);
+        }
+      }
+    };
+
+    window.addEventListener(AUTH_EVENTS.unauthorized, handleAuthReset);
+    window.addEventListener(AUTH_EVENTS.logout, handleAuthReset);
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => {
+      window.removeEventListener(AUTH_EVENTS.unauthorized, handleAuthReset);
+      window.removeEventListener(AUTH_EVENTS.logout, handleAuthReset);
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, [readUserFromStorage]);
+
+  const mapRole = useCallback((role: ApiUser['role']): User['role'] => {
     const normalized = typeof role === 'string' ? role.toLowerCase() : String(role ?? '').toLowerCase();
 
     if (normalized === '1' || normalized === 'admin') {
@@ -88,17 +150,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
 
     return 'client';
-  };
+  }, []);
 
-  const mapApiUserToContextUser = (payload: ApiUser): User => ({
-    id: String(payload.id),
-    email: payload.email,
-    name: payload.name,
-    avatar: payload.avatar ?? undefined,
-    role: mapRole(payload.role ?? null),
-  });
+  const mapApiUserToContextUser = useCallback(
+    (payload: ApiUser): User => ({
+      id: String(payload.id),
+      email: payload.email,
+      name: payload.name,
+      avatar: payload.avatar ?? undefined,
+      role: mapRole(payload.role ?? null),
+    }),
+    [mapRole],
+  );
 
-  const extractErrorMessage = (error: unknown, fallback: string): string => {
+  const extractErrorMessage = useCallback((error: unknown, fallback: string): string => {
     if (error && typeof error === 'object') {
       const maybeResponse = (error as { response?: { data?: { message?: string } } }).response;
       if (maybeResponse?.data?.message && typeof maybeResponse.data.message === 'string') {
@@ -111,85 +176,97 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
 
     return fallback;
-  };
+  }, []);
 
-  const login = async (email: string, password: string) => {
-    setLoading(true);
-    try {
-      const response = await api.post<{ user: ApiUser; access_token: string }>(
-        '/api/auth/login',
-        { email, password },
-      );
+  const login = useCallback(
+    async (email: string, password: string) => {
+      setLoading(true);
+      try {
+        const response = await api.post<{ user: ApiUser; access_token: string }>(
+          '/api/auth/login',
+          { email, password },
+        );
 
-      const token = response.data?.access_token;
-      const apiUser = response.data?.user;
+        const token = response.data?.access_token;
+        const apiUser = response.data?.user;
 
-      if (!token || !apiUser) {
-        throw new Error('Invalid authentication response.');
+        if (!token || !apiUser) {
+          throw new Error('Invalid authentication response.');
+        }
+
+        sessionStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(token));
+
+        const mappedUser = mapApiUserToContextUser(apiUser);
+        setUser(mappedUser);
+        localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(mappedUser));
+        broadcastAuthEvent('authorized');
+      } catch (error) {
+        const message = extractErrorMessage(error, 'فشل في تسجيل الدخول');
+        throw new Error(message);
+      } finally {
+        setLoading(false);
       }
+    },
+    [broadcastAuthEvent, extractErrorMessage, mapApiUserToContextUser],
+  );
 
-      sessionStorage.setItem('token', JSON.stringify(token));
+  const signup = useCallback(
+    async (email: string, password: string, name: string) => {
+      setLoading(true);
+      try {
+        const response = await api.post<{ user: ApiUser; access_token: string }>(
+          '/api/auth/register',
+          {
+            name,
+            email,
+            password,
+            password_confirmation: password,
+            role: '3',
+          },
+        );
 
-      const mappedUser = mapApiUserToContextUser(apiUser);
-      setUser(mappedUser);
-      localStorage.setItem('avocat_user', JSON.stringify(mappedUser));
-    } catch (error) {
-      const message = extractErrorMessage(error, 'فشل في تسجيل الدخول');
-      throw new Error(message);
-    } finally {
-      setLoading(false);
-    }
-  };
+        const token = response.data?.access_token;
+        const apiUser = response.data?.user;
 
-  const signup = async (email: string, password: string, name: string) => {
-    setLoading(true);
-    try {
-      const response = await api.post<{ user: ApiUser; access_token: string }>(
-        '/api/auth/register',
-        {
-          name,
-          email,
-          password,
-          password_confirmation: password,
-          role: '3',
-        },
-      );
+        if (!token || !apiUser) {
+          throw new Error('Invalid registration response.');
+        }
 
-      const token = response.data?.access_token;
-      const apiUser = response.data?.user;
+        sessionStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(token));
 
-      if (!token || !apiUser) {
-        throw new Error('Invalid registration response.');
+        const mappedUser = mapApiUserToContextUser(apiUser);
+        setUser(mappedUser);
+        localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(mappedUser));
+        broadcastAuthEvent('authorized');
+      } catch (error) {
+        const message = extractErrorMessage(error, 'فشل في إنشاء الحساب');
+        throw new Error(message);
+      } finally {
+        setLoading(false);
       }
+    },
+    [broadcastAuthEvent, extractErrorMessage, mapApiUserToContextUser],
+  );
 
-      sessionStorage.setItem('token', JSON.stringify(token));
-
-      const mappedUser = mapApiUserToContextUser(apiUser);
-      setUser(mappedUser);
-      localStorage.setItem('avocat_user', JSON.stringify(mappedUser));
-    } catch (error) {
-      const message = extractErrorMessage(error, 'فشل في إنشاء الحساب');
-      throw new Error(message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const logout = () => {
+  const logout = useCallback(() => {
     setUser(null);
-    localStorage.removeItem('avocat_user');
-    sessionStorage.removeItem('token');
+    localStorage.removeItem(STORAGE_USER_KEY);
+    sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+    broadcastAuthEvent('logout');
     void api.post('/api/auth/logout').catch(() => undefined);
-  };
+  }, [broadcastAuthEvent]);
 
-  const value = {
-    user,
-    isAuthenticated: !!user,
-    login,
-    signup,
-    logout,
-    loading
-  };
+  const value = useMemo<AuthContextType>(
+    () => ({
+      user,
+      isAuthenticated: !!user,
+      login,
+      signup,
+      logout,
+      loading,
+    }),
+    [loading, login, logout, signup, user],
+  );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -64,3 +64,33 @@
     background-image: linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.08));
   }
 }
+
+@layer utilities {
+  .neon-text {
+    color: hsl(var(--neon));
+    text-shadow:
+      0 0 6px hsl(var(--neon-glow) / 0.75),
+      0 0 18px hsl(var(--neon-glow) / 0.35),
+      0 0 30px hsl(var(--neon-glow) / 0.18);
+  }
+
+  .neon-text-muted {
+    color: hsl(var(--neon-muted));
+  }
+
+  .dark .neon-text-muted {
+    color: hsl(var(--neon));
+    opacity: 0.9;
+  }
+
+  .neon-divider {
+    background: linear-gradient(
+      90deg,
+      transparent,
+      hsl(var(--neon) / 0.55),
+      hsl(var(--neon) / 0.8),
+      transparent
+    );
+    box-shadow: 0 0 12px hsl(var(--neon-glow) / 0.35);
+  }
+}

--- a/frontend/src/pages/Landing/Footer.tsx
+++ b/frontend/src/pages/Landing/Footer.tsx
@@ -3,7 +3,6 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { useWebsiteContent } from '@/hooks/useWebsiteContent';
 import { smoothScrollToElement } from '@/utils/smoothScroll';
 import { Linkedin, Mail, MapPin, Phone, Twitter } from 'lucide-react';
-import { cn } from '@/lib/utils';
 
 interface QuickLink {
   href: string;
@@ -48,36 +47,51 @@ const Footer: React.FC = () => {
     if (element) smoothScrollToElement(element, { offset: 90, duration: 950 });
   };
 
+  const headingClass = 'text-base sm:text-lg font-semibold neon-text drop-shadow-md';
+  const linkClass =
+    'group inline-flex items-center gap-2 text-sm sm:text-base text-primary-foreground/80 transition-colors duration-300 hover:text-neon focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+
   return (
-    <footer className="bg-gradient-primary text-primary-foreground shadow-luxury">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          
+    <footer className="relative overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-primary-foreground">
+      <div className="pointer-events-none absolute inset-0 opacity-80 mix-blend-screen" aria-hidden>
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(57,255,242,0.12),_transparent_55%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(0,255,188,0.08),_transparent_60%)]" />
+      </div>
+
+      <div className="relative z-10 mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-4 lg:gap-10">
           {/* ===== Brand Section ===== */}
-          <div className="space-y-4">
-            <div className="flex items-center space-x-2 rtl:space-x-reverse">
+          <div className="space-y-6">
+            <div className="flex items-center gap-3">
               <BrandLogo variant="full" className="h-12" lang={language} dark />
+              <span className="sr-only">Avocat</span>
             </div>
-            <p className="text-primary-foreground/80 leading-relaxed">{mission}</p>
+            <p className="max-w-xs text-sm leading-relaxed text-primary-foreground/85 sm:text-base">
+              {mission}
+            </p>
+            <div className="h-1 w-24 rounded-full neon-divider" />
           </div>
 
           {/* ===== Quick Links ===== */}
-          <div className="space-y-4">
-            <h4 className="font-semibold text-lg text-primary-foreground">
+          <div className="space-y-4 sm:justify-self-center sm:text-center lg:justify-self-start lg:text-left">
+            <h4 className={headingClass}>
               {direction === 'rtl' ? 'روابط سريعة' : 'Quick Links'}
             </h4>
-            <ul className="space-y-2">
+            <ul className="space-y-3">
               {quickLinks.map((link) => (
                 <li key={link.href}>
                   <a
                     href={link.href}
-                    onClick={(e) => {
-                      e.preventDefault();
+                    onClick={(event) => {
+                      event.preventDefault();
                       scrollTo(link.href);
                     }}
-                    className="text-primary-foreground/70 hover:text-gold transition-colors duration-300"
+                    className={linkClass}
                   >
-                    {link.label}
+                    <span className="inline-flex h-2 w-2 rounded-full bg-neon/60 transition-transform duration-300 group-hover:scale-125" />
+                    <span className="text-sm sm:text-base font-medium">
+                      {link.label}
+                    </span>
                   </a>
                 </li>
               ))}
@@ -85,16 +99,14 @@ const Footer: React.FC = () => {
           </div>
 
           {/* ===== Services ===== */}
-          <div className="space-y-4">
-            <h4 className="font-semibold text-lg text-primary-foreground">
+          <div className="space-y-4 sm:justify-self-center sm:text-center lg:justify-self-start lg:text-left">
+            <h4 className={headingClass}>
               {direction === 'rtl' ? 'خدماتنا' : 'Our Services'}
             </h4>
-            <ul className="space-y-2">
-              {serviceHighlights.map((service, idx) => (
-                <li key={idx}>
-                  <span className="text-primary-foreground/70 hover:text-gold transition-colors duration-300 cursor-pointer">
-                    {service}
-                  </span>
+            <ul className="space-y-3 text-sm sm:text-base">
+              {serviceHighlights.map((service, index) => (
+                <li key={`${service}-${index}`} className="text-primary-foreground/75 transition-colors hover:text-neon">
+                  {service}
                 </li>
               ))}
             </ul>
@@ -102,11 +114,11 @@ const Footer: React.FC = () => {
 
           {/* ===== Contact Info ===== */}
           <div className="space-y-4">
-            <h4 className="font-semibold text-lg text-primary-foreground">
+            <h4 className={headingClass}>
               {direction === 'rtl' ? 'معلومات التواصل' : 'Contact Info'}
             </h4>
-            <div className="space-y-3">
-              {contactDetails.map((detail, idx) => {
+            <div className="space-y-4 text-sm sm:text-base">
+              {contactDetails.map((detail, index) => {
                 const Icon =
                   detail.icon === 'phone'
                     ? Phone
@@ -122,11 +134,11 @@ const Footer: React.FC = () => {
 
                 return (
                   <div
-                    key={idx}
-                    className="flex items-center space-x-3 rtl:space-x-reverse"
+                    key={`${detail.icon ?? 'info'}-${index}`}
+                    className="flex items-start gap-3 text-primary-foreground/85"
                   >
-                    {Icon && <Icon className="w-5 h-5 text-gold flex-shrink-0" />}
-                    <span className="text-primary-foreground/80">{detail.text}</span>
+                    {Icon && <Icon className="h-5 w-5 flex-shrink-0 text-neon" />}
+                    <span className="leading-relaxed">{detail.text}</span>
                   </div>
                 );
               })}
@@ -135,24 +147,18 @@ const Footer: React.FC = () => {
         </div>
 
         {/* ===== Bottom Bar ===== */}
-        <div className="border-t border-primary-foreground/20 mt-12 pt-8">
-          <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
-            <p className="text-primary-foreground/70 text-sm">
+        <div className="mt-16 border-t border-white/10 pt-8">
+          <div className="flex flex-col gap-6 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <p className="neon-text-muted text-xs font-medium uppercase tracking-[0.2em] sm:text-sm">
               {direction === 'rtl'
                 ? `© ${currentYear} مكتب أفوكات للمحاماة. جميع الحقوق محفوظة.`
                 : `© ${currentYear} Avocat Law Firm. All rights reserved.`}
             </p>
-            <div className="flex space-x-6 rtl:space-x-reverse">
-              <a
-                href="#"
-                className="text-primary-foreground/70 hover:text-gold transition-colors duration-300 text-sm"
-              >
+            <div className="flex flex-wrap items-center justify-center gap-4 sm:justify-end">
+              <a href="#" className={`${linkClass} text-sm sm:text-base`}>
                 {direction === 'rtl' ? 'سياسة الخصوصية' : 'Privacy Policy'}
               </a>
-              <a
-                href="#"
-                className="text-primary-foreground/70 hover:text-gold transition-colors duration-300 text-sm"
-              >
+              <a href="#" className={`${linkClass} text-sm sm:text-base`}>
                 {direction === 'rtl' ? 'الشروط والأحكام' : 'Terms of Service'}
               </a>
             </div>

--- a/frontend/src/pages/Landing/HeroCarousel.tsx
+++ b/frontend/src/pages/Landing/HeroCarousel.tsx
@@ -7,10 +7,13 @@ import { useWebsiteContent } from '@/hooks/useWebsiteContent';
 import type { Locale } from '@/types/website';
 import {
   ChevronLeft,
-  ChevronRight, 
+  ChevronRight,
   ShieldCheck,
   Sparkles,
-  Loader2,Cpu, PlayCircle } from 'lucide-react';
+  Loader2,
+  Cpu,
+  PlayCircle,
+} from 'lucide-react';
 import { smoothScrollToElement } from '@/utils/smoothScroll';
 import { resolveAssetUrl } from '@/utils/asset';
 
@@ -109,7 +112,7 @@ const HeroCarousel: React.FC = () => {
     <section
       id="home"
       dir={isArabic ? 'rtl' : 'ltr'}
-      className="relative h-[90vh] min-h-[640px] overflow-hidden bg-black"
+      className="relative flex min-h-[520px] flex-col justify-between overflow-hidden bg-black sm:min-h-[600px] lg:min-h-[720px]"
     >
       {/* الخلفية */}
       <AnimatePresence mode="wait">
@@ -141,12 +144,12 @@ const HeroCarousel: React.FC = () => {
 
       {/* المحتوى */}
       <div className="relative z-10 flex h-full items-center">
-        <div className="container mx-auto px-4 lg:px-8">
+        <div className="container mx-auto px-4 py-20 sm:py-24 lg:px-8 lg:py-32">
           <motion.div
             key={active.id}
             initial="hidden"
             animate="visible"
-            className="max-w-4xl rounded-3xl bg-slate-950/60 p-6 shadow-ambient backdrop-blur lg:p-10 dark:bg-background/70"
+            className="max-w-3xl rounded-3xl bg-slate-950/70 p-6 shadow-ambient backdrop-blur-sm sm:p-8 lg:p-10 dark:bg-background/70"
           >
             {/* البادج */}
             {active.badge && (
@@ -175,13 +178,17 @@ const HeroCarousel: React.FC = () => {
             <motion.p
               variants={textVariants}
               custom={2}
-              className="mt-4 text-lg text-white/85 leading-relaxed"
+              className="mt-4 text-base leading-relaxed text-white/80 sm:text-lg"
             >
               {active.subtitle}
             </motion.p>
 
             {/* النقاط */}
-            <motion.ul className="mt-6 space-y-3 text-base text-white/85" initial="hidden" animate="visible">
+            <motion.ul
+              className="mt-6 space-y-3 text-sm text-white/85 sm:text-base"
+              initial="hidden"
+              animate="visible"
+            >
               {active.bullets.map((b, i) => (
                 <motion.li
                   key={b}
@@ -197,46 +204,42 @@ const HeroCarousel: React.FC = () => {
 
             {/* الأزرار */}
             <motion.div
-            
-  dir={isArabic ? 'ltr' : 'rtl'}
+              dir={isArabic ? 'ltr' : 'rtl'}
               variants={textVariants}
               custom={active.bullets.length + 4}
               className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center"
             >
-       
+              <Button
+                onClick={() => smoothScrollToElement(document.querySelector('#demo')!)}
+                variant="accent"
+                className="btn-primary flex w-full items-center justify-center gap-2 rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg transition-transform hover:-translate-y-0.5 sm:w-auto sm:px-8 sm:text-base"
+              >
+                <PlayCircle className="h-5 w-5" />
+                <span>{isArabic ? 'ابدأ رقمنة مكتبك' : 'Start Your Digital Transformation'}</span>
+              </Button>
 
-<Button
-  onClick={() => smoothScrollToElement(document.querySelector('#demo')!)}
-  variant="accent"
-  className="btn-primary flex items-center justify-center gap-2 px-8 py-3 text-base font-semibold text-white"
->
-  <PlayCircle className="h-5 w-5" />
-  <span>{isArabic ? 'ابدأ رقمنة مكتبك' : 'Start Your Digital Transformation'}</span>
-</Button>
-
-<Button
-  onClick={() => smoothScrollToElement(document.querySelector('#contact')!)}
-  variant="hero"
-  className="btn-glass flex items-center justify-center gap-2 border-white/40 px-8 py-3 text-base font-semibold text-white"
->
-  <Cpu className="h-5 w-5" />
-  <span>{isArabic ? 'تعرّف على الأنظمة' : 'Explore Our Systems'}</span>
-</Button>
-
+              <Button
+                onClick={() => smoothScrollToElement(document.querySelector('#contact')!)}
+                variant="hero"
+                className="btn-glass flex w-full items-center justify-center gap-2 rounded-full border-white/40 px-6 py-3 text-sm font-semibold text-white backdrop-blur transition-transform hover:-translate-y-0.5 sm:w-auto sm:px-8 sm:text-base"
+              >
+                <Cpu className="h-5 w-5" />
+                <span>{isArabic ? 'تعرّف على الأنظمة' : 'Explore Our Systems'}</span>
+              </Button>
             </motion.div>
           </motion.div>
         </div>
       </div>
 
       {/* عناصر التحكم */}
-   <div
-  dir={isArabic ? 'rtl' : 'ltr'}
-  className="absolute bottom-6 inset-x-0 z-20 flex items-center justify-center gap-4"
->
+      <div
+        dir={isArabic ? 'rtl' : 'ltr'}
+        className="absolute inset-x-0 bottom-4 z-20 flex items-center justify-center gap-4 px-4 sm:bottom-6"
+      >
   {/* زر السابق */}
   <button
     onClick={() => setCurrent((prev) => (prev - 1 + slides.length) % slides.length)}
-    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white hover:bg-black/60 transition"
+    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white transition hover:bg-black/60"
     aria-label={isArabic ? 'الشريحة السابقة' : 'Previous slide'}
   >
     {isArabic ? (
@@ -253,7 +256,7 @@ const HeroCarousel: React.FC = () => {
         key={i}
         onClick={() => setCurrent(i)}
         className={`h-2 rounded-full transition-all ${
-          i === current ? 'w-8 bg-white' : 'w-2 bg-white/40 hover:bg-white/70'
+          i === current ? 'w-8 bg-white shadow-[0_0_12px_rgba(255,255,255,0.6)]' : 'w-2 bg-white/40 hover:bg-white/70'
         }`}
         aria-label={`Go to slide ${i + 1}`}
       />
@@ -263,7 +266,7 @@ const HeroCarousel: React.FC = () => {
   {/* زر التالي */}
   <button
     onClick={() => setCurrent((prev) => (prev + 1) % slides.length)}
-    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white hover:bg-black/60 transition"
+    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white transition hover:bg-black/60"
     aria-label={isArabic ? 'الشريحة التالية' : 'Next slide'}
   >
     {isArabic ? (

--- a/frontend/src/pages/Landing/LandingNavbar.tsx
+++ b/frontend/src/pages/Landing/LandingNavbar.tsx
@@ -124,7 +124,7 @@ const LandingNavbar: React.FC = () => {
           : "bg-transparent"
       }`}
     >
-      <div className="container mx-auto flex h-20 items-center justify-between px-4 lg:px-8">
+      <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between px-4 lg:px-8">
         <button
           type="button"
           onClick={() => scrollToAnchor("#home")}

--- a/frontend/src/styles/theme-tokens.css
+++ b/frontend/src/styles/theme-tokens.css
@@ -5,6 +5,11 @@
     --primary-foreground: 0 0% 100%;  /* White */
     --primary-glow: 220 55% 25%;      /* Lighter Navy */
 
+    /* Neon Accent */
+    --neon: 182 100% 72%;
+    --neon-glow: 182 100% 78%;
+    --neon-muted: 182 70% 90%;
+
     /* Gold Accents */
     --gold: 45 100% 50%;              
     --gold-muted: 45 65% 45%;
@@ -68,9 +73,14 @@
     --card-foreground: 200 20% 95%;
     --popover: 220 35% 10%;
     --popover-foreground: 200 20% 95%;
-    --primary: 45 100% 55%; 
+    --primary: 45 100% 55%;
     --primary-foreground: 220 60% 10%;
     --primary-glow: 45 100% 65%;
+
+    /* Neon Accent */
+    --neon: 182 100% 74%;
+    --neon-glow: 182 100% 82%;
+    --neon-muted: 182 60% 26%;
     --secondary: 220 30% 15%;
     --secondary-foreground: 200 20% 95%;
     --muted: 220 30% 15%;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -67,6 +67,11 @@ const config: Config = {
           muted: "hsl(var(--gold-muted))",
           light: "hsl(var(--gold-light))",
         },
+        neon: {
+          DEFAULT: "hsl(var(--neon))",
+          glow: "hsl(var(--neon-glow))",
+          muted: "hsl(var(--neon-muted))",
+        },
         slate: {
           DEFAULT: "hsl(var(--slate))",
           light: "hsl(var(--slate-light))",


### PR DESCRIPTION
## Summary
- refresh the landing footer with neon-accent styling, responsive spacing, and theme-aware utilities
- tune the hero carousel and navbar layout for smaller screens while keeping CTA buttons legible
- harden authentication with a reusable AdminRoute guard, event-driven context syncing, and Axios token refresh handling

## Testing
- `npm run lint` *(fails: existing repo lint errors unrelated to the changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e40e8835e8832f88f34941a1a0982b