### PR TITLE
Fix auth provider initialization error

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -72,6 +72,31 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
+  const mapRole = useCallback((role: ApiUser['role']): User['role'] => {
+    const normalized = typeof role === 'string' ? role.toLowerCase() : String(role ?? '').toLowerCase();
+
+    if (normalized === '1' || normalized === 'admin') {
+      return 'admin';
+    }
+
+    if (normalized === '2' || normalized === 'lawyer') {
+      return 'lawyer';
+    }
+
+    return 'client';
+  }, []);
+
+  const mapApiUserToContextUser = useCallback(
+    (payload: ApiUser): User => ({
+      id: String(payload.id),
+      email: payload.email,
+      name: payload.name,
+      avatar: payload.avatar ?? undefined,
+      role: mapRole(payload.role ?? null),
+    }),
+    [mapRole],
+  );
+
   useEffect(() => {
     const initialize = async () => {
       try {
@@ -137,31 +162,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       window.removeEventListener('storage', handleStorageChange);
     };
   }, [readUserFromStorage]);
-
-  const mapRole = useCallback((role: ApiUser['role']): User['role'] => {
-    const normalized = typeof role === 'string' ? role.toLowerCase() : String(role ?? '').toLowerCase();
-
-    if (normalized === '1' || normalized === 'admin') {
-      return 'admin';
-    }
-
-    if (normalized === '2' || normalized === 'lawyer') {
-      return 'lawyer';
-    }
-
-    return 'client';
-  }, []);
-
-  const mapApiUserToContextUser = useCallback(
-    (payload: ApiUser): User => ({
-      id: String(payload.id),
-      email: payload.email,
-      name: payload.name,
-      avatar: payload.avatar ?? undefined,
-      role: mapRole(payload.role ?? null),
-    }),
-    [mapRole],
-  );
 
   const extractErrorMessage = useCallback((error: unknown, fallback: string): string => {
     if (error && typeof error === 'object') {


### PR DESCRIPTION
## Summary
- ensure the AuthContext user mapping helper is defined before the effects that depend on it
- prevent the AuthProvider initialization from throwing a ReferenceError during bootstrapping

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e41c49eaa0832f8a136111351a66b1