### PR TITLE
Align admin website management routes with Sanctum

### DIFF
--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:eKkJtG/njqluhOIGeZSWrCLQCaQU4hJJxzq/idcvimI="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -235,6 +235,9 @@ Route::prefix('admin/website')
         Route::get('/settings', [PageController::class, 'settings']);
         Route::put('/settings', [PageController::class, 'updateSettings']);
 
+        Route::apiResource('team', TeamController::class);
+        Route::apiResource('achievements', AchievementController::class);
+
         Route::get('/articles', [ArticleController::class, 'index']);
         Route::post('/articles', [ArticleController::class, 'store']);
         Route::get('/articles/{article}', [ArticleController::class, 'show']);

--- a/backend/tests/Feature/AdminWebsiteManagementTest.php
+++ b/backend/tests/Feature/AdminWebsiteManagementTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+function actingAsRole(string $role): User
+{
+    $user = User::factory()->create([
+        'role' => $role,
+    ]);
+
+    Sanctum::actingAs($user);
+
+    return $user;
+}
+
+test('admin can manage team members via admin website routes', function () {
+    actingAsRole('1');
+
+    $payload = [
+        'name_en' => 'Sarah Johnson',
+        'name_ar' => 'سارة جونسون',
+        'position_en' => 'Managing Partner',
+        'position_ar' => 'الشريك الإداري',
+        'bio_en' => 'Oversees complex litigation matters.',
+        'bio_ar' => 'تشرف على قضايا التقاضي المعقدة.',
+        'highlights_en' => ['Litigation lead'],
+        'highlights_ar' => ['قيادة التقاضي'],
+        'image' => 'https://example.com/sarah.jpg',
+    ];
+
+    $createResponse = $this->postJson('/api/admin/website/team', $payload);
+
+    $createResponse
+        ->assertCreated()
+        ->assertJsonPath('data.name.en', 'Sarah Johnson');
+
+    $teamId = $createResponse->json('data.id');
+
+    expect($teamId)->not->toBeNull();
+
+    $this->assertDatabaseHas('team_members', [
+        'id' => $teamId,
+        'name_en' => 'Sarah Johnson',
+    ]);
+
+    $this->putJson("/api/admin/website/team/{$teamId}", [
+        'position_en' => 'Senior Partner',
+        'position_ar' => 'شريك أول',
+    ])->assertOk()->assertJsonPath('data.position.en', 'Senior Partner');
+
+    $this->deleteJson("/api/admin/website/team/{$teamId}")->assertNoContent();
+
+    $this->assertDatabaseMissing('team_members', [
+        'id' => $teamId,
+    ]);
+});
+
+test('admin can manage achievements via admin website routes', function () {
+    actingAsRole('1');
+
+    $createResponse = $this->postJson('/api/admin/website/achievements', [
+        'title_en' => 'Cases Won',
+        'title_ar' => 'قضايا فزنا بها',
+        'number' => 120,
+    ]);
+
+    $createResponse
+        ->assertCreated()
+        ->assertJsonPath('data.title.en', 'Cases Won');
+
+    $achievementId = $createResponse->json('data.id');
+
+    expect($achievementId)->not->toBeNull();
+
+    $this->assertDatabaseHas('achievements', [
+        'id' => $achievementId,
+        'title_en' => 'Cases Won',
+    ]);
+
+    $this->putJson("/api/admin/website/achievements/{$achievementId}", [
+        'number' => 125,
+    ])->assertOk()->assertJsonPath('data.number', 125);
+
+    $this->deleteJson("/api/admin/website/achievements/{$achievementId}")->assertNoContent();
+
+    $this->assertDatabaseMissing('achievements', [
+        'id' => $achievementId,
+    ]);
+});
+
+test('non admin users cannot access admin website management routes', function () {
+    actingAsRole('3');
+
+    $this->postJson('/api/admin/website/team', [
+        'name_en' => 'Blocked',
+        'name_ar' => 'محظور',
+        'position_en' => 'Viewer',
+        'position_ar' => 'مشاهد',
+        'bio_en' => 'Should not be created.',
+        'bio_ar' => 'يجب ألا يتم إنشاؤه.',
+    ])->assertForbidden();
+});
+
+test('unauthenticated requests to admin website routes are rejected', function () {
+    app('auth')->forgetGuards();
+
+    $this->getJson('/api/admin/website/team')->assertUnauthorized();
+});
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,8 +16,10 @@ To resolve the issue:
 1. Log in through the normal authentication flow (`/api/auth/login`). The response contains an `access_token` that the frontend stores in `sessionStorage`.
 2. After a successful login refresh, the axios interceptor sends the `Authorization: Bearer <token>` header, allowing requests such as `/api/admin/auth/me` and `/api/admin/website/pages` to succeed.
 
