### PR TITLE
Improve landing navbar action button styling

### DIFF
--- a/frontend/src/components/ui/theme-toggle.tsx
+++ b/frontend/src/components/ui/theme-toggle.tsx
@@ -1,23 +1,50 @@
 import React from "react";
 import { Moon, Sun } from "lucide-react";
+
 import { useTheme } from "@/contexts/ThemeContext";
+import { cn } from "@/lib/utils";
+
+import type { ButtonProps } from "./button";
 import { Button } from "./button";
 
-const ThemeToggle: React.FC = () => {
+export type ThemeToggleTone = "hero" | "dark" | "light";
+
+export const themeToggleToneVariantMap: Record<ThemeToggleTone, ButtonProps["variant"]> = {
+  hero: "glass",
+  dark: "glass",
+  light: "outline",
+};
+
+export const themeToggleToneClassMap: Record<ThemeToggleTone, string> = {
+  hero: "border-white/60 text-white hover:bg-white/15 shadow-[0_18px_48px_-20px_rgba(15,23,42,0.65)] ring-1 ring-white/20",
+  dark: "border-white/40 text-white hover:bg-white/10",
+  light: "border-border text-foreground hover:bg-muted/40",
+};
+
+interface ThemeToggleProps {
+  tone?: ThemeToggleTone;
+  className?: string;
+}
+
+const ThemeToggle: React.FC<ThemeToggleProps> = ({ tone, className }) => {
   const { theme, toggleTheme } = useTheme();
   const isDark = theme === "dark";
 
+  const resolvedTone: ThemeToggleTone = tone ?? (isDark ? "dark" : "light");
+  const variant = themeToggleToneVariantMap[resolvedTone];
+  const toneClasses = themeToggleToneClassMap[resolvedTone];
+
   return (
     <Button
-      variant={isDark ? "glass" : "outline"}
+      variant={variant}
       size="icon"
       onClick={toggleTheme}
       aria-label={isDark ? "Switch to Light" : "Switch to Dark"}
-      className={`transition-all duration-300 rounded-full ${
-        isDark
-          ? "border-white/40 text-white hover:bg-white/10"
-          : "border-border text-foreground hover:bg-muted/40"
-      }`}
+      className={cn(
+        "rounded-full transition-all duration-300",
+        toneClasses,
+        className,
+      )}
     >
       {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
     </Button>

--- a/frontend/src/pages/Landing/LandingNavbar.tsx
+++ b/frontend/src/pages/Landing/LandingNavbar.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import ThemeToggle from "@/components/ui/theme-toggle";
+import ThemeToggle, {
+  themeToggleToneClassMap,
+  themeToggleToneVariantMap,
+  type ThemeToggleTone,
+} from "@/components/ui/theme-toggle";
 import BrandLogo from "@/components/common/BrandLogo";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -86,10 +90,10 @@ const LandingNavbar: React.FC = () => {
   const { label: toggleLabel, aria: toggleAria } = toggleCopy[language];
   const underlineAlignment = isArabic ? "right-0 origin-right" : "left-0 origin-left";
 
-  const isTransparent = !isScrolled;
-  const buttonTone = isDark
-    ? "border-white/40 text-white hover:bg-white/10"
-    : "border-border text-foreground hover:bg-muted/40";
+  const actionTone: ThemeToggleTone = isTop ? "hero" : isDark ? "dark" : "light";
+  const actionVariant = themeToggleToneVariantMap[actionTone];
+  const actionToneClasses = themeToggleToneClassMap[actionTone];
+  const actionButtonBase = "rounded-full transition-all duration-300";
 
   return (
     <nav
@@ -164,15 +168,15 @@ const LandingNavbar: React.FC = () => {
 
         {/* Actions */}
         <div className="flex items-center gap-3">
-          <ThemeToggle />
+          <ThemeToggle tone={actionTone} />
 
           {/* Language */}
           <Button
-            variant={isDark ? "glass" : "outline"}
+            variant={actionVariant}
             size="icon"
             onClick={toggleLanguage}
-            aria-label="Toggle language"
-            className={`rounded-full ${buttonTone} ${
+            aria-label={toggleAria}
+            className={`${actionButtonBase} ${actionToneClasses} ${
               isArabic ? "font-arabic" : "font-english"
             }`}
           >
@@ -192,9 +196,9 @@ const LandingNavbar: React.FC = () => {
 
           {/* Mobile Menu */}
           <Button
-            variant={isDark ? "glass" : "outline"}
+            variant={actionVariant}
             size="icon"
-            className={`lg:hidden ${buttonTone}`}
+            className={`lg:hidden ${actionButtonBase} ${actionToneClasses}`}
             onClick={() => setIsOpen((p) => !p)}
             aria-label={isOpen ? "Close navigation" : "Open navigation"}
           >


### PR DESCRIPTION
## Summary
- extend the theme toggle to support reusable tone variants for hero, dark, and light contexts
- update the landing navbar to apply shared tone variants to the theme, language, and menu actions so the controls stay visible over the hero cover

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e52471d7dc832f8915266f5799ee76