### PR TITLE
refactor: integrate shadcn sidebar navigation

### DIFF
--- a/frontend/docs/frontend-overview-ar.md
+++ b/frontend/docs/frontend-overview-ar.md
@@ -1,0 +1,93 @@
+# توثيق واجهة منصة Avocat
+
+## 1. نظرة عامة تقنية
+- الواجهة مبنية باستخدام **React 18** مع **TypeScript** ويتم تجميعها عبر **Vite**، مع الاعتماد على Tailwind CSS وطبقة مكونات مستندة إلى shadcn/Radix لتصميم واجهة تفاعلية قابلة لإعادة الاستخدام.【F:frontend/package.json†L1-L60】【F:frontend/tailwind.config.ts†L1-L118】
+- نقطة الدخول هي ملف `index.html` الذي يحمّل الحزمة الأساسية ويستضيف عنصر الجذر، بينما يتولى `main.tsx` إقلاع تطبيق React وربطه بمزودي الحالة والسياقات العالمية.【F:frontend/index.html†L1-L49】【F:frontend/src/main.tsx†L1-L15】
+- يتم تنظيم الكود داخل مجلد `src` حسب الوظائف (صفحات، مكونات، سياقات، خدمات API، وحدات متخصصة، إلخ) مما يسهل فهم الحدود بين واجهة الهبوط ولوحة التحكم ومسارات الإدارة المتقدمة.【F:frontend/src/App.tsx†L1-L103】【F:frontend/src/api/legalCases.service.ts†L1-L154】
+
+## 2. دورة حياة الواجهة وتشغيلها
+1. **تحميل المستند**: يستورد المتصفح `index.html` ثم يشغّل حزمة Vite التي تربط `main.tsx` بعنصر الجذر في DOM.【F:frontend/index.html†L1-L49】
+2. **تهيئة React**: يقوم `main.tsx` بإنشاء الجذر عبر `createRoot` ويغلّف التطبيق داخل `React.StrictMode` لضمان اكتشاف السلوكيات غير المتوقعة أثناء التطوير.【F:frontend/src/main.tsx†L1-L15】
+3. **حقن المزودين العالميين**: ملف `AppProviders.tsx` يطبّق شجرة المزودين (السمة، اللغة، TanStack Query، المصادقة، الإشعارات، حالة الشريط الجانبي، مزودات التلميحات ومشغلات التنبيه) قبل تمرير الأطفال، مما يجعل هذه السياقات متاحة على مستوى التطبيق بأكمله.【F:frontend/src/providers/AppProviders.tsx†L1-L39】
+4. **تعريف التوجيه**: داخل `App.tsx` يتم إنشاء بنية المسارات باستخدام `BrowserRouter` و`Routes`، حيث تُقسّم إلى مسارات عامة (الهبوط، الدخول، التسجيل) ومسارات محمية ضمن `/dashboard` مع عناصر داخلية متعددة، بالإضافة إلى صفحة 404.【F:frontend/src/App.tsx†L1-L103】
+5. **حماية الوصول**: مكوّن `ProtectedRoute` يتحقق من حالة التحميل والمصادقة؛ يعرض شاشة انتظار أثناء استرجاع بيانات الجلسة ويعيد التوجيه إلى صفحة الدخول إذا لم يكن المستخدم مصرحًا له.【F:frontend/src/components/ProtectedRoute.tsx†L1-L29】
+6. **إدارة البيانات المتفاعلة**: تعتمد الصفحات التي تتعامل مع بيانات حية على TanStack Query (مثل خطاطيف `useLegalCases`) لإجراء الطلبات عبر خدمات Axios، تخزين النتائج مؤقتًا، وإبطالها عند التعديل أو الحذف، مما يضمن تزامن الواجهة مع الخادم.【F:frontend/src/hooks/useLegalCases.tsx†L1-L55】【F:frontend/src/api/axiosConfig.ts†L1-L59】
+7. **تدفق الترجمة والاتجاه**: سياق اللغة يقرأ لغة المستخدم، يحدّث اتجاه الصفحة (RTL/LTR)، ويستدعي i18next لتحميل النصوص من ملفات الترجمة، ما يسمح بإظهار نفس الواجهة بالعربية أو الإنجليزية دون إعادة التحميل.【F:frontend/src/contexts/LanguageContext.tsx†L1-L86】【F:frontend/src/i18n/index.ts†L1-L35】
+8. **الإشعارات الفورية**: عند تسجيل الدخول كمشرف يتم تشغيل `NotificationCenter` للاتصال بخادم الأحداث عبر SSE، مزامنة سجل النشاط، وتغذية لوحات الإدارة ببيانات آنية مع تكرار تلقائي عند حدوث خطأ.【F:frontend/src/modules/notifications/NotificationCenter.tsx†L1-L200】
+
+## 3. المزودون والسياقات الأساسية
+| السياق | المهام الرئيسية | نقاط التكامل |
+| --- | --- | --- |
+| ThemeContext | تخزين اختيار السمة (فاتح/داكن)، مراقبة تفضيل النظام، وتحديث `classList` للجذر لضبط ألوان Tailwind المتغيرة ديناميكيًا.【F:frontend/src/contexts/ThemeContext.tsx†L1-L97】 | مكونات التصميم، شريط الأدوات العلوي، مخططات اللون في Tailwind. |
+| LanguageContext | تبديل اللغة، التحكم في الاتجاه، والربط بـ i18next مع تخزين الاختيار في LocalStorage.【F:frontend/src/contexts/LanguageContext.tsx†L1-L86】 | نصوص الصفحات، الشريط الجانبي، عناصر التنقل. |
+| AuthContext | إقلاع الجلسة من التخزين، تنفيذ عمليات تسجيل الدخول/الخروج/التسجيل، وتخزين رمز الوصول ومعلومات المستخدم.【F:frontend/src/contexts/AuthContext.tsx†L1-L129】 | حماية المسارات، التبديل الشرطي للمحتوى، طلبات API المصادق عليها. |
+| SidebarContext | التحكم في حالة طي الشريط الجانبي وفتحه على الأجهزة المحمولة مع تحديث العرض استنادًا إلى حجم الشاشة.【F:frontend/src/contexts/SidebarContext.tsx†L1-L92】 | مكونات التخطيط (Sidebar، MobileDrawer). |
+| NotificationCenter | إدارة إشعارات SSE، عدد الرسائل غير المقروءة، وإبطال استعلامات TanStack Query المرتبطة بلوحات الإدارة.【F:frontend/src/modules/notifications/NotificationCenter.tsx†L1-L200】 | صفحات إدارة الموقع، مركز الإشعارات في الرأس. |
+
+## 4. هيكل المجلدات العملية
+- **`src/pages`**: يحتوي على صفحات التطبيق الموجهة بالتوجيه؛ أمثلة تشمل لوحة الهبوط المقسمة إلى وحدات (`Landing/index.tsx` مع أقسام مثل HeroCarousel وServices) وصفحات لوحة التحكم المتعددة.【F:frontend/src/pages/Landing/index.tsx†L1-L39】【F:frontend/src/pages/Dashboard.tsx†L1-L11】
+- **`src/components`**: يضم المكونات القابلة لإعادة الاستخدام (التخطيطات، عناصر الجدولة، النماذج، مكونات المجال مثل تفاصيل القضايا) إضافة إلى مكتبة واجهة المستخدم المولدة من shadcn/Radix.【F:frontend/src/components/layout/AppShell.tsx†L1-L34】【F:frontend/src/components/legalCases/Details/LegalCaseDetails.tsx†L1-L80】
+- **`src/api`**: طبقة الخدمات التي تتعامل مع REST API عبر Axios، وتشمل ملفات مخصصة للقضايا، العملاء، الإعلانات القضائية، إلخ.【F:frontend/src/api/legalCases.service.ts†L1-L154】【F:frontend/src/api/clients.service.ts†L1-L131】
+- **`src/hooks`**: خطاطيف الأعمال المخصصة لتجميع الوصول إلى البيانات المنطقية (مثل `useLegalCases`, `useWebsiteContent`, `useClients`) وتغليف منطق TanStack Query.【F:frontend/src/hooks/useLegalCases.tsx†L1-L55】【F:frontend/src/hooks/useWebsiteContent.ts†L1-L73】
+- **`src/config`**: ملفات التهيئة مثل `config.ts` لعنوان الخادم، و`sidebar.ts` لتوليد بنية الشريط الجانبي وأسماء الأيقونات.【F:frontend/src/config/config.ts†L1-L9】【F:frontend/src/config/sidebar.ts†L1-L83】
+- **`src/modules`**: وحدات متخصصة عالية المستوى مثل مركز الإشعارات الذي يربط SSE مع React Query لتغذية صفحات الإدارة.【F:frontend/src/modules/notifications/NotificationCenter.tsx†L1-L200】
+
+## 5. خريطة الصفحات والمسارات
+### 5.1 المسارات العامة
+| المسار | الغرض | المكونات البارزة |
+| --- | --- | --- |
+| `/` | صفحة الهبوط المكونة من أقسام قابلة للتخصيص من لوحة الإدارة (عرض الشرائح، الخدمات، الإنجازات، الفريق...).【F:frontend/src/pages/Landing/index.tsx†L1-L39】 | `LandingNavbar`, `HeroCarousel`, `Services`, `Testimonials`, `Insights`, `Contact`, `Footer`. |
+| `/login` | شاشة مصادقة تتيح التبديل بين الدخول والتسجيل، مع تحكم كامل في التحقق والرسائل عبر التوست ومركز اللغة.【F:frontend/src/pages/Login.tsx†L1-L119】 | تبويبات Radix، نموذجين، `BrandLogo`, `useAuth`, `useToast`. |
+| `/signup` | توجيه بسيط يعيد استخدام تخطيط المصادقة (غالبًا يحمّل نفس المكونات من `Login`).【F:frontend/src/pages/Signup.tsx†L1-L87】 | نموذج تسجيل منفصل، قسم مميزات للمنصة. |
+| `*` | صفحة 404 تعرض رسالة مخصصة وروابط رجوع باستخدام مكونات الواجهة المشتركة.【F:frontend/src/pages/NotFound.tsx†L1-L63】 | `Button`, `BrandLogo`, تصميم متدرج. |
+
+### 5.2 لوحة التحكم المحمية `/dashboard`
+يتم تغليف جميع المسارات داخل `Dashboard` بواسطة `AppShell` الذي يوفّر الشريط الجانبي، الرأس، تخطيط المحتوى، ودعم الاتجاهين.【F:frontend/src/pages/Dashboard.tsx†L1-L11】【F:frontend/src/components/layout/AppShell.tsx†L1-L34】
+
+| المسار الفرعي | الوظيفة | المكونات والخطاطيف |
+| --- | --- | --- |
+| (index) | لوحة معلومات غنية بالبطاقات، الرسوم البيانية (Recharts)، وملخص النشاط.【F:frontend/src/pages/dashboard/DashboardHome.tsx†L1-L120】 | `StatsCards`, `RecentCases`, بطاقات Tailwind، تكامل مع `useLanguage` و`useTheme`. |
+| `cases` | شبكة إدارة القضايا مع جدول تفصيلي، بحث، وفرز، بالإضافة إلى نموذج إضافة/تعديل ومدخل للتفاصيل.【F:frontend/src/pages/LegalCasesPage.tsx†L1-L120】 | `DetailsTable`, `AddEditLegalCaseModal`, خطاطيف `useLegalCases` و`useDeleteLegalCase`. |
+| `cases/:id` | عرض تفاصيل القضية بجلساتها وإجراءاتها وأطرافها، مع نماذج فرعية لإضافة الجلسات والإعلانات.【F:frontend/src/components/legalCases/Details/LegalCaseDetails.tsx†L1-L80】 | أقسام `CaseSection`, `ClientsSection`, `SessionsSection`, خطاطيف استرجاع التفاصيل. |
+| `clients` | لوحة إدارة العملاء الحاليين مع تصفية وإجراءات متعددة.【F:frontend/src/pages/ClientsPage.tsx†L1-L22】 | `useClients`, نماذج التعديل، أدوات التصدير. |
+| `unClients` | تتبع العملاء المحتملين (بدون وكالة)، إعادة استخدام `DetailsTable` مع أعمدة مختلفة.【F:frontend/src/pages/UnClientsPage.tsx†L1-L29】 | `useClients` مع فلاتر prospect، أزرار التحويل. |
+| `lawyers` و`lawyers/:id` | دليل المحامين وبطاقة التفاصيل الفردية، بما في ذلك بطاقات الخدمات ومؤشرات التقييم.【F:frontend/src/pages/LawyersPage.tsx†L1-L4】 | `LawyersList`, `LawyerDetails`, خطاطيف `useUserRoles`. |
+| `services` | إدارة الخدمات القانونية: بطاقات الخدمات، جداول الأسعار، وإمكانية التعديل.【F:frontend/src/pages/ServicesPage.tsx†L1-L140】 | استخدام مباشر لـ`useQuery`/`useMutation` مع خدمات `services.service`، بالإضافة إلى حوار `ServiceFormDialog`. |
+| `office_settings` | إعدادات المكتب (المعلومات العامة، فرق العمل، مستندات الهوية).【F:frontend/src/pages/OfficeSettingsPage.tsx†L1-L140】 | تبويبات متعددة تعتمد على `useQuery` و`useMutation` مع خدمات `officeSettings.service` مع حوارات تأكيد وتبديل سمة العلامة التجارية. |
+| `website/*` | مركز إدارة الموقع (صفحات، مقالات، الفريق، الإنجازات، الإعدادات) مع واجهات إدخال ديناميكية تعتمد على المحتوى من الـ CMS الداخلي.【F:frontend/src/pages/admin/Website/AdminWebsitePage.tsx†L1-L62】 | `PagesManager`, `ArticlesManager`, `TeamManager`, `AchievementsManager`, `SettingsManager`, كل منها يستخدم خطاطيف `useWebsiteContent` و`useWebsiteCollection`. |
+| `website/report` | تقرير أداء الموقع مع بطاقات جاهزة تعرض مؤشرات النشر وصحة الـ API بناءً على `ReportWidget`.【F:frontend/src/pages/admin/Website/WebsiteReportPage.tsx†L1-L17】【F:frontend/src/pages/admin/Website/components/ReportWidget.tsx†L1-L120】 | `ReportWidget` يجمع بين `useQuery`، صلاحيات `useUserRoles`، وإشعارات `useNotifications` لعرض التقدم واستخدام الوسائط. |
+| `website/workflow` | لوحة لمتابعة سير عمل النشر وجدول الموافقات في الزمن الحقيقي.【F:frontend/src/pages/admin/Website/WorkflowBoardPage.tsx†L1-L80】 | `useQuery` لاستدعاء `getPublishingQueue`، مع تكامل `useUserRoles` و`useNotifications` لعرض حالة الاتصال والتنبيهات. |
+| `website/activity` | سجل النشاط الإداري يعرض أحداث SSE القادمة من `NotificationCenter`.【F:frontend/src/pages/admin/Website/ActivityLogPage.tsx†L1-L120】 | `useNotificationCenterContext`, جدول أحداث. |
+| `website/notifications` | مركز إشعارات المسؤول مع إمكانيات تعليم كمقروء وإزالة الرسائل.【F:frontend/src/pages/admin/Website/NotificationsPage.tsx†L1-L112】 | `NotificationFeed`, `useNotificationCenterContext`. |
+| مسارات قادمة (`sessions`, `procedures`, `reports`, `settings`, `users_roles`, `archive`, `courts_search`) | يتم تمثيلها بمكون Placeholder يترجم العناوين ويلمح لقدومها مستقبلاً.【F:frontend/src/App.tsx†L25-L70】 | `DashboardPlaceholder` مع نص مترجم من `LanguageContext`. |
+
+## 6. المكونات المشتركة والبنية البصرية
+- **التخطيط**: `AppShell` يجمع `Sidebar`, `MobileDrawer`, و`Header` ويضبط اتجاه النص وفق اللغة النشطة.【F:frontend/src/components/layout/AppShell.tsx†L1-L34】
+- **الشريط الجانبي**: يعتمد على تهيئة `sidebarGroups` لتوليد العناصر ديناميكيًا، مع دعم الطي، إشارات الحالة، وتوافق الأجهزة المحمولة.【F:frontend/src/config/sidebar.ts†L1-L83】【F:frontend/src/components/layout/Sidebar.tsx†L1-L180】
+- **مكتبة UI**: مجلد `components/ui` يحتوي على تغليفات لمكونات Radix (أزرار، تبويبات، نماذج، توست، Tooltip...) مع دمج Tailwind و`class-variance-authority` لتخصيص الأنماط.【F:frontend/src/components/ui/button.tsx†L1-L74】【F:frontend/src/components/ui/tabs.tsx†L1-L95】
+- **الجداول المتقدمة**: مكوّن `DetailsTable` يوفر فرزًا، تصديرًا إلى Excel، إجراءات صفية، وحالات تحميل/عدم وجود بيانات موحدة.【F:frontend/src/components/common/DetailsTable.tsx†L1-L220】
+- **مكونات المجال**: مثل `AddEditLegalCaseModal`, `LegalCaseDetails`، و`ClientsTable` التي تجمع بين النماذج، الجداول، والتكامل مع خدمات API المتخصصة.【F:frontend/src/components/legalCases/AddEditLegalCaseModal.tsx†L1-L210】【F:frontend/src/components/clientsAndUnclients/ClientsTable.tsx†L1-L160】
+
+## 7. الحزم الخارجية الرئيسية
+| الفئة | الحزم |
+| --- | --- |
+| إطار العمل والتجميع | `react`, `react-dom`, `vite`, `@vitejs/plugin-react-swc`, `typescript`.【F:frontend/package.json†L1-L54】 |
+| إدارة الحالة والطلبات | `@tanstack/react-query`, `axios`.【F:frontend/package.json†L41-L44】 |
+| التدويل | `i18next`, `react-i18next`, `i18next-browser-languagedetector`.【F:frontend/package.json†L47-L48】 |
+| واجهة المستخدم | حزمة Radix المتعددة، `lucide-react` للأيقونات، `framer-motion` للحركة، `embla-carousel-react` للسلايدر، `react-day-picker`, `cmdk`, `sonner`.【F:frontend/package.json†L17-L60】 |
+| الرسوم والتحليلات | `recharts` للرسوم البيانية، `react-resizable-panels` للتخطيطات التكيفية.【F:frontend/package.json†L52-L54】 |
+| الأدوات المساندة | `class-variance-authority`, `clsx`, `tailwind-merge`, `tailwindcss-animate`, `file-saver`, `xlsx` للتصدير.【F:frontend/package.json†L44-L60】 |
+
+## 8. إدارة المحتوى والبيانات المساعدة
+- تتوفر بيانات وهمية وعينات واجهات في `src/data` لدعم العرض في حال غياب بيانات حقيقية (مثل `dashboard-showcase` و`mock-data`).【F:frontend/src/data/dashboard-showcase.ts†L1-L120】【F:frontend/src/data/mock-data.ts†L1-L140】
+- أدوات المساعدة مثل `smoothScrollToElement` و`resolveAssetUrl` تُستخدم في صفحة الهبوط للتمرير السلس وتحميل الوسائط الديناميكية من إعدادات لوحة الإدارة.【F:frontend/src/utils/smoothScroll.ts†L1-L60】【F:frontend/src/utils/asset.ts†L1-L80】
+
+## 9. التدويل ودعم الاتجاهين
+- إعداد i18next يحمّل نطاق `common` للغتين العربية والإنجليزية مع كشف اللغة تلقائيًا وتخزينها في LocalStorage لضمان تماسك التجربة بين الزيارات.【F:frontend/src/i18n/index.ts†L1-L35】
+- عند تغيير اللغة يقوم `LanguageContext` بتحديث `dir` على مستوى `documentElement`، ما يسمح بتبديل الاتجاه في التخطيط والمكونات تلقائيًا دون إعادة تحميل الصفحة.【F:frontend/src/contexts/LanguageContext.tsx†L21-L78】
+
+## 10. مسار العمل الإداري المتكامل
+- صفحات إدارة الموقع (`/dashboard/website/...`) تستفيد من خطاطيف `useWebsiteContent` و`useWebsiteCollection` لجلب كتل المحتوى (hero, services, testimonials) مع دعم الترجمة والتخزين المؤقت، ما يتيح تحرير موقع الهبوط مباشرة من لوحة التحكم.【F:frontend/src/hooks/useWebsiteContent.ts†L1-L73】【F:frontend/src/pages/admin/Website/AdminWebsitePage.tsx†L1-L62】
+- مركز الإشعارات وسجل النشاط يعتمدان على `NotificationCenter` لتتبع الأحداث المباشرة (نشر المحتوى، سير العمل، الموافقات) وإظهارها في الصفحات الخاصة مع إمكانية التعليم كمقروء والإبطال التلقائي لاستعلامات React Query المتعلقة.【F:frontend/src/modules/notifications/NotificationCenter.tsx†L1-L200】【F:frontend/src/pages/admin/Website/NotificationsPage.tsx†L1-L112】
+
+هذا المستند يوفّر خريطة مرجعية شاملة لفهم بنية الواجهة، كيفية إقلاعها، وكيفية ترابط الصفحات والمكونات مع الحزم الخارجية، مما يسهّل على المطورين الجدد أو فرق التكامل بدء العمل بثقة وسرعة.

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,249 +1,270 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { motion } from "framer-motion";
 import { ChevronDown, ChevronRight, LogOut } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import BrandLogo from "../common/BrandLogo";