+The backend now exposes a dedicated `/api/admin/website/...` namespace for managing the marketing site. Listing and mutating pages, articles, testimonials, team members, and achievements all happen behind Sanctum + role checks. Any request that reaches those routes without a valid admin or editor session will return `401` or `403`.
+
 If you are logged in as a non-admin user, the same calls will still fail with `403 Forbidden` because of the `role:admin` middleware on those routes. Switch to an account whose `role` value maps to `admin`.
 
-The `404 Not Found` responses for `/api/admin/website/testimonials` and `/api/admin/website/articles` occur because the backend only exposes `team`, `achievements`, and `articles` CRUD endpoints inside the `/api/website` prefix. There is currently no `/api/admin/website/testimonials` route, so the frontend call returns `404`. Fetch testimonials from the page content instead, or add the missing backend route before calling it.
+If you still receive `404 Not Found` responses from the admin namespace, double-check the slug or identifier you are passing in the URL. The route definitions are available in [`backend/routes/api.php`](../backend/routes/api.php).
 
-In short, authenticate with an admin account before visiting the admin dashboard and avoid calling routes that are not implemented on the backend.
+In short, authenticate with an admin account before visiting the admin dashboard and make sure you are targeting the `/api/admin/website/...` endpoints.

--- a/frontend/src/api/websiteAdmin.service.ts
+++ b/frontend/src/api/websiteAdmin.service.ts
@@ -186,22 +186,22 @@ export interface TeamMemberInput {
 }
 
 export const listTeamMembers = async (): Promise<TeamMemberApi[]> => {
-  const { data } = await api.get('/api/website/team');
+  const { data } = await api.get('/api/admin/website/team');
   return unwrapCollection<TeamMemberApi>(data);
 };
 
 export const createTeamMember = async (payload: TeamMemberInput): Promise<TeamMemberApi> => {
-  const { data } = await api.post('/api/website/team', payload);
+  const { data } = await api.post('/api/admin/website/team', payload);
   return unwrap<TeamMemberApi>(data);
 };
 
 export const updateTeamMember = async (id: number, payload: TeamMemberInput): Promise<TeamMemberApi> => {
-  const { data } = await api.put(`/api/website/team/${id}`, payload);
+  const { data } = await api.put(`/api/admin/website/team/${id}`, payload);
   return unwrap<TeamMemberApi>(data);
 };
 
 export const deleteTeamMember = async (id: number): Promise<void> => {
-  await api.delete(`/api/website/team/${id}`);
+  await api.delete(`/api/admin/website/team/${id}`);
 };
 
 export interface AchievementInput {
@@ -211,22 +211,22 @@ export interface AchievementInput {
 }
 
 export const listAchievements = async (): Promise<AchievementApi[]> => {
-  const { data } = await api.get('/api/website/achievements');
+  const { data } = await api.get('/api/admin/website/achievements');
   return unwrapCollection<AchievementApi>(data);
 };
 
 export const createAchievement = async (payload: AchievementInput): Promise<AchievementApi> => {
-  const { data } = await api.post('/api/website/achievements', payload);
+  const { data } = await api.post('/api/admin/website/achievements', payload);
   return unwrap<AchievementApi>(data);
 };
 
 export const updateAchievement = async (id: number, payload: AchievementInput): Promise<AchievementApi> => {
-  const { data } = await api.put(`/api/website/achievements/${id}`, payload);
+  const { data } = await api.put(`/api/admin/website/achievements/${id}`, payload);
   return unwrap<AchievementApi>(data);
 };
 
 export const deleteAchievement = async (id: number): Promise<void> => {
-  await api.delete(`/api/website/achievements/${id}`);
+  await api.delete(`/api/admin/website/achievements/${id}`);
 };
 
 export interface ArticleInput {


### PR DESCRIPTION
## Summary
- expose team and achievement CRUD endpoints under the /api/admin/website namespace
- update the React admin data service and docs to point at the centralized admin routes
- add feature coverage for admin, unauthorized, and unauthenticated access and set an APP_KEY for phpunit

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68e51e267324832f95518ce97fa7c405