### PR TITLE
fix: show brand icon on mobile landing navbar

### DIFF
--- a/frontend/src/pages/Landing/LandingNavbar.tsx
+++ b/frontend/src/pages/Landing/LandingNavbar.tsx
@@ -128,24 +128,24 @@ const LandingNavbar: React.FC = () => {
         <button
           type="button"
           onClick={() => scrollToAnchor("#home")}
-          className="flex items-center gap-3" 
+          className="flex items-center gap-3"
         >
-         <button
-  type="button"
-  onClick={() => scrollToAnchor("#home")}
-  className="flex items-center gap-3" 
->
-  <div className="hidden sm:block">
-    <BrandLogo
-      variant="text"
-      className="h-12"
-      lang={language}
-      dark={isTop ? true : undefined}
-    />
-  </div> 
-</button>
-
- 
+          <div className="sm:hidden">
+            <BrandLogo
+              variant="icon"
+              className="h-10 w-10"
+              lang={language}
+              dark={isTop ? true : undefined}
+            />
+          </div>
+          <div className="hidden sm:block">
+            <BrandLogo
+              variant="text"
+              className="h-12"
+              lang={language}
+              dark={isTop ? true : undefined}
+            />
+          </div>
         </button>
 
         <div className="hidden items-center gap-6 lg:flex">


### PR DESCRIPTION
## Summary
- render the brand icon variant within the landing navbar when viewed on small screens
- keep the existing text logo for larger breakpoints while fixing duplicated button markup

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e51d05984c832f871f57018629998f