-import { cn } from "@/lib/utils";
-import { useLanguage } from "@/contexts/LanguageContext";
-import { useAuth } from "@/contexts/AuthContext";
-import { useSidebar } from "@/contexts/SidebarContext";
-import { useIsMobile } from "@/hooks/use-mobile";
 import LegalIcon from "@/components/common/LegalIcon";
+import { Button } from "@/components/ui/button";
+import {
+  Sidebar as SidebarRoot,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { useAuth } from "@/contexts/AuthContext";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useSidebar as useSidebarContext } from "@/contexts/SidebarContext";
 import { getIconDesign } from "@/config/iconography";
-import { sidebarGroups, type SidebarItem as SidebarItemType } from "@/config/sidebar";
+import { sidebarGroups } from "@/config/sidebar";
+import { cn } from "@/lib/utils";
 
 const Sidebar: React.FC = () => {
   const location = useLocation();
-  const isMobile = useIsMobile();
   const { t, isRTL } = useLanguage();
   const { logout } = useAuth();
-  const { isCollapsed } = useSidebar();
+  const { isCollapsed } = useSidebarContext();
 
   const collapsed = isCollapsed;
+  const currentPath = location.pathname;
 
-  const isPathActive = useMemo(
-    () =>
-      (path?: string) =>
-        !!path && (location.pathname === path || location.pathname.startsWith(`${path}/`)),
-    [location.pathname]
+  const isActive = useCallback(
+    (path?: string) =>
+      !!path && (currentPath === path || currentPath.startsWith(`${path}/`)),
+    [currentPath]
   );
 
-  if (isMobile) return null;
+  const initialExpanded = useMemo(() => {
+    const defaults: Record<string, boolean> = {};
+    sidebarGroups.forEach((group) => {
+      group.items.forEach((item) => {
+        if (item.children?.length) {
+          defaults[item.key] = item.children.some((child) => isActive(child.path));
+        }
+      });
+    });
+    return defaults;
+  }, [isActive]);
+
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(initialExpanded);
+
+  useEffect(() => {
+    setExpandedGroups((prev) => {
+      const next = { ...prev };
+      sidebarGroups.forEach((group) => {
+        group.items.forEach((item) => {
+          if (item.children?.length) {
+            if (item.children.some((child) => isActive(child.path))) {
+              next[item.key] = true;
+            }
+          }
+        });
+      });
+      return next;
+    });
+  }, [currentPath, isActive]);
+
+  const toggleGroup = useCallback((key: string) => {
+    setExpandedGroups((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  }, []);
+
+  const renderIcon = useCallback(
+    (iconKey: string, size: "default" | "sm" = "default") => {
+      const design = getIconDesign(iconKey);
+      const sizeClasses =
+        size === "sm"
+          ? "h-7 w-7 rounded-lg"
+          : collapsed
+            ? "h-9 w-9 rounded-xl"
+            : "h-10 w-10 rounded-2xl";
+      const iconSize = size === "sm" ? 16 : collapsed ? 20 : 18;
+
+      return (
+        <span
+          className={cn(
+            "flex items-center justify-center shadow-sm text-white",
+            design.badgeClass,
+            sizeClasses,
+          )}
+          style={{
+            background: design.badgeGradient,
+            boxShadow: design.shadow ?? "var(--shadow-premium)",
+          }}
+        >
+          <LegalIcon iconKey={iconKey} width={iconSize} height={iconSize} />
+        </span>
+      );
+    },
+    [collapsed],
+  );
 
   return (
-    <motion.aside
-      initial={{ width: collapsed ? 64 : 256 }}
-      animate={{ width: collapsed ? 64 : 256 }}
-      transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
-      className={cn(
-        "sidebar-shell hidden h-screen flex-shrink-0 flex-col md:sticky md:top-0 md:flex"
-      )}
+    <SidebarRoot
+      collapsible="icon"
+      className="hidden border-r border-border bg-card md:flex"
       dir={isRTL ? "rtl" : "ltr"}
-      data-collapsed={collapsed}
     >
-      {/* Brand Section */}
-      <div
-        className={cn(
-          "sidebar-brand flex items-center justify-center gap-3 transition-all duration-300",
-          collapsed ? "px-4 py-3" : "px-6 py-5"
-        )}
-      >
-        <BrandLogo
-          variant={collapsed ? "icon" : "full"}
-          className={collapsed ? "h-10 w-10" : "h-9 w-auto"}
-        />
-      </div>
+      <SidebarContent className="flex h-full flex-col gap-4 py-4">
+        <div
+          className={cn(
+            "flex items-center px-4 transition-all duration-300",
+            collapsed ? "justify-center" : "justify-start",
+          )}
+        >
+          <BrandLogo
+            variant={collapsed ? "icon" : "full"}
+            className={collapsed ? "h-10 w-10" : "h-9 w-auto"}
+          />
+        </div>
 
-      {/* Navigation Groups */}
-      <nav className="flex-1 space-y-6 overflow-y-auto px-3 py-4 sidebar-scroll">
-        {sidebarGroups.map((group) => (
-          <div key={group.key} className="space-y-2">
-            {!collapsed && (
-              <p className="sidebar-group-label px-2 text-xs font-semibold">
+        <div className="flex-1 space-y-6 overflow-y-auto px-2">
+          {sidebarGroups.map((group) => (
+            <SidebarGroup key={group.key}>
+              <SidebarGroupLabel
+                className={cn(
+                  "px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground",
+                  collapsed && "hidden",
+                )}
+              >
                 {t(`sidebar.sections.${group.key}`)}
-              </p>
-            )}
-            <div className="space-y-1">
-              {group.items.map((item) => (
-                <SidebarItem
-                  key={item.key}
-                  item={item}
-                  collapsed={collapsed}
-                  isPathActive={isPathActive}
-                  isRTL={isRTL}
-                  t={t}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-      </nav>
+              </SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu className="space-y-1">
+                  {group.items.map((item) => {
+                    const hasChildren = !!item.children?.length;
+                    const groupActive = hasChildren
+                      ? item.children!.some((child) => isActive(child.path))
+                      : false;
+                    const itemActive = item.path ? isActive(item.path) : groupActive;
 
-      {/* Logout Section */}
-      <div className="sidebar-footer border-t border-transparent px-3 py-4">
+                    if (!hasChildren) {
+                      const target = item.path ?? "#";
+
+                      return (
+                        <SidebarMenuItem key={item.key}>
+                          <SidebarMenuButton
+                            asChild
+                            isActive={itemActive}
+                            tooltip={collapsed ? t(`nav.${item.key}`) : undefined}
+                            className={cn(
+                              "rounded-lg transition-all duration-200",
+                              collapsed ? "justify-center" : "gap-3 px-3",
+                              itemActive
+                                ? "bg-primary/10 text-primary font-medium"
+                                : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                            )}
+                          >
+                            <NavLink to={target} className="flex w-full items-center gap-3">
+                              {renderIcon(item.iconKey)}
+                              {!collapsed && (
+                                <span className="truncate font-medium">
+                                  {t(`nav.${item.key}`)}
+                                </span>
+                              )}
+                            </NavLink>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      );
+                    }
+
+                    const isExpanded = expandedGroups[item.key] ?? groupActive;
+                    const childSpacing = collapsed ? "" : isRTL ? "mr-8" : "ml-8";
+
+                    return (
+                      <SidebarMenuItem key={item.key}>
+                        <Collapsible open={isExpanded} onOpenChange={() => toggleGroup(item.key)}>
+                          <CollapsibleTrigger asChild>
+                            <SidebarMenuButton
+                              isActive={groupActive}
+                              tooltip={collapsed ? t(`nav.${item.key}`) : undefined}
+                              className={cn(
+                                "rounded-lg transition-all duration-200",
+                                collapsed ? "justify-center" : "gap-3 px-3",
+                                groupActive
+                                  ? "bg-primary/10 text-primary font-medium"
+                                  : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                              )}
+                            >
+                              <div className="flex items-center gap-3">
+                                {renderIcon(item.iconKey)}
+                                {!collapsed && (
+                                  <span className="truncate font-medium">
+                                    {t(`nav.${item.key}`)}
+                                  </span>
+                                )}
+                              </div>
+                              {!collapsed && (
+                                <span className="ml-auto">
+                                  {isExpanded ? (
+                                    <ChevronDown className="h-4 w-4" />
+                                  ) : (
+                                    <ChevronRight className="h-4 w-4" />
+                                  )}
+                                </span>
+                              )}
+                            </SidebarMenuButton>
+                          </CollapsibleTrigger>
+                          <CollapsibleContent className={cn("mt-1 space-y-1", collapsed && "hidden")}>
+                            {!collapsed &&
+                              item.children?.map((child) => {
+                                const childActive = isActive(child.path);
+                                const childTarget = child.path ?? "#";
+                                return (
+                                  <SidebarMenuButton
+                                    key={child.key}
+                                    asChild
+                                    isActive={childActive}
+                                    className={cn(
+                                      "rounded-lg px-3 py-2 text-sm transition-all duration-200",
+                                      childSpacing,
+                                      childActive
+                                        ? "bg-primary/10 text-primary font-medium"
+                                        : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                                    )}
+                                  >
+                                    <NavLink
+                                      to={childTarget}
+                                      className="flex w-full items-center gap-3"
+                                    >
+                                      {renderIcon(child.iconKey, "sm")}
+                                      <span className="truncate">{t(`nav.${child.key}`)}</span>
+                                    </NavLink>
+                                  </SidebarMenuButton>
+                                );
+                              })}
+                          </CollapsibleContent>
+                        </Collapsible>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          ))}
+        </div>
+      </SidebarContent>
+      <SidebarFooter className="border-t border-border px-3 py-4">
         <Button
           onClick={logout}
           variant="ghost"
           className={cn(
-            "w-full justify-start text-sidebar-text-muted transition-colors hover:bg-destructive/10 hover:text-destructive",
-            collapsed ? "px-2" : "px-3"
+            "w-full items-center justify-start gap-3 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive",
+            collapsed && "justify-center gap-0",
           )}
         >
-          <LogOut className="h-5 w-5 flex-shrink-0" />
-          {!collapsed && (
-            <span className={cn(isRTL ? "mr-2" : "ml-2")}>{t("auth.logout")}</span>
-          )}
+          <LogOut className="h-5 w-5" />
+          {!collapsed && <span>{t("auth.logout")}</span>}
         </Button>
-      </div>
-    </motion.aside>
-  );
-};
-
-interface SidebarItemProps {
-  item: SidebarItemType;
-  collapsed: boolean;
-  isPathActive: (path?: string) => boolean;
-  isRTL: boolean;
-  t: (key: string) => string;
-}
-
-const SidebarItem: React.FC<SidebarItemProps> = ({
-  item,
-  collapsed,
-  isPathActive,
-  isRTL,
-  t
-}) => {
-  const [open, setOpen] = useState(false);
-  const hasChildren = item.children && item.children.length > 0;
-  const childActive = hasChildren
-    ? item.children!.some((child) => isPathActive(child.path))
-    : false;
-  const isActive = item.path ? isPathActive(item.path) : childActive;
-
-  const design = getIconDesign(item.iconKey);
-
-  const iconBadge = (
-    <span
-      className={cn(
-        "sidebar-icon-badge flex items-center justify-center rounded-xl transition-all duration-300",
-        collapsed
-          ? "w-[var(20px)] h-[var(20px)]"
-          : "w-[var(24px)] h-[var(24px)]",
-        design.badgeClass ?? "text-white"
-      )}
-      style={{
-        background: design.badgeGradient,
-        boxShadow: design.shadow ?? "var(--shadow-premium)"
-      }}
-    >
-      <LegalIcon
-        iconKey={item.iconKey}
-        width={collapsed ? 20 : 18}
-        height={collapsed ? 20 : 18}
-      />
-    </span>
-  );
-
-  useEffect(() => {
-    if (childActive) setOpen(true);
-  }, [childActive]);
-
-  const handleToggle = () => {
-    if (hasChildren) setOpen((prev) => !prev);
-  };
-
-  return (
-    <div className="relative">
-      {/* Parent Item */}
-      <div
-        className={cn(
-          "sidebar-nav-item group relative flex items-center rounded-2xl text-sm transition-all duration-300",
-          collapsed ? "justify-center py-2" : "px-1 py-1.5",
-          isActive ? "text-sidebar-primary" : "text-sidebar-text-muted"
-        )}
-        data-active={isActive}
-        data-collapsed={collapsed}
-      >
-        <NavLink
-          to={
-            item.path ?? (hasChildren ? item.children?.[0]?.path ?? "#" : "#")
-          }
-          end={!hasChildren}
-          className={cn(
-            "sidebar-nav-link flex w-full items-center gap-3 rounded-2xl px-3 py-2",
-            collapsed && "justify-center px-0"
-          )}
-          onClick={(event) => {
-            if (!item.path && hasChildren) {
-              event.preventDefault();
-              handleToggle();
-            }
-          }}
-        >
-          {iconBadge}
-          {!collapsed && <span className="truncate">{t(`nav.${item.key}`)}</span>}
-        </NavLink>
-
-        {!collapsed && hasChildren && (
-          <button
-            type="button"
-            className="ml-auto inline-flex h-6 w-6 items-center justify-center rounded-md text-sidebar-text-muted hover:text-sidebar-primary"
-            onClick={(event) => {
-              event.stopPropagation();
-              handleToggle();
-            }}
-            aria-label={open ? t("sidebar.toggle.close") : t("sidebar.toggle.open")}
-          >
-            {open ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-          </button>
-        )}
-      </div>
-
-      {/* Child Items */}
-      {!collapsed && hasChildren && open && (
-        <motion.div
-          initial={{ height: 0, opacity: 0 }}
-          animate={{ height: "auto", opacity: 1 }}
-          exit={{ height: 0, opacity: 0 }}
-          className={cn("mt-1 space-y-1", isRTL ? "mr-6" : "ml-6")}
-        >
-          {item.children!.map((child) => {
-            const childDesign = getIconDesign(child.iconKey);
-
-            return (
-              <NavLink
-                key={child.key}
-                to={child.path ?? "#"}
-                className={({ isActive }) =>
-                  cn(
-                    "sidebar-subitem flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm",
-                    isActive ? "is-active" : "text-sidebar-text-muted"
-                  )
-                }
-              >
-                <span
-                  className="sidebar-icon-badge flex h-8 w-8 items-center justify-center rounded-lg"
-                  style={{
-                    background: childDesign.badgeGradient,
-                    boxShadow: "var(var(--shadow-luxury))"
-                  }}
-                >
-                  <LegalIcon iconKey={child.iconKey} width={16} height={16} />
-                </span>
-                <span>{t(`nav.${child.key}`)}</span>
-              </NavLink>
-            );
-          })}
-        </motion.div>
-      )}
-    </div>
+      </SidebarFooter>
+    </SidebarRoot>
   );
 };
 

--- a/frontend/src/contexts/SidebarContext.tsx
+++ b/frontend/src/contexts/SidebarContext.tsx
@@ -3,8 +3,13 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
+import {
+  SidebarProvider as SidebarUiProvider,
+  useSidebar as useUiSidebar,
+} from '@/components/ui/sidebar';
 
 interface SidebarContextType {
   isCollapsed: boolean;
@@ -16,10 +21,7 @@ interface SidebarContextType {
 
 const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 
-const DESKTOP_SIDEBAR_WIDTH = '280px';
-const TABLET_SIDEBAR_WIDTH = '220px';
-const MOBILE_SIDEBAR_WIDTH = '100%';
-const ICON_SIDEBAR_WIDTH = '88px';
+const SIDEBAR_STORAGE_KEY = 'sidebar-collapsed';
 
 export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -27,75 +29,55 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ child
       return false;
     }
 
-    const saved = window.localStorage.getItem('sidebar-collapsed');
-    return saved ? JSON.parse(saved) : false;
+    const stored = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : false;
   });
-  const [isMobileOpen, setIsMobileOpen] = useState(false);
 
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-
-    const root = document.documentElement;
-    root.style.setProperty('--sidebar-width-icon', ICON_SIDEBAR_WIDTH);
-
-    const applyResponsiveWidth = () => {
-      if (typeof window === 'undefined') return;
-      const viewportWidth = window.innerWidth;
-
-      if (viewportWidth < 640) {
-        root.style.setProperty('--sidebar-width', MOBILE_SIDEBAR_WIDTH);
-      } else if (viewportWidth < 1024) {
-        root.style.setProperty('--sidebar-width', TABLET_SIDEBAR_WIDTH);
-      } else {
-        root.style.setProperty('--sidebar-width', DESKTOP_SIDEBAR_WIDTH);
-      }
-    };
-
-    applyResponsiveWidth();
-    window.addEventListener('resize', applyResponsiveWidth);
-
-    return () => {
-      window.removeEventListener('resize', applyResponsiveWidth);
-    };
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsCollapsed(!open);
   }, []);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem('sidebar-collapsed', JSON.stringify(isCollapsed));
+      window.localStorage.setItem(SIDEBAR_STORAGE_KEY, JSON.stringify(isCollapsed));
     }
   }, [isCollapsed]);
 
+  return (
+    <SidebarUiProvider open={!isCollapsed} onOpenChange={handleOpenChange}>
+      <SidebarContextBridge isCollapsed={isCollapsed}>{children}</SidebarContextBridge>
+    </SidebarUiProvider>
+  );
+};
+
+const SidebarContextBridge: React.FC<{
+  isCollapsed: boolean;
+  children: React.ReactNode;
+}> = ({ isCollapsed, children }) => {
+  const { toggleSidebar, openMobile, setOpenMobile } = useUiSidebar();
+
   const toggleCollapsed = useCallback(() => {
-    setIsCollapsed(prev => !prev);
-  }, []);
+    toggleSidebar();
+  }, [toggleSidebar]);
 
   const toggleMobile = useCallback(() => {
-    setIsMobileOpen(prev => !prev);
-  }, []);
+    setOpenMobile(prev => !prev);
+  }, [setOpenMobile]);
 
   const closeMobile = useCallback(() => {
-    setIsMobileOpen(false);
-  }, []);
+    setOpenMobile(false);
+  }, [setOpenMobile]);
 
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-    if (isMobileOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isMobileOpen]);
-
-  const value = {
-    isCollapsed,
-    isMobileOpen,
-    toggleCollapsed,
-    toggleMobile,
-    closeMobile
-  };
+  const value = useMemo(
+    () => ({
+      isCollapsed,
+      isMobileOpen: openMobile,
+      toggleCollapsed,
+      toggleMobile,
+      closeMobile,
+    }),
+    [isCollapsed, openMobile, toggleCollapsed, toggleMobile, closeMobile],
+  );
 
   return (
     <SidebarContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- rebuild the dashboard sidebar with the shadcn/ui sidebar primitives to match the collapsible menu behavior and styling that product requested
- bridge the existing sidebar context to the shadcn provider so collapse state persists via localStorage and mobile toggles keep working

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e41045709c832fa7dab9be202b2022