### PR TITLE
Adjust Arabic typography scale on landing

### DIFF
--- a/frontend/src/components/SectionTitle.tsx
+++ b/frontend/src/components/SectionTitle.tsx
@@ -73,6 +73,12 @@ export const SectionTitle = <T extends HeadingTag = 'h2'>(props: SectionTitlePro
 
   const direction = textDir ?? (isArabic ? 'ltr' : 'rtl'); // ✅ هذا هو المتغير المستخدم فعلاً
 
+  const sizeClasses = isArabic
+    ? 'text-2xl sm:text-3xl lg:text-4xl'
+    : 'text-3xl sm:text-4xl lg:text-5xl';
+
+  const trackingClass = isArabic ? 'tracking-[0.05em]' : 'tracking-[0.08em]';
+
   return (
     <MotionComponent
       dir={direction}
@@ -82,7 +88,8 @@ export const SectionTitle = <T extends HeadingTag = 'h2'>(props: SectionTitlePro
       transition={transition ?? (animateOnView ? defaultTransition : undefined)}
       className={cn(
         'section-title relative inline-flex w-fit items-center justify-center text-balance font-extrabold',
-        'tracking-[0.08em] text-3xl md:text-5xl',
+        sizeClasses,
+        trackingClass,
         'text-[hsl(var(--title-color-light))] dark:text-[hsl(var(--title-color-dark))]',
         'drop-shadow-[0_0_18px_rgba(175,220,255,var(--glow-intensity))]',
         'after:pointer-events-none after:absolute after:inset-0 after:-z-10 after:rounded-[2.5rem]',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,14 @@
     @apply bg-background text-foreground;
   }
 
+  html[lang='ar'] body {
+    font-family: 'Cairo', 'Amiri', 'Inter', var(--font-display, 'Inter'), sans-serif;
+  }
+
+  html[lang='ar'] .font-display {
+    font-family: 'Cairo', 'Amiri', 'Inter', var(--font-display, 'Inter'), sans-serif;
+  }
+
   /* Dark CTA background */
   .bg-cta-dark {
     @apply bg-gradient-to-br from-primary via-primary-glow to-slate-bg;

--- a/frontend/src/pages/Landing/CallToAction.tsx
+++ b/frontend/src/pages/Landing/CallToAction.tsx
@@ -5,9 +5,11 @@ import { useWebsiteContent } from '@/hooks/useWebsiteContent';
 import { Play, ArrowRight, Sparkles, Zap } from 'lucide-react';
 import { smoothScrollToElement } from '@/utils/smoothScroll';
 import { motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
 
 const CallToAction: React.FC = () => {
   const { language, isRTL } = useLanguage();
+  const isArabic = language === 'ar';
   const locale = language as 'ar' | 'en';
   const { getLocalizedValue, getValueForLocale } = useWebsiteContent('cta');
 
@@ -74,7 +76,10 @@ const CallToAction: React.FC = () => {
             whileInView={{ y: 0, opacity: 1 }}
             viewport={{ once: true }}
             transition={{ duration: 0.7 }}
-            className="text-4xl md:text-6xl font-display font-bold text-white leading-tight"
+            className={cn(
+              'font-display font-bold text-white leading-tight text-balance',
+              isArabic ? 'text-3xl sm:text-4xl lg:text-5xl' : 'text-4xl md:text-6xl'
+            )}
           >
             {title}{' '}
             <span className="bg-gradient-gold bg-clip-text text-transparent animate-shine">
@@ -88,7 +93,10 @@ const CallToAction: React.FC = () => {
             whileInView={{ y: 0, opacity: 1 }}
             viewport={{ once: true }}
             transition={{ duration: 0.7, delay: 0.2 }}
-            className="text-xl md:text-2xl text-white/85 max-w-3xl mx-auto leading-relaxed"
+            className={cn(
+              'text-white/85 max-w-3xl mx-auto leading-relaxed',
+              isArabic ? 'text-base sm:text-lg' : 'text-xl md:text-2xl'
+            )}
           >
             {subtitle}
           </motion.p>
@@ -115,7 +123,10 @@ const CallToAction: React.FC = () => {
           <div className={`flex flex-col sm:flex-row gap-6 justify-center items-center ${isRTL ? 'sm:flex-row-reverse' : ''}`}>
             <Button
               size="lg"
-              className="btn-gold text-lg px-10 py-5 group shadow-gold hover:shadow-xl hover:scale-105 transition-all"
+              className={cn(
+                'btn-gold px-10 py-5 group shadow-gold hover:shadow-xl hover:scale-105 transition-all',
+                isArabic ? 'text-base sm:text-lg' : 'text-lg'
+              )}
               onClick={() => scrollToSection('#capabilities')}
             >
               <Play className="w-5 h-5 mr-3 rtl:ml-3 rtl:mr-0 group-hover:scale-110 transition-transform" />
@@ -125,7 +136,10 @@ const CallToAction: React.FC = () => {
             <Button
               size="lg"
               variant="outline"
-              className="text-lg px-10 py-5 border-2 border-white/50 text-white hover:bg-white/20 transition-all"
+              className={cn(
+                'px-10 py-5 border-2 border-white/50 text-white hover:bg-white/20 transition-all',
+                isArabic ? 'text-base sm:text-lg' : 'text-lg'
+              )}
               onClick={() => scrollToSection('#contact')}
             >
               {secondaryLabel}
@@ -155,7 +169,14 @@ const CallToAction: React.FC = () => {
           </motion.div>
 
           {/* Bottom Note */}
-          <p className="text-white/80 text-lg font-medium mt-8 animate-pulse">{bottomNote}</p>
+          <p
+            className={cn(
+              'text-white/80 font-medium mt-8 animate-pulse',
+              isArabic ? 'text-base sm:text-lg' : 'text-lg'
+            )}
+          >
+            {bottomNote}
+          </p>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/Landing/HeroCarousel.tsx
+++ b/frontend/src/pages/Landing/HeroCarousel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { motion, AnimatePresence, easeOut } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import SectionTitle from '@/components/SectionTitle';
@@ -7,13 +7,17 @@ import { useWebsiteContent } from '@/hooks/useWebsiteContent';
 import type { Locale } from '@/types/website';
 import {
   ChevronLeft,
-  ChevronRight, 
+  ChevronRight,
   ShieldCheck,
   Sparkles,
-  Loader2,Cpu, PlayCircle } from 'lucide-react';
+  Loader2,
+  Cpu,
+  PlayCircle,
+} from 'lucide-react';
 import { smoothScrollToElement } from '@/utils/smoothScroll';
 import { resolveAssetUrl } from '@/utils/asset';
 import SilkBackground from './components/SilkBackground';
+import { cn } from '@/lib/utils';
 
 interface HeroSlide {
   id: number;
@@ -170,42 +174,52 @@ const HeroCarousel: React.FC = () => {
             )}
 
             {/* العنوان */}
-          <SectionTitle
-  as="h1"
-  variants={textVariants}
-  custom={1}
-  dir={isArabic ? 'rtl' : 'ltr'}
-  animateOnView={false}
-  glowIntensity={0.85}
-  className={`
-    max-w-3xl font-display 
-    lg:text-6xl 
-    ${isArabic ? 'text-right' : 'text-left'}
-    text-[hsl(var(--title-color-dark))] 
-    dark:text-[hsl(var(--title-color-dark))] 
-  `}
->
-  {active.title}
-</SectionTitle>
+            <SectionTitle
+              as="h1"
+              variants={textVariants}
+              custom={1}
+              dir={isArabic ? 'rtl' : 'ltr'}
+              animateOnView={false}
+              glowIntensity={0.85}
+              className={cn(
+                'max-w-3xl font-display text-balance text-[hsl(var(--title-color-dark))] dark:text-[hsl(var(--title-color-dark))]',
+                isArabic
+                  ? 'text-3xl sm:text-4xl xl:text-5xl'
+                  : 'text-4xl md:text-5xl xl:text-6xl',
+                isArabic ? 'text-right' : 'text-left'
+              )}
+            >
+              {active.title}
+            </SectionTitle>
 
 
             <motion.p
               variants={textVariants}
               custom={2}
-              className="mt-4 text-lg text-white/85 leading-relaxed"
+              className={cn(
+                'mt-4 text-white/85 leading-relaxed',
+                isArabic ? 'text-base sm:text-lg' : 'text-lg sm:text-xl'
+              )}
             >
               {active.subtitle}
             </motion.p>
 
             {/* النقاط */}
-            <motion.ul className="mt-6 space-y-3 text-base text-white/85" initial="hidden" animate="visible">
+            <motion.ul
+              className={cn(
+                'mt-6 space-y-3 text-white/85',
+                isArabic ? 'text-sm sm:text-base' : 'text-base'
+              )}
+              initial="hidden"
+              animate="visible"
+            >
               {active.bullets.map((b, i) => (
                 <motion.li
-                
+
                   key={b}
                   variants={textVariants}
                   custom={i + 3}
-                  className="flex items-start gap-3"
+                  className="flex items-start gap-3 leading-relaxed"
                 >
                   <ShieldCheck className="mt-1 h-5 w-5 text-accent flex-shrink-0" />
                   <span>{b}</span>
@@ -214,82 +228,84 @@ const HeroCarousel: React.FC = () => {
             </motion.ul>
 
             {/* الأزرار */}
-              <motion.div
-              
-    dir={isArabic ? 'ltr' : 'rtl'}
+            <motion.div
+              dir={isArabic ? 'ltr' : 'rtl'}
               variants={textVariants}
               custom={active.bullets.length + 4}
               className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center"
             >
-       
+              <Button
+                onClick={() => smoothScrollToElement(document.querySelector('#demo')!)}
+                variant="accent"
+                className={cn(
+                  'btn-primary flex items-center justify-center gap-2 px-8 py-3 font-semibold text-white',
+                  isArabic ? 'text-sm sm:text-base' : 'text-base'
+                )}
+              >
+                <PlayCircle className="h-5 w-5" />
+                <span>{isArabic ? 'ابدأ رقمنة مكتبك' : 'Start Your Digital Transformation'}</span>
+              </Button>
 
-<Button
-  onClick={() => smoothScrollToElement(document.querySelector('#demo')!)}
-  variant="accent"
-  className="btn-primary flex items-center justify-center gap-2 px-8 py-3 text-base font-semibold text-white"
->
-  <PlayCircle className="h-5 w-5" />
-  <span>{isArabic ? 'ابدأ رقمنة مكتبك' : 'Start Your Digital Transformation'}</span>
-</Button>
-
-<Button
-  onClick={() => smoothScrollToElement(document.querySelector('#contact')!)}
-  variant="hero"
-  className="btn-glass flex items-center justify-center gap-2 border-white/40 px-8 py-3 text-base font-semibold text-white"
->
-  <Cpu className="h-5 w-5" />
-  <span>{isArabic ? 'تعرّف على الأنظمة' : 'Explore Our Systems'}</span>
-</Button>
-
+              <Button
+                onClick={() => smoothScrollToElement(document.querySelector('#contact')!)}
+                variant="hero"
+                className={cn(
+                  'btn-glass flex items-center justify-center gap-2 border-white/40 px-8 py-3 font-semibold text-white',
+                  isArabic ? 'text-sm sm:text-base' : 'text-base'
+                )}
+              >
+                <Cpu className="h-5 w-5" />
+                <span>{isArabic ? 'تعرّف على الأنظمة' : 'Explore Our Systems'}</span>
+              </Button>
             </motion.div>
           </motion.div>
         </div>
       </div>
 
       {/* عناصر التحكم */}
-   <div
-  dir={isArabic ? 'rtl' : 'ltr'}
-  className="absolute bottom-6 inset-x-0 z-20 flex items-center justify-center gap-4"
->
-  {/* زر السابق */}
-  <button
-    onClick={() => setCurrent((prev) => (prev - 1 + slides.length) % slides.length)}
-    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white hover:bg-black/60 transition"
-    aria-label={isArabic ? 'الشريحة السابقة' : 'Previous slide'}
-  >
-    {isArabic ? (
-      <ChevronRight className="h-5 w-5" /> // ← بالعربي الزر العكسي
-    ) : (
-      <ChevronLeft className="h-5 w-5" />
-    )}
-  </button>
+      <div
+        dir={isArabic ? 'rtl' : 'ltr'}
+        className="absolute bottom-6 inset-x-0 z-20 flex items-center justify-center gap-4"
+      >
+        {/* زر السابق */}
+        <button
+          onClick={() => setCurrent((prev) => (prev - 1 + slides.length) % slides.length)}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white hover:bg-black/60 transition"
+          aria-label={isArabic ? 'الشريحة السابقة' : 'Previous slide'}
+        >
+          {isArabic ? (
+            <ChevronRight className="h-5 w-5" /> // ← بالعربي الزر العكسي
+          ) : (
+            <ChevronLeft className="h-5 w-5" />
+          )}
+        </button>
 
-  {/* النقاط (المؤشرات) */}
-  <div className="flex gap-2">
-    {slides.map((_, i) => (
-      <button
-        key={i}
-        onClick={() => setCurrent(i)}
-        className={`h-2 rounded-full transition-all ${
-          i === current ? 'w-8 bg-white' : 'w-2 bg-white/40 hover:bg-white/70'
-        }`}
-        aria-label={`Go to slide ${i + 1}`}
-      />
-    ))}
-  </div>
+        {/* النقاط (المؤشرات) */}
+        <div className="flex gap-2">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setCurrent(i)}
+              className={`h-2 rounded-full transition-all ${
+                i === current ? 'w-8 bg-white' : 'w-2 bg-white/40 hover:bg-white/70'
+              }`}
+              aria-label={`Go to slide ${i + 1}`}
+            />
+          ))}
+        </div>
 
-  {/* زر التالي */}
-  <button
-    onClick={() => setCurrent((prev) => (prev + 1) % slides.length)}
-    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white hover:bg-black/60 transition"
-    aria-label={isArabic ? 'الشريحة التالية' : 'Next slide'}
-  >
-    {isArabic ? (
-      <ChevronLeft className="h-5 w-5" /> // ← بالعربي السهم العكسي
-    ) : (
-      <ChevronRight className="h-5 w-5" />
-    )}
-  </button> 
+        {/* زر التالي */}
+        <button
+          onClick={() => setCurrent((prev) => (prev + 1) % slides.length)}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-black/40 text-white hover:bg-black/60 transition"
+          aria-label={isArabic ? 'الشريحة التالية' : 'Next slide'}
+        >
+          {isArabic ? (
+            <ChevronLeft className="h-5 w-5" /> // ← بالعربي السهم العكسي
+          ) : (
+            <ChevronRight className="h-5 w-5" />
+          )}
+        </button>
 
         <button
           onClick={() => setAutoPlay((p) => !p)}

--- a/frontend/src/pages/Landing/components/SectionHeader.tsx
+++ b/frontend/src/pages/Landing/components/SectionHeader.tsx
@@ -3,6 +3,7 @@ import { motion, cubicBezier } from 'framer-motion';
 
 import SectionTitle from '@/components/SectionTitle';
 import { cn } from '@/lib/utils';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 interface SectionHeaderProps {
   badge?: string | null;
@@ -39,6 +40,9 @@ const alignClasses: Record<'left' | 'center' | 'right', string> = {
 };
 
 const SectionHeader: React.FC<SectionHeaderProps> = memo(({ badge, title, subtitle, align = 'center', eyebrowIcon }) => {
+  const { language } = useLanguage();
+  const isArabic = language === 'ar';
+
   if (!title && !badge && !subtitle) {
     return null;
   }
@@ -54,7 +58,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = memo(({ badge, title, subtit
         <motion.div
           variants={badgeMotion}
           className={cn(
-            'inline-flex items-center gap-2 rounded-full border border-border/70 bg-card/90 px-5 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground shadow-inner-glow backdrop-blur-sm dark:border-border/40 dark:bg-background/40 dark:text-foreground/80',
+            'inline-flex items-center gap-2 rounded-full border border-border/70 bg-card/90 px-5 py-2 text-xs font-semibold uppercase text-muted-foreground shadow-inner-glow backdrop-blur-sm dark:border-border/40 dark:bg-background/40 dark:text-foreground/80',
+            isArabic ? 'tracking-[0.2em]' : 'tracking-[0.35em]',
             align === 'center' ? 'justify-center' : 'justify-start',
           )}
         >
@@ -78,7 +83,10 @@ const SectionHeader: React.FC<SectionHeaderProps> = memo(({ badge, title, subtit
       {subtitle ? (
         <motion.p
           variants={subtitleMotion}
-          className="text-lg leading-relaxed text-muted-foreground/90 dark:text-muted-foreground/75 md:text-xl"
+          className={cn(
+            'leading-relaxed text-muted-foreground/90 dark:text-muted-foreground/75',
+            isArabic ? 'text-base sm:text-lg' : 'text-lg md:text-xl',
+          )}
         >
           {subtitle}
         </motion.p>


### PR DESCRIPTION
## Summary
- reduce heading tracking and scale when Arabic is active to keep hero and section titles readable
- refresh landing call-to-action and hero copy, bullets, and buttons with responsive Arabic-friendly sizes
- force Cairo-based font stacks for Arabic content to improve consistency across sections

## Testing
- npm run lint *(fails: existing TypeScript lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c116af14832f985583f23b4925d